### PR TITLE
fix: add fallback target check for unified build detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,12 @@ find_package(Threads REQUIRED)
 message(STATUS "Searching for common_system...")
 find_system_dependency(common_system)
 
+# Fallback: check for TARGET directly (unified build case where PARENT_SCOPE may not propagate)
+if(NOT common_system_FOUND AND TARGET common_system)
+    message(STATUS "Found common_system as existing target (unified build)")
+    set(common_system_FOUND TRUE)
+endif()
+
 if(common_system_FOUND)
     message(STATUS "common_system integration enabled")
     set(BUILD_WITH_COMMON_SYSTEM ON)


### PR DESCRIPTION
## Summary
Add fallback mechanism to detect common_system target in unified build environments.

## Problem
When building database_system as part of unified_system super-build, the 
`find_system_dependency` function's `PARENT_SCOPE` variable propagation sometimes 
fails to set `common_system_FOUND` in the calling scope, causing a false-negative 
configuration error even when the target exists.

## Solution
Add a direct `TARGET common_system` check as fallback before the fatal error check.
This ensures proper detection regardless of CMake variable scope behavior.

## Test plan
- [x] Full unified_system build verification (Tier 0-3)
- [x] All 242 targets build successfully