### PR TITLE
feat(di): add IDatabase service registration adapter

### DIFF
--- a/include/kcenon/database/adapters/common_system_database_adapter.h
+++ b/include/kcenon/database/adapters/common_system_database_adapter.h
@@ -1,0 +1,283 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file common_system_database_adapter.h
+ * @brief Adapter to bridge database_system's database_manager with common_system's IDatabase.
+ *
+ * This adapter implements the common::interfaces::IDatabase interface using
+ * database_system's database_manager as the underlying implementation.
+ *
+ * @see TICKET-103 for integration requirements.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#ifdef BUILD_WITH_COMMON_SYSTEM
+
+#include <kcenon/common/interfaces/database_interface.h>
+#include <kcenon/common/patterns/result.h>
+
+// Include database_system headers
+#include "../../database/database_manager.h"
+#include "../../database/core/database_context.h"
+
+namespace kcenon::database::adapters {
+
+/**
+ * @class common_system_database_adapter
+ * @brief Adapter that implements IDatabase interface using database_manager
+ *
+ * This adapter bridges the gap between common_system's IDatabase interface
+ * and database_system's database_manager implementation.
+ *
+ * Thread Safety:
+ * - Delegates thread safety to underlying database_manager
+ * - Each adapter instance should be used from a single thread
+ *   or protected with appropriate synchronization
+ */
+class common_system_database_adapter : public common::interfaces::IDatabase {
+public:
+    /**
+     * @brief Construct adapter with a new database_manager instance
+     * @param db_type The database type to use (defaults to PostgreSQL)
+     */
+    explicit common_system_database_adapter(
+        ::database::database_types db_type = ::database::database_types::postgresql)
+        : context_(std::make_shared<::database::database_context>())
+        , manager_(std::make_shared<::database::database_manager>(context_))
+        , db_type_(db_type)
+        , connected_(false) {
+        manager_->set_mode(db_type_);
+    }
+
+    /**
+     * @brief Construct adapter with an existing database_manager
+     * @param manager Pre-configured database_manager instance
+     */
+    explicit common_system_database_adapter(
+        std::shared_ptr<::database::database_manager> manager)
+        : manager_(std::move(manager))
+        , db_type_(manager_ ? manager_->database_type() : ::database::database_types::postgresql)
+        , connected_(false) {}
+
+    ~common_system_database_adapter() override {
+        if (connected_) {
+            disconnect();
+        }
+    }
+
+    // Non-copyable
+    common_system_database_adapter(const common_system_database_adapter&) = delete;
+    common_system_database_adapter& operator=(const common_system_database_adapter&) = delete;
+
+    // Movable
+    common_system_database_adapter(common_system_database_adapter&&) = default;
+    common_system_database_adapter& operator=(common_system_database_adapter&&) = default;
+
+    /**
+     * @brief Connect to database using connection string
+     * @param connection_string Database-specific connection string
+     * @return VoidResult indicating success or error
+     */
+    common::VoidResult connect(const std::string& connection_string) override {
+        if (!manager_) {
+            return common::make_error<std::monostate>(
+                1, "Database manager not initialized", "database_system::adapter");
+        }
+
+        if (connected_) {
+            return common::make_error<std::monostate>(
+                2, "Already connected to database", "database_system::adapter");
+        }
+
+        if (manager_->connect(connection_string)) {
+            connected_ = true;
+            return common::VoidResult::ok({});
+        }
+
+        return common::make_error<std::monostate>(
+            3, "Failed to connect to database", "database_system::adapter");
+    }
+
+    /**
+     * @brief Disconnect from database
+     * @return VoidResult indicating success or error
+     */
+    common::VoidResult disconnect() override {
+        if (!manager_) {
+            return common::make_error<std::monostate>(
+                1, "Database manager not initialized", "database_system::adapter");
+        }
+
+        if (!connected_) {
+            return common::VoidResult::ok({});  // Already disconnected
+        }
+
+        if (manager_->disconnect()) {
+            connected_ = false;
+            return common::VoidResult::ok({});
+        }
+
+        return common::make_error<std::monostate>(
+            4, "Failed to disconnect from database", "database_system::adapter");
+    }
+
+    /**
+     * @brief Execute a query and return results
+     * @param query SQL query string
+     * @return Result containing query results or error
+     */
+    common::Result<common::database_result> execute_query(const std::string& query) override {
+        if (!manager_) {
+            return common::make_error<common::database_result>(
+                1, "Database manager not initialized", "database_system::adapter");
+        }
+
+        if (!connected_) {
+            return common::make_error<common::database_result>(
+                5, "Not connected to database", "database_system::adapter");
+        }
+
+        auto result = manager_->select_query(query);
+
+        // Convert database::database_result to common::database_result
+        common::database_result common_result;
+        common_result.reserve(result.size());
+
+        for (const auto& row : result) {
+            common::database_row common_row;
+            for (const auto& [key, value] : row) {
+                common_row[key] = convert_value(value);
+            }
+            common_result.push_back(std::move(common_row));
+        }
+
+        return common::Result<common::database_result>::ok(std::move(common_result));
+    }
+
+    /**
+     * @brief Execute a command without returning results
+     * @param command SQL command string (INSERT, UPDATE, DELETE, etc.)
+     * @return VoidResult indicating success or error
+     */
+    common::VoidResult execute_command(const std::string& command) override {
+        if (!manager_) {
+            return common::make_error<std::monostate>(
+                1, "Database manager not initialized", "database_system::adapter");
+        }
+
+        if (!connected_) {
+            return common::make_error<std::monostate>(
+                5, "Not connected to database", "database_system::adapter");
+        }
+
+        // Determine command type and execute appropriate method
+        std::string upper_command = command.substr(0, 10);
+        std::transform(upper_command.begin(), upper_command.end(),
+                       upper_command.begin(), ::toupper);
+
+        unsigned int affected_rows = 0;
+        if (upper_command.find("INSERT") != std::string::npos) {
+            affected_rows = manager_->insert_query(command);
+        } else if (upper_command.find("UPDATE") != std::string::npos) {
+            affected_rows = manager_->update_query(command);
+        } else if (upper_command.find("DELETE") != std::string::npos) {
+            affected_rows = manager_->delete_query(command);
+        } else {
+            // For DDL or other commands, use create_query
+            if (!manager_->create_query(command)) {
+                return common::make_error<std::monostate>(
+                    6, "Failed to execute command", "database_system::adapter");
+            }
+            return common::VoidResult::ok({});
+        }
+
+        // affected_rows of 0 might be valid (e.g., no matching rows)
+        return common::VoidResult::ok({});
+    }
+
+    /**
+     * @brief Begin a database transaction
+     * @return VoidResult indicating success or error
+     */
+    common::VoidResult begin_transaction() override {
+        return execute_command("BEGIN TRANSACTION");
+    }
+
+    /**
+     * @brief Commit the current transaction
+     * @return VoidResult indicating success or error
+     */
+    common::VoidResult commit() override {
+        return execute_command("COMMIT");
+    }
+
+    /**
+     * @brief Rollback the current transaction
+     * @return VoidResult indicating success or error
+     */
+    common::VoidResult rollback() override {
+        return execute_command("ROLLBACK");
+    }
+
+    /**
+     * @brief Check if database is currently connected
+     * @return true if connected, false otherwise
+     */
+    bool is_connected() const override {
+        return connected_;
+    }
+
+    /**
+     * @brief Get the underlying database_manager
+     * @return Shared pointer to the database_manager
+     */
+    std::shared_ptr<::database::database_manager> get_manager() const {
+        return manager_;
+    }
+
+    /**
+     * @brief Get the database context
+     * @return Shared pointer to the database_context
+     */
+    std::shared_ptr<::database::database_context> get_context() const {
+        return context_;
+    }
+
+private:
+    /**
+     * @brief Convert database_system value to common_system value
+     */
+    static common::database_value convert_value(const ::database::database_value& value) {
+        return std::visit([](auto&& arg) -> common::database_value {
+            using T = std::decay_t<decltype(arg)>;
+            if constexpr (std::is_same_v<T, ::database::database_null>) {
+                return common::database_null{};
+            } else if constexpr (std::is_same_v<T, std::string>) {
+                return arg;
+            } else if constexpr (std::is_same_v<T, std::int64_t>) {
+                return arg;
+            } else if constexpr (std::is_same_v<T, double>) {
+                return arg;
+            } else if constexpr (std::is_same_v<T, bool>) {
+                return arg;
+            } else {
+                return common::database_null{};
+            }
+        }, value);
+    }
+
+    std::shared_ptr<::database::database_context> context_;
+    std::shared_ptr<::database::database_manager> manager_;
+    ::database::database_types db_type_;
+    bool connected_;
+};
+
+} // namespace kcenon::database::adapters
+
+#endif // BUILD_WITH_COMMON_SYSTEM

