### PR TITLE
feat: integrate logging and monitoring for gateway and replication manager

### DIFF
--- a/database/gateway/database_gateway.cpp
+++ b/database/gateway/database_gateway.cpp
@@ -88,12 +88,15 @@ result<void> database_gateway::start(uint16_t port, const security_config& secur
         }
     );
 
-    // Set up error callback
+    // Set up error callback with logging
     network_server_->set_error_callback(
-        [](std::shared_ptr<network_system::session::messaging_session> /* session */,
-           std::error_code ec) {
-            // Log error but don't crash
-            (void)ec;  // Error handling could be expanded
+        [this](std::shared_ptr<network_system::session::messaging_session> /* session */,
+               std::error_code ec) {
+            // Log error using integrated logger
+            if (logger_) {
+                logger_->log_error("network_error", ec.message(),
+                    std::to_string(ec.value()));
+            }
         }
     );
 
@@ -101,6 +104,10 @@ result<void> database_gateway::start(uint16_t port, const security_config& secur
     auto start_result = network_server_->start_server(port);
     if (start_result.is_err()) {
         network_server_.reset();
+        if (logger_) {
+            logger_->log_error("start", "Failed to start network server: " +
+                start_result.error().message, "");
+        }
         return result<void>(error_info{
             -10,
             "Failed to start network server: " + start_result.error().message,
@@ -109,11 +116,23 @@ result<void> database_gateway::start(uint16_t port, const security_config& secur
     }
 
     running_.store(true);
+
+    // Log successful start
+    if (logger_) {
+        logger_->log(integrated::db_log_level::info,
+            "Gateway started on port " + std::to_string(port));
+    }
+
     return result<void>::ok();
 }
 
 void database_gateway::stop() {
     if (!running_.load()) return;
+
+    // Log shutdown start
+    if (logger_) {
+        logger_->log(integrated::db_log_level::info, "Gateway stopping...");
+    }
 
     running_.store(false);
 
@@ -132,6 +151,18 @@ void database_gateway::stop() {
     if (audit_logger_) {
         audit_logger_->stop();
         audit_logger_.reset();
+    }
+
+    // Shutdown observability adapters
+    if (monitor_) {
+        monitor_->shutdown();
+        monitor_.reset();
+    }
+
+    if (logger_) {
+        logger_->log(integrated::db_log_level::info, "Gateway stopped");
+        logger_->shutdown();
+        logger_.reset();
     }
 }
 
@@ -230,12 +261,71 @@ void database_gateway::configure_audit_logging(const audit_config& config) {
     }
 }
 
+result<void> database_gateway::configure_observability(const gateway_observability_config& config) {
+    observability_config_ = config;
+
+    // Shutdown existing adapters if any
+    if (logger_) {
+        logger_->shutdown();
+        logger_.reset();
+    }
+    if (monitor_) {
+        monitor_->shutdown();
+        monitor_.reset();
+    }
+
+    // Initialize logger adapter if enabled
+    if (config.enable_logging) {
+        logger_ = std::make_unique<integrated::adapters::logger_adapter>(
+            config.logger_config,
+            integrated::adapters::logger_backend_type::auto_select
+        );
+        auto init_result = logger_->initialize();
+        if (!init_result.is_ok()) {
+            return result<void>(error_info{
+                -20,
+                "Failed to initialize gateway logger: " + init_result.get_error().message,
+                "gateway"
+            });
+        }
+        logger_->log(integrated::db_log_level::info, "Gateway logger initialized");
+    }
+
+    // Initialize monitoring adapter if enabled
+    if (config.enable_monitoring) {
+        monitor_ = std::make_unique<integrated::adapters::monitoring_adapter>(
+            config.monitoring_config,
+            integrated::adapters::monitoring_backend_type::auto_select
+        );
+        auto init_result = monitor_->initialize();
+        if (!init_result.is_ok()) {
+            return result<void>(error_info{
+                -21,
+                "Failed to initialize gateway monitoring: " + init_result.get_error().message,
+                "gateway"
+            });
+        }
+        if (logger_) {
+            logger_->log(integrated::db_log_level::info, "Gateway monitoring initialized");
+        }
+    }
+
+    return result<void>::ok();
+}
+
 result<core::database_result> database_gateway::execute_query(const std::string& query) {
     auto start_time = std::chrono::steady_clock::now();
     bool success = false;
     core::database_result final_result;
     std::string target_cluster_id;
     std::string error_msg;
+
+    // Log query start if logging is enabled
+    if (logger_ && observability_config_.logger_config.enable_query_logging) {
+        logger_->log(integrated::db_log_level::debug,
+            "Gateway executing query: " + query.substr(0, 100) +
+            (query.length() > 100 ? "..." : ""));
+    }
 
     // Check cache first (for SELECT queries only)
     if (cache_config_.enabled && is_cacheable(query)) {
@@ -246,10 +336,21 @@ result<core::database_result> database_gateway::execute_query(const std::string&
             auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
                 end_time - start_time
             );
+
+            // Record cache hit metric
+            if (monitor_) {
+                monitor_->record_metric("gateway_cache_hits", 1.0);
+            }
+
             audit_log_query(query, true, duration, "cache", "");
             return result<core::database_result>::ok(cached.value());
         }
         cache_misses_.fetch_add(1);
+
+        // Record cache miss metric
+        if (monitor_) {
+            monitor_->record_metric("gateway_cache_misses", 1.0);
+        }
     }
 
     // Route query to appropriate cluster
@@ -318,10 +419,33 @@ result<core::database_result> database_gateway::execute_query(const std::string&
 
     if (!success) {
         error_msg = query_result.error().message;
+
+        // Log error
+        if (logger_) {
+            logger_->log_error("execute_query", error_msg,
+                std::to_string(query_result.error().code));
+        }
     }
 
     if (success && cache_config_.enabled && is_cacheable(query)) {
         cache_result(query, query_result.value());
+    }
+
+    // Record query execution metrics
+    if (monitor_) {
+        auto duration_us = std::chrono::duration_cast<std::chrono::microseconds>(
+            end_time - start_time
+        );
+        monitor_->record_query_execution(duration_us, success);
+    }
+
+    // Log query completion with duration
+    if (logger_) {
+        logger_->log_query(
+            success ? integrated::db_log_level::info : integrated::db_log_level::error,
+            query,
+            std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time)
+        );
     }
 
     audit_log_query(query, success, duration, target_cluster_id, error_msg);

--- a/database/gateway/database_gateway.h
+++ b/database/gateway/database_gateway.h
@@ -24,6 +24,10 @@ All rights reserved.
 #include <kcenon/network/core/messaging_server.h>
 #include <kcenon/network/session/messaging_session.h>
 
+// Logging/monitoring integration
+#include "../integrated/adapters/logger_adapter.h"
+#include "../integrated/adapters/monitoring_adapter.h"
+
 namespace database::gateway {
 
 /**
@@ -70,6 +74,25 @@ struct audit_config {
     size_t max_file_size_mb{100};               ///< Max file size before rotation
     size_t max_files{10};                       ///< Max rotated files to keep
     bool async_write{true};                     ///< Use async writing for performance
+};
+
+/**
+ * @brief Gateway observability configuration
+ *
+ * Configures logging and monitoring integration for the gateway.
+ */
+struct gateway_observability_config {
+    /// Enable integrated logging
+    bool enable_logging{true};
+
+    /// Enable integrated monitoring
+    bool enable_monitoring{true};
+
+    /// Logger configuration
+    integrated::db_logger_config logger_config;
+
+    /// Monitoring configuration
+    integrated::db_monitoring_config monitoring_config;
 };
 
 /**
@@ -210,6 +233,13 @@ public:
      * @param config Audit logging configuration
      */
     void configure_audit_logging(const audit_config& config);
+
+    /**
+     * @brief Configure observability (logging and monitoring)
+     * @param config Observability configuration
+     * @return result::ok() on success, error on failure
+     */
+    result<void> configure_observability(const gateway_observability_config& config);
 
     /**
      * @brief Execute query through gateway
@@ -376,6 +406,11 @@ private:
     mutable std::mutex auth_mutex_;
     std::unordered_map<std::string, std::string> users_; // username -> password hash
     std::unordered_map<std::string, std::vector<std::string>> permissions_; // username -> permissions
+
+    // Observability (logging and monitoring integration)
+    gateway_observability_config observability_config_;
+    std::unique_ptr<integrated::adapters::logger_adapter> logger_;
+    std::unique_ptr<integrated::adapters::monitoring_adapter> monitor_;
 };
 
 } // namespace database::gateway

--- a/database/replication/replication_manager.cpp
+++ b/database/replication/replication_manager.cpp
@@ -53,6 +53,11 @@ result<void> replication_manager::start_replication(
         return result<void>(error_info{-1, "Replication already active", "replication"});
     }
 
+    if (logger_) {
+        logger_->log(integrated::db_log_level::info,
+            "Starting replication from " + source.id + " to " + target.id);
+    }
+
     source_config_ = source;
     target_config_ = target;
     config_ = config;
@@ -60,12 +65,18 @@ result<void> replication_manager::start_replication(
     // Initialize source connection
     auto source_result = initialize_source();
     if (source_result.is_err()) {
+        if (logger_) {
+            logger_->log_error("initialize_source", source_result.error().message, "");
+        }
         return source_result;
     }
 
     // Initialize target connection
     auto target_result = initialize_target();
     if (target_result.is_err()) {
+        if (logger_) {
+            logger_->log_error("initialize_target", target_result.error().message, "");
+        }
         return target_result;
     }
 
@@ -83,12 +94,22 @@ result<void> replication_manager::start_replication(
     cdc_thread_ = std::thread(&replication_manager::cdc_worker, this);
     replication_thread_ = std::thread(&replication_manager::replication_worker, this);
 
+    if (logger_) {
+        logger_->log(integrated::db_log_level::info,
+            "Replication started successfully with " +
+            std::to_string(config.tables.size()) + " table(s)");
+    }
+
     return result<void>::ok();
 }
 
 result<void> replication_manager::stop_replication() {
     if (!active_.load()) {
         return result<void>(error_info{-2, "Replication not active", "replication"});
+    }
+
+    if (logger_) {
+        logger_->log(integrated::db_log_level::info, "Stopping replication...");
     }
 
     active_.store(false);
@@ -115,6 +136,26 @@ result<void> replication_manager::stop_replication() {
     if (target_client_) {
         target_client_->shutdown();
         target_client_.reset();
+    }
+
+    // Log final statistics
+    if (logger_) {
+        std::lock_guard<std::mutex> lock(stats_mutex_);
+        logger_->log(integrated::db_log_level::info,
+            "Replication stopped. Events replicated: " +
+            std::to_string(stats_.events_replicated) +
+            ", Failed: " + std::to_string(stats_.events_failed) +
+            ", Conflicts: " + std::to_string(stats_.conflicts_resolved));
+    }
+
+    // Shutdown observability adapters
+    if (monitor_) {
+        monitor_->shutdown();
+        monitor_.reset();
+    }
+    if (logger_) {
+        logger_->shutdown();
+        logger_.reset();
     }
 
     return result<void>::ok();
@@ -181,6 +222,60 @@ bool replication_manager::is_healthy() const {
 size_t replication_manager::get_pending_event_count() const {
     std::lock_guard<std::mutex> lock(queue_mutex_);
     return event_queue_.size();
+}
+
+result<void> replication_manager::configure_observability(
+    const replication_observability_config& config
+) {
+    observability_config_ = config;
+
+    // Shutdown existing adapters if any
+    if (logger_) {
+        logger_->shutdown();
+        logger_.reset();
+    }
+    if (monitor_) {
+        monitor_->shutdown();
+        monitor_.reset();
+    }
+
+    // Initialize logger adapter if enabled
+    if (config.enable_logging) {
+        logger_ = std::make_unique<integrated::adapters::logger_adapter>(
+            config.logger_config,
+            integrated::adapters::logger_backend_type::auto_select
+        );
+        auto init_result = logger_->initialize();
+        if (!init_result.is_ok()) {
+            return result<void>(error_info{
+                -20,
+                "Failed to initialize replication logger: " + init_result.get_error().message,
+                "replication"
+            });
+        }
+        logger_->log(integrated::db_log_level::info, "Replication logger initialized");
+    }
+
+    // Initialize monitoring adapter if enabled
+    if (config.enable_monitoring) {
+        monitor_ = std::make_unique<integrated::adapters::monitoring_adapter>(
+            config.monitoring_config,
+            integrated::adapters::monitoring_backend_type::auto_select
+        );
+        auto init_result = monitor_->initialize();
+        if (!init_result.is_ok()) {
+            return result<void>(error_info{
+                -21,
+                "Failed to initialize replication monitoring: " + init_result.get_error().message,
+                "replication"
+            });
+        }
+        if (logger_) {
+            logger_->log(integrated::db_log_level::info, "Replication monitoring initialized");
+        }
+    }
+
+    return result<void>::ok();
 }
 
 result<void> replication_manager::initialize_source() {
@@ -386,12 +481,31 @@ void replication_manager::replication_worker() {
 
         // Apply each event
         for (const auto& event : events_to_process) {
+            auto apply_start = std::chrono::steady_clock::now();
             auto apply_result = apply_change_event(event);
+            auto apply_end = std::chrono::steady_clock::now();
 
             auto end_time = std::chrono::system_clock::now();
             auto lag = std::chrono::duration_cast<std::chrono::milliseconds>(
                 end_time - event.timestamp
             );
+
+            // Record metrics
+            if (monitor_) {
+                auto apply_duration = std::chrono::duration_cast<std::chrono::microseconds>(
+                    apply_end - apply_start
+                );
+                monitor_->record_query_execution(apply_duration, apply_result.is_ok());
+                monitor_->record_metric("replication_lag_ms",
+                    static_cast<double>(lag.count()));
+            }
+
+            // Log event processing result
+            if (!apply_result.is_ok() && logger_) {
+                logger_->log_error("apply_change_event",
+                    apply_result.error().message,
+                    std::to_string(apply_result.error().code));
+            }
 
             update_stats(apply_result.is_ok(), lag);
         }

--- a/database/replication/replication_manager.h
+++ b/database/replication/replication_manager.h
@@ -20,7 +20,9 @@ All rights reserved.
 #include "../distributed/cluster_manager.h"
 #include "cdc/cdc_strategy_interface.h"
 
-// Logging/monitoring integration removed - requires proper CMake setup
+// Logging/monitoring integration
+#include "../integrated/adapters/logger_adapter.h"
+#include "../integrated/adapters/monitoring_adapter.h"
 
 namespace database::replication {
 
@@ -63,6 +65,25 @@ struct replication_config {
     std::chrono::seconds batch_interval{60};    ///< Batch interval (for BATCH mode)
     size_t batch_size{1000};                    ///< Max records per batch
     bool bidirectional{false};                  ///< Enable bidirectional replication
+};
+
+/**
+ * @brief Replication observability configuration
+ *
+ * Configures logging and monitoring integration for the replication manager.
+ */
+struct replication_observability_config {
+    /// Enable integrated logging
+    bool enable_logging{true};
+
+    /// Enable integrated monitoring
+    bool enable_monitoring{true};
+
+    /// Logger configuration
+    integrated::db_logger_config logger_config;
+
+    /// Monitoring configuration
+    integrated::db_monitoring_config monitoring_config;
 };
 
 /**
@@ -242,6 +263,13 @@ public:
      */
     size_t get_pending_event_count() const;
 
+    /**
+     * @brief Configure observability (logging and monitoring)
+     * @param config Observability configuration
+     * @return result::ok() on success, error on failure
+     */
+    result<void> configure_observability(const replication_observability_config& config);
+
 private:
     /**
      * @brief Initialize source connection and CDC
@@ -320,7 +348,10 @@ private:
     // CDC strategy for capturing source changes
     std::unique_ptr<cdc::cdc_strategy_interface> cdc_strategy_;
 
-    // Note: Logging/monitoring integration removed - requires proper CMake setup
+    // Observability (logging and monitoring integration)
+    replication_observability_config observability_config_;
+    std::unique_ptr<integrated::adapters::logger_adapter> logger_;
+    std::unique_ptr<integrated::adapters::monitoring_adapter> monitor_;
 };
 
 } // namespace database::replication

--- a/tests/gateway_test.cpp
+++ b/tests/gateway_test.cpp
@@ -652,3 +652,103 @@ TEST_F(DatabaseGatewayTest, AuditLoggingEnabled) {
     // Cleanup
     std::filesystem::remove_all(temp_dir);
 }
+
+// =============================================================================
+// Gateway Observability Integration Tests
+// =============================================================================
+
+TEST_F(DatabaseGatewayTest, ConfigureObservability) {
+    gateway_observability_config config;
+    config.enable_logging = true;
+    config.enable_monitoring = true;
+
+    // Configure logger
+    config.logger_config.enable_query_logging = true;
+    config.logger_config.log_slow_queries = true;
+    config.logger_config.slow_query_threshold = std::chrono::milliseconds(100);
+    config.logger_config.min_log_level = integrated::db_log_level::debug;
+
+    // Configure monitoring
+    config.monitoring_config.enable_metrics = true;
+    config.monitoring_config.enable_health_checks = true;
+
+    auto result = gateway_->configure_observability(config);
+    EXPECT_TRUE(result.is_ok());
+}
+
+TEST_F(DatabaseGatewayTest, ObservabilityWithLoggingOnly) {
+    gateway_observability_config config;
+    config.enable_logging = true;
+    config.enable_monitoring = false;
+    config.logger_config.min_log_level = integrated::db_log_level::info;
+
+    auto result = gateway_->configure_observability(config);
+    EXPECT_TRUE(result.is_ok());
+}
+
+TEST_F(DatabaseGatewayTest, ObservabilityWithMonitoringOnly) {
+    gateway_observability_config config;
+    config.enable_logging = false;
+    config.enable_monitoring = true;
+    config.monitoring_config.enable_metrics = true;
+
+    auto result = gateway_->configure_observability(config);
+    EXPECT_TRUE(result.is_ok());
+}
+
+TEST_F(DatabaseGatewayTest, ObservabilityBothDisabled) {
+    gateway_observability_config config;
+    config.enable_logging = false;
+    config.enable_monitoring = false;
+
+    auto result = gateway_->configure_observability(config);
+    EXPECT_TRUE(result.is_ok());
+}
+
+TEST_F(DatabaseGatewayTest, ObservabilityReconfiguration) {
+    // First configuration
+    gateway_observability_config config1;
+    config1.enable_logging = true;
+    config1.enable_monitoring = false;
+
+    auto result1 = gateway_->configure_observability(config1);
+    EXPECT_TRUE(result1.is_ok());
+
+    // Reconfigure with different settings
+    gateway_observability_config config2;
+    config2.enable_logging = true;
+    config2.enable_monitoring = true;
+
+    auto result2 = gateway_->configure_observability(config2);
+    EXPECT_TRUE(result2.is_ok());
+}
+
+TEST_F(DatabaseGatewayTest, ObservabilityWithFileLogging) {
+    std::filesystem::path temp_dir = std::filesystem::temp_directory_path() / "gateway_observability_test";
+    std::filesystem::create_directories(temp_dir);
+
+    gateway_observability_config config;
+    config.enable_logging = true;
+    config.enable_monitoring = false;
+    config.logger_config.enable_file_logging = true;
+    config.logger_config.log_directory = temp_dir.string();
+    config.logger_config.enable_query_logging = true;
+
+    auto result = gateway_->configure_observability(config);
+    EXPECT_TRUE(result.is_ok());
+
+    // Start gateway and execute a query to generate logs
+    security_config security;
+    gateway_->start(5002, security);
+
+    auto cluster = std::make_shared<cluster_manager>();
+    gateway_->register_cluster("test-cluster", cluster);
+
+    // Execute query (will fail but should log)
+    gateway_->execute_query("SELECT * FROM test");
+
+    gateway_->stop();
+
+    // Cleanup
+    std::filesystem::remove_all(temp_dir);
+}

--- a/tests/replication_test.cpp
+++ b/tests/replication_test.cpp
@@ -1114,3 +1114,114 @@ TEST_F(TargetClientInitializationTest, TargetWithDirectHostConfig) {
         );
     }
 }
+
+// =============================================================================
+// Replication Observability Integration Tests
+// =============================================================================
+
+TEST_F(ReplicationManagerTest, ConfigureObservability) {
+    replication_observability_config config;
+    config.enable_logging = true;
+    config.enable_monitoring = true;
+
+    // Configure logger
+    config.logger_config.enable_query_logging = true;
+    config.logger_config.log_slow_queries = true;
+    config.logger_config.slow_query_threshold = std::chrono::milliseconds(100);
+    config.logger_config.min_log_level = integrated::db_log_level::debug;
+
+    // Configure monitoring
+    config.monitoring_config.enable_metrics = true;
+    config.monitoring_config.enable_health_checks = true;
+
+    auto result = manager_->configure_observability(config);
+    EXPECT_TRUE(result.is_ok());
+}
+
+TEST_F(ReplicationManagerTest, ObservabilityWithLoggingOnly) {
+    replication_observability_config config;
+    config.enable_logging = true;
+    config.enable_monitoring = false;
+    config.logger_config.min_log_level = integrated::db_log_level::info;
+
+    auto result = manager_->configure_observability(config);
+    EXPECT_TRUE(result.is_ok());
+}
+
+TEST_F(ReplicationManagerTest, ObservabilityWithMonitoringOnly) {
+    replication_observability_config config;
+    config.enable_logging = false;
+    config.enable_monitoring = true;
+    config.monitoring_config.enable_metrics = true;
+
+    auto result = manager_->configure_observability(config);
+    EXPECT_TRUE(result.is_ok());
+}
+
+TEST_F(ReplicationManagerTest, ObservabilityBothDisabled) {
+    replication_observability_config config;
+    config.enable_logging = false;
+    config.enable_monitoring = false;
+
+    auto result = manager_->configure_observability(config);
+    EXPECT_TRUE(result.is_ok());
+}
+
+TEST_F(ReplicationManagerTest, ObservabilityReconfiguration) {
+    // First configuration
+    replication_observability_config config1;
+    config1.enable_logging = true;
+    config1.enable_monitoring = false;
+
+    auto result1 = manager_->configure_observability(config1);
+    EXPECT_TRUE(result1.is_ok());
+
+    // Reconfigure with different settings
+    replication_observability_config config2;
+    config2.enable_logging = true;
+    config2.enable_monitoring = true;
+
+    auto result2 = manager_->configure_observability(config2);
+    EXPECT_TRUE(result2.is_ok());
+}
+
+TEST_F(ReplicationManagerTest, ObservabilityWithFileLogging) {
+    std::filesystem::path temp_dir = std::filesystem::temp_directory_path() / "replication_observability_test";
+    std::filesystem::create_directories(temp_dir);
+
+    replication_observability_config config;
+    config.enable_logging = true;
+    config.enable_monitoring = false;
+    config.logger_config.enable_file_logging = true;
+    config.logger_config.log_directory = temp_dir.string();
+    config.logger_config.enable_query_logging = true;
+
+    auto result = manager_->configure_observability(config);
+    EXPECT_TRUE(result.is_ok());
+
+    // Cleanup
+    std::filesystem::remove_all(temp_dir);
+}
+
+TEST_F(ReplicationManagerTest, ObservabilityLogsReplicationEvents) {
+    // Configure observability first
+    replication_observability_config obs_config;
+    obs_config.enable_logging = true;
+    obs_config.enable_monitoring = true;
+    obs_config.logger_config.min_log_level = integrated::db_log_level::debug;
+
+    auto obs_result = manager_->configure_observability(obs_config);
+    EXPECT_TRUE(obs_result.is_ok());
+
+    // Start replication (will generate log entries)
+    auto source = create_test_source();
+    auto target = create_test_target();
+    auto config = create_test_config();
+
+    auto start_result = manager_->start_replication(source, target, config);
+    EXPECT_TRUE(start_result.is_ok());
+
+    // Stop replication (will log final statistics)
+    auto stop_result = manager_->stop_replication();
+    EXPECT_TRUE(stop_result.is_ok());
+}


### PR DESCRIPTION
## Summary

- Integrate `logger_adapter` and `monitoring_adapter` from the integrated system into Gateway and Replication Manager
- Add `gateway_observability_config` and `replication_observability_config` for configuring logging/monitoring
- Implement structured logging for query execution, errors, start/stop events
- Implement metrics collection for cache hits/misses, query execution duration, replication lag

## Changes

### Gateway
- Add `configure_observability()` method with `gateway_observability_config`
- Log query start/completion with timing information
- Record cache hit/miss metrics
- Log network errors with integrated logger
- Properly shutdown observability adapters on stop

### Replication Manager
- Add `configure_observability()` method with `replication_observability_config`
- Log replication start/stop events with statistics
- Record query execution and replication lag metrics
- Log event application errors
- Properly shutdown observability adapters on stop

## Test plan

- [x] Add unit tests for `configure_observability()` in `gateway_test.cpp`
- [x] Add unit tests for `configure_observability()` in `replication_test.cpp`
- [x] Test logging-only configuration
- [x] Test monitoring-only configuration
- [x] Test both disabled configuration
- [x] Test reconfiguration scenarios
- [x] Test file logging configuration