### PR TITLE
fix(integrated): use correct Result API method for error access

### DIFF
--- a/database/integrated/adapters/backends/system_monitoring_backend.cpp
+++ b/database/integrated/adapters/backends/system_monitoring_backend.cpp
@@ -73,7 +73,7 @@ common::VoidResult system_monitoring_backend::initialize()
 		if (!init_result.is_ok())
 		{
 			return make_error("Failed to initialize monitoring_system: " +
-							  std::string(init_result.get_error().message));
+							  std::string(init_result.error().message));
 		}
 
 		start_time_ = std::chrono::steady_clock::now();


### PR DESCRIPTION
## Summary
- Fix compilation error in `system_monitoring_backend.cpp`
- Change `get_error()` to `error()` to use correct `common::Result` member method
- `get_error()` is a free function in common_system, not a member method

## Test plan
- [ ] Build succeeds without compilation errors
- [ ] Existing tests pass