--- a/include/kcenon/database/di/service_registration.h
+++ b/include/kcenon/database/di/service_registration.h
@@ -1,0 +1,213 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file service_registration.h
+ * @brief Service container registration for database_system services.
+ *
+ * This header provides functions to register database_system services
+ * with the unified service container from common_system.
+ *
+ * @see TICKET-103 for integration requirements.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#ifdef BUILD_WITH_COMMON_SYSTEM
+
+#include <kcenon/common/di/service_container.h>
+#include <kcenon/common/interfaces/database_interface.h>
+
+#include "../adapters/common_system_database_adapter.h"
+#include "../../database/database_manager.h"
+#include "../../database/core/database_context.h"
+
+namespace kcenon::database::di {
+
+/**
+ * @brief Configuration for database service registration
+ */
+struct database_registration_config {
+    /// Database type (postgresql, mysql, sqlite, etc.)
+    ::database::database_types db_type = ::database::database_types::postgresql;
+
+    /// Connection string (optional - can be set later via connect())
+    std::string connection_string;
+
+    /// Whether to connect immediately upon registration
+    bool connect_on_register = false;
+
+    /// Service lifetime (typically singleton for database connections)
+    common::di::service_lifetime lifetime = common::di::service_lifetime::singleton;
+};
+
+/**
+ * @brief Register database services with the service container.
+ *
+ * Registers IDatabase implementation using database_system's database_manager.
+ * By default, registers as a singleton with PostgreSQL backend.
+ *
+ * @param container The service container to register with
+ * @param config Optional configuration for the database
+ * @return VoidResult indicating success or registration error
+ *
+ * @code
+ * auto& container = common::di::service_container::global();
+ *
+ * // Register with default configuration
+ * auto result = register_database_services(container);
+ *
+ * // Or with custom configuration
+ * database_registration_config config;
+ * config.db_type = ::database::database_types::sqlite;
+ * config.connection_string = "database.db";
+ * config.connect_on_register = true;
+ * auto result = register_database_services(container, config);
+ *
+ * // Then resolve database anywhere in the application
+ * auto db = container.resolve<common::interfaces::IDatabase>().value();
+ * db->connect("host=localhost dbname=mydb");
+ * auto result = db->execute_query("SELECT * FROM users");
+ * @endcode
+ */
+inline common::VoidResult register_database_services(
+    common::di::IServiceContainer& container,
+    const database_registration_config& config = {}) {
+
+    // Check if already registered
+    if (container.is_registered<common::interfaces::IDatabase>()) {
+        return common::make_error<std::monostate>(
+            common::di::di_error_codes::already_registered,
+            "IDatabase is already registered",
+            "database_system::di"
+        );
+    }
+
+    // Register database factory
+    return container.register_factory<common::interfaces::IDatabase>(
+        [config](common::di::IServiceContainer&) -> std::shared_ptr<common::interfaces::IDatabase> {
+            // Create adapter with configured database type
+            auto adapter = std::make_shared<adapters::common_system_database_adapter>(config.db_type);
+
+            // Connect if connection string provided and connect_on_register is true
+            if (config.connect_on_register && !config.connection_string.empty()) {
+                auto result = adapter->connect(config.connection_string);
+                if (result.is_err()) {
+                    // Return adapter anyway - caller can check is_connected()
+                    // This is intentional to avoid throwing in factory
+                }
+            }
+
+            return adapter;
+        },
+        config.lifetime
+    );
+}
+
+/**
+ * @brief Register a pre-configured database_manager instance.
+ *
+ * Use this when you have already created a database_manager instance and want
+ * to register it with the container.
+ *
+ * @param container The service container to register with
+ * @param manager The database_manager instance to register
+ * @return VoidResult indicating success or registration error
+ *
+ * @code
+ * // Create database_manager manually
+ * auto context = std::make_shared<::database::database_context>();
+ * auto manager = std::make_shared<::database::database_manager>(context);
+ * manager->set_mode(::database::database_types::postgresql);
+ * manager->connect("host=localhost dbname=mydb");
+ *
+ * // Register the instance
+ * register_database_instance(container, manager);
+ * @endcode
+ */
+inline common::VoidResult register_database_instance(
+    common::di::IServiceContainer& container,
+    std::shared_ptr<::database::database_manager> manager) {
+
+    if (!manager) {
+        return common::make_error<std::monostate>(
+            common::error_codes::INVALID_ARGUMENT,
+            "Cannot register null database_manager instance",
+            "database_system::di"
+        );
+    }
+
+    auto adapter = std::make_shared<adapters::common_system_database_adapter>(std::move(manager));
+
+    return container.register_instance<common::interfaces::IDatabase>(adapter);
+}
+
+/**
+ * @brief Unregister database services from the container.
+ *
+ * @param container The service container to unregister from
+ * @return VoidResult indicating success or error
+ */
+inline common::VoidResult unregister_database_services(
+    common::di::IServiceContainer& container) {
+
+    return container.unregister<common::interfaces::IDatabase>();
+}
+
+/**
+ * @brief Get the underlying database_manager from an IDatabase resolved from the container.
+ *
+ * This utility function allows accessing the underlying database_manager
+ * when needed for advanced operations like connection pooling.
+ *
+ * @param database The IDatabase instance (should be a common_system_database_adapter)
+ * @return Shared pointer to the underlying database_manager, or nullptr if not an adapter
+ *
+ * @code
+ * auto idatabase = container.resolve<common::interfaces::IDatabase>().value();
+ * auto manager = get_underlying_database_manager(idatabase);
+ * if (manager) {
+ *     // Use advanced database_manager features
+ *     auto pool = manager->get_connection_pool(::database::database_types::postgresql);
+ * }
+ * @endcode
+ */
+inline std::shared_ptr<::database::database_manager> get_underlying_database_manager(
+    const std::shared_ptr<common::interfaces::IDatabase>& database) {
+
+    auto adapter = std::dynamic_pointer_cast<adapters::common_system_database_adapter>(database);
+    if (adapter) {
+        return adapter->get_manager();
+    }
+    return nullptr;
+}
+
+/**
+ * @brief Register all database_system services with the container.
+ *
+ * Convenience function to register all available database_system services.
+ *
+ * @param container The service container to register with
+ * @param config Optional configuration for database
+ * @return VoidResult indicating success or registration error
+ */
+inline common::VoidResult register_all_database_services(
+    common::di::IServiceContainer& container,
+    const database_registration_config& config = {}) {
+
+    // Register IDatabase
+    auto result = register_database_services(container, config);
+    if (result.is_err()) {
+        return result;
+    }
+
+    return common::VoidResult::ok({});
+}
+
+} // namespace kcenon::database::di
+
+#endif // BUILD_WITH_COMMON_SYSTEM


### PR DESCRIPTION
## Summary
- Add `common_system_database_adapter` that implements `IDatabase` interface
- Add `service_registration.h` for DI container registration
- Support for connection pooling integration via database_manager

## Test plan
- [ ] Verify adapter correctly implements IDatabase interface
- [ ] Test service registration and resolution
- [ ] Test connection pooling integration

Part of TICKET-103: System adapters for unified service container