### PR TITLE
fix(cmake): add fallback library linking for container_system

### DIFF
--- a/database/CMakeLists.txt
+++ b/database/CMakeLists.txt
@@ -379,6 +379,25 @@ if(USE_CONTAINER_SYSTEM)
 
             if(_DATABASE_CONTAINER_TARGET)
                 target_link_libraries(${PROJECT_NAME} PUBLIC ${_DATABASE_CONTAINER_TARGET})
+                message(STATUS "Database: Linked container_system via target: ${_DATABASE_CONTAINER_TARGET}")
+            else()
+                # Fallback: find and link library file directly when no target exists
+                find_system_dependency_library(container_system)
+                if(container_system_LIBRARY_DIR)
+                    find_library(_CONTAINER_LIB
+                        NAMES container_system
+                        PATHS "${container_system_LIBRARY_DIR}"
+                        NO_DEFAULT_PATH
+                    )
+                    if(_CONTAINER_LIB)
+                        target_link_libraries(${PROJECT_NAME} PUBLIC ${_CONTAINER_LIB})
+                        message(STATUS "Database: Linked container_system library directly: ${_CONTAINER_LIB}")
+                    else()
+                        message(WARNING "Database: container_system library file not found in ${container_system_LIBRARY_DIR}")
+                    endif()
+                else()
+                    message(WARNING "Database: container_system library directory not found - linking may fail")
+                endif()
             endif()
         else()
             message(WARNING "Database: container_system headers not found - integration disabled")


### PR DESCRIPTION
## Summary

- Fixed container_system linker errors when building database_system standalone
- Added fallback mechanism to find and link container_system library directly when no CMake target exists

## Problem

When building database_system with `USE_CONTAINER_SYSTEM=ON`, the build would fail with undefined symbol errors for `container_module::value_container` methods. This occurred because:

1. `find_system_dependency()` finds container_system source directory but doesn't create a CMake target
2. `database/CMakeLists.txt` only included headers but didn't link the library when no target was found
3. The linker couldn't find symbols like `set_message_type()`, `to_json()`, `value_container()` constructors

## Solution

Added a fallback mechanism in `database/CMakeLists.txt` that:

1. Uses `find_system_dependency_library()` to locate the container_system library directory
2. Uses `find_library()` to locate `libcontainer_system.a`
3. Links the library directly when no CMake target is available

## Test plan

- [x] Build passes without linker errors
- [x] `integrated_container_protocol_test` runs successfully (13/13 tests passed)
- [x] All 391 tests pass (`100% tests passed, 0 tests failed out of 391`)

Fixes #246