### PR TITLE
feat(replication): implement target database client initialization

### DIFF
--- a/database/replication/replication_manager.cpp
+++ b/database/replication/replication_manager.cpp
@@ -8,6 +8,7 @@ All rights reserved.
 #include "replication_manager.h"
 #include "safe_query_builder.h"
 #include "cdc/cdc_factory.h"
+#include "../core/backend_registry.h"
 
 #include <algorithm>
 #include <sstream>
@@ -220,8 +221,92 @@ result<void> replication_manager::initialize_source() {
 }
 
 result<void> replication_manager::initialize_target() {
-    // Create target client based on node configuration
-    // Similar to source, but for applying changes
+    // Detect database type from target connection string
+    auto db_type = cdc::cdc_factory::detect_database_type(
+        target_config_.connection_string
+    );
+
+    // Map CDC database_type to backend registry name
+    std::string backend_name;
+    switch (db_type) {
+        case cdc::database_type::SQLITE:
+            backend_name = "sqlite";
+            break;
+        case cdc::database_type::POSTGRESQL:
+            backend_name = "postgresql";
+            break;
+        case cdc::database_type::MYSQL:
+            backend_name = "mysql";
+            break;
+        case cdc::database_type::MONGODB:
+            backend_name = "mongodb";
+            break;
+        default:
+            return result<void>(error_info{
+                -11,
+                "Unsupported target database type",
+                "replication"
+            });
+    }
+
+    // Check if backend is available
+    if (!core::backend_registry::instance().has_backend(backend_name)) {
+        return result<void>(error_info{
+            -12,
+            "Target backend not available: " + backend_name +
+                ". Ensure the backend is compiled and registered.",
+            "replication"
+        });
+    }
+
+    // Create target backend instance
+    target_client_ = core::backend_registry::instance().create(backend_name);
+    if (!target_client_) {
+        return result<void>(error_info{
+            -13,
+            "Failed to create target backend: " + backend_name,
+            "replication"
+        });
+    }
+
+    // Build connection configuration
+    core::connection_config conn_config;
+
+    // Try parsing as key=value format first
+    conn_config = core::connection_config::from_string(target_config_.connection_string);
+
+    // If parsing didn't set host, use node_config fields directly
+    if (conn_config.host.empty() && !target_config_.host.empty()) {
+        conn_config.host = target_config_.host;
+        conn_config.port = target_config_.port;
+        conn_config.database = target_config_.database;
+        conn_config.username = target_config_.username;
+        conn_config.password = target_config_.password;
+    }
+
+    // For SQLite, store the connection string (file path) in database field
+    if (db_type == cdc::database_type::SQLITE && conn_config.database.empty()) {
+        // Extract file path from connection string
+        std::string path = target_config_.connection_string;
+        if (path.find("sqlite://") == 0) {
+            path = path.substr(9);  // Remove "sqlite://" prefix
+        } else if (path.find("sqlite:") == 0) {
+            path = path.substr(7);  // Remove "sqlite:" prefix
+        }
+        conn_config.database = path;
+    }
+
+    // Initialize target client connection
+    auto init_result = target_client_->initialize(conn_config);
+    if (init_result.is_err()) {
+        target_client_.reset();
+        return result<void>(error_info{
+            -14,
+            "Failed to initialize target database connection: " +
+                init_result.error().message,
+            "replication"
+        });
+    }
 
     return result<void>::ok();
 }

--- a/tests/replication_test.cpp
+++ b/tests/replication_test.cpp
@@ -943,3 +943,174 @@ TEST(CDCConfigTest, DefaultValues) {
     EXPECT_EQ(config.max_batch_size, 1000);
     EXPECT_EQ(config.change_table_prefix, "_cdc_");
 }
