### PR TITLE
feat(redis): add callback-based logging to redis_manager

### DIFF
--- a/database/backends/redis/redis_manager.cpp
+++ b/database/backends/redis/redis_manager.cpp
@@ -41,16 +41,38 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sstream>
 #include <stdexcept>
 
-// Logging helper macros - using std::cerr/cout for consistent behavior
-// Note: For structured logging, use integrated_database module which provides
-// logger_adapter. The database module itself should not depend on
-// integrated_database to avoid circular dependencies.
+// Logging helper macros - using callback if set, otherwise std::cerr/cout
+// This design allows integration with logger_adapter from integrated_database
+// module via runtime callback injection, avoiding circular dependencies.
+// Note: These macros must be used within redis_manager member functions
+// where logger_callback_ is accessible.
 #define REDIS_LOG_ERROR(context, message)                                      \
-  std::cerr << "[Redis:" << context << "] Error: " << message << std::endl
+  do {                                                                         \
+    if (logger_callback_) {                                                    \
+      logger_callback_(redis_log_level::error, context, message);              \
+    } else {                                                                   \
+      std::cerr << "[Redis:" << context << "] Error: " << message              \
+                << std::endl;                                                  \
+    }                                                                          \
+  } while (0)
+
 #define REDIS_LOG_WARNING(message)                                             \
-  std::cerr << "[Redis] Warning: " << message << std::endl
+  do {                                                                         \
+    if (logger_callback_) {                                                    \
+      logger_callback_(redis_log_level::warning, "warning", message);          \
+    } else {                                                                   \
+      std::cerr << "[Redis] Warning: " << message << std::endl;                \
+    }                                                                          \
+  } while (0)
+
 #define REDIS_LOG_INFO(message)                                                \
-  std::cout << "[Redis] Info: " << message << std::endl
+  do {                                                                         \
+    if (logger_callback_) {                                                    \
+      logger_callback_(redis_log_level::info, "info", message);                \
+    } else {                                                                   \
+      std::cout << "[Redis] Info: " << message << std::endl;                   \
+    }                                                                          \
+  } while (0)
 
 namespace database {
 redis_manager::redis_manager(void)
@@ -60,6 +82,10 @@ redis_manager::~redis_manager(void) { disconnect(); }
 
 database_types redis_manager::database_type(void) {
   return database_types::redis;
+}
+
+void redis_manager::set_logger(redis_logger_callback callback) {
+  logger_callback_ = std::move(callback);
 }
 
 bool redis_manager::connect(const std::string &connect_string) {

--- a/database/backends/redis/redis_manager.h
+++ b/database/backends/redis/redis_manager.h
@@ -33,9 +33,29 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include "../../database_base.h"
+#include <functional>
 #include <mutex>
 
 namespace database {
+
+/**
+ * @brief Log levels for Redis operations.
+ */
+enum class redis_log_level { debug, info, warning, error };
+
+/**
+ * @brief Callback type for custom logging.
+ *
+ * This allows integration with external logging systems (e.g., logger_adapter)
+ * without creating compile-time dependencies.
+ *
+ * @param level The log level
+ * @param context The operation context (e.g., "connect", "execute_query")
+ * @param message The log message
+ */
+using redis_logger_callback = std::function<void(
+    redis_log_level, const std::string &, const std::string &)>;
+
 /**
  * @class redis_manager
  * @brief Manages Redis database operations.
@@ -266,6 +286,18 @@ public:
    */
   bool set_is_member(const std::string &key, const std::string &member);
 
+  /**
+   * @brief Sets a custom logger callback for Redis operations.
+   *
+   * This allows integration with external logging systems (e.g.,
+   * logger_adapter) without creating compile-time dependencies. When set, all
+   * logging calls will be routed through this callback instead of
+   * std::cerr/std::cout.
+   *
+   * @param callback Logger function that receives (level, context, message)
+   */
+  void set_logger(redis_logger_callback callback);
+
 private:
   /**
    * @brief Parses Redis connection string.
@@ -311,10 +343,11 @@ private:
                          std::string &value);
 
 private:
-  void *context_;          ///< Pointer to Redis context
-  std::mutex redis_mutex_; ///< Mutex for thread safety
-  std::string host_;       ///< Redis host
-  int port_;               ///< Redis port
-  int database_;           ///< Redis database number
+  void *context_;                         ///< Pointer to Redis context
+  std::mutex redis_mutex_;                ///< Mutex for thread safety
+  std::string host_;                      ///< Redis host
+  int port_;                              ///< Redis port
+  int database_;                          ///< Redis database number
+  redis_logger_callback logger_callback_; ///< Optional custom logger callback
 };
 } // namespace database


### PR DESCRIPTION
## Summary
Implements callback-based logging for `redis_manager` to enable integration with `logger_adapter` without circular dependencies.

## Changes
- Add `redis_log_level` enum (debug/info/warning/error)
- Add `redis_logger_callback` typedef using `std::function`
- Add `set_logger()` method for runtime logger injection
- Update logging macros with callback support and fallback

## Testing
- All 37 redis_query_builder tests pass
- Build verified on macOS

## Architecture Decision
The callback-based approach solves the circular dependency issue where `database` module cannot depend on `integrated_database`. Now `integrated_database` can inject `logger_adapter` at runtime.

Closes #208