+
+// =============================================================================
+// Target Client Initialization Tests
+// =============================================================================
+
+class TargetClientInitializationTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        manager_ = std::make_unique<replication_manager>();
+    }
+
+    void TearDown() override {
+        if (manager_ && manager_->is_active()) {
+            manager_->stop_replication();
+        }
+    }
+
+    node_config create_sqlite_source() {
+        node_config source;
+        source.id = "sqlite-source";
+        source.connection_string = ":memory:";
+        source.role = node_role::PRIMARY;
+        return source;
+    }
+
+    node_config create_sqlite_target() {
+        node_config target;
+        target.id = "sqlite-target";
+        target.connection_string = ":memory:";
+        target.role = node_role::REPLICA;
+        return target;
+    }
+
+    node_config create_postgresql_target() {
+        node_config target;
+        target.id = "postgresql-target";
+        target.connection_string = "postgresql://user:pass@localhost:5432/testdb";
+        target.host = "localhost";
+        target.port = 5432;
+        target.database = "testdb";
+        target.username = "user";
+        target.password = "pass";
+        target.role = node_role::REPLICA;
+        return target;
+    }
+
+    replication_config create_test_config() {
+        replication_config config;
+        config.mode = sync_mode::REALTIME;
+        config.conflict_resolution = conflict_strategy::LAST_WRITE_WINS;
+        config.batch_size = 100;
+        return config;
+    }
+
+    std::unique_ptr<replication_manager> manager_;
+};
+
+// Test database type detection from connection strings
+TEST_F(TargetClientInitializationTest, DetectSQLiteFromConnectionString) {
+    auto db_type = cdc_factory::detect_database_type(":memory:");
+    EXPECT_EQ(db_type, database_type::SQLITE);
+
+    db_type = cdc_factory::detect_database_type("test.db");
+    EXPECT_EQ(db_type, database_type::SQLITE);
+
+    db_type = cdc_factory::detect_database_type("sqlite:///path/to/db.sqlite");
+    EXPECT_EQ(db_type, database_type::SQLITE);
+}
+
+TEST_F(TargetClientInitializationTest, DetectPostgreSQLFromConnectionString) {
+    auto db_type = cdc_factory::detect_database_type("postgresql://user:pass@localhost:5432/db");
+    EXPECT_EQ(db_type, database_type::POSTGRESQL);
+
+    db_type = cdc_factory::detect_database_type("postgres://user:pass@localhost/db");
+    EXPECT_EQ(db_type, database_type::POSTGRESQL);
+}
+
+TEST_F(TargetClientInitializationTest, DetectMySQLFromConnectionString) {
+    auto db_type = cdc_factory::detect_database_type("mysql://user:pass@localhost:3306/db");
+    EXPECT_EQ(db_type, database_type::MYSQL);
+}
+
+TEST_F(TargetClientInitializationTest, DetectMongoDBFromConnectionString) {
+    auto db_type = cdc_factory::detect_database_type("mongodb://user:pass@localhost:27017/db");
+    EXPECT_EQ(db_type, database_type::MONGODB);
+}
+
+// Test that replication can start with SQLite source and target
+// Note: This test may fail if SQLite backend is not registered
+TEST_F(TargetClientInitializationTest, StartReplicationWithSQLiteTarget) {
+    auto source = create_sqlite_source();
+    auto target = create_sqlite_target();
+    auto config = create_test_config();
+
+    // Add a table mapping to track
+    table_mapping mapping;
+    mapping.source_table = "test_table";
+    mapping.target_table = "test_table";
+    config.tables.push_back(mapping);
+
+    auto result = manager_->start_replication(source, target, config);
+
+    // Result depends on whether SQLite backend is available
+    // If backend is registered, it should succeed
+    // If not, it will fail with backend not available error
+    if (result.is_err()) {
+        // Expected error if backend not registered
+        EXPECT_TRUE(
+            result.error().message.find("backend") != std::string::npos ||
+            result.error().message.find("initialize") != std::string::npos
+        );
+    } else {
+        EXPECT_TRUE(manager_->is_active());
+    }
+}
+
+// Test that invalid database type is handled gracefully
+TEST_F(TargetClientInitializationTest, HandlesInvalidDatabaseType) {
+    node_config source;
+    source.id = "invalid-source";
+    source.connection_string = "unknown://some/connection";
+
+    node_config target;
+    target.id = "invalid-target";
+    target.connection_string = "unknown://another/connection";
+
+    auto config = create_test_config();
+
+    auto result = manager_->start_replication(source, target, config);
+
+    // Should fail gracefully with an error message
+    // (either unsupported database type or backend not available)
+    // Note: detect_database_type defaults to SQLITE for unknown types
+    if (result.is_err()) {
+        EXPECT_FALSE(result.error().message.empty());
+    }
+}
+
+// Test configuration with direct host/port settings
+TEST_F(TargetClientInitializationTest, TargetWithDirectHostConfig) {
+    auto source = create_sqlite_source();
+
+    node_config target;
+    target.id = "direct-config-target";
+    target.host = "localhost";
+    target.port = 5432;
+    target.database = "testdb";
+    target.username = "user";
+    target.password = "pass";
+    target.connection_string = "postgresql://localhost:5432/testdb";
+    target.role = node_role::REPLICA;
+
+    auto config = create_test_config();
+    table_mapping mapping;
+    mapping.source_table = "test_table";
+    mapping.target_table = "test_table";
+    config.tables.push_back(mapping);
+
+    auto result = manager_->start_replication(source, target, config);
+
+    // Test verifies that the configuration is processed correctly
+    // Actual success depends on backend availability
+    if (result.is_err()) {
+        // Error should be related to connection/backend, not configuration parsing
+        EXPECT_TRUE(
+            result.error().message.find("backend") != std::string::npos ||
+            result.error().message.find("connection") != std::string::npos ||
+            result.error().message.find("initialize") != std::string::npos
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Implement `initialize_target()` method in `replication_manager` to properly initialize target database connections
- Use `backend_registry` for dynamic backend creation based on detected database type
- Add comprehensive unit tests for target client initialization

## Changes

### Implementation (`database/replication/replication_manager.cpp`)
- Detect database type from connection string using `cdc_factory::detect_database_type()`
- Map CDC database types to backend registry names (sqlite, postgresql, mysql, mongodb)
- Create backend instance via `backend_registry::instance().create(backend_name)`
- Parse connection configuration from connection string or node_config fields
- Handle SQLite file path extraction from various connection string formats
- Add specific error codes (-11 to -14) for different failure scenarios

### Tests (`tests/replication_test.cpp`)
- Add `TargetClientInitializationTest` test fixture
- Database type detection tests for SQLite, PostgreSQL, MySQL, MongoDB connection strings
- Replication start tests with SQLite target
- Invalid database type handling tests
- Direct host configuration tests

## Test plan

- [ ] Verify database type detection works for all supported connection string formats
- [ ] Verify replication can start when SQLite backend is available
- [ ] Verify graceful error handling when backend is not registered
- [ ] Verify direct host/port configuration fallback works correctly

## Related

- Addresses TICKET-001: Database Client Initialization for replication_manager