### PR TITLE
refactor(backends): migrate all backends to common::Result<T> API

### DIFF
--- a/database/backends/mongodb_backend.cpp
+++ b/database/backends/mongodb_backend.cpp
@@ -62,7 +62,11 @@ database_types mongodb_backend::type() const
 database::result<void> mongodb_backend::initialize(const core::connection_config& config)
 {
 	if (initialized_) {
-		return database::result<void>::err(database::error_info("Backend already initialized"));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			"Backend already initialized",
+			"mongodb_backend"
+		};
 	}
 
 	connection_config_ = config;
@@ -70,18 +74,22 @@ database::result<void> mongodb_backend::initialize(const core::connection_config
 
 	if (!manager_->connect(conn_uri)) {
 		last_error_ = "Failed to connect to MongoDB server";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::connection_failed),
+			last_error_,
+			"mongodb_backend"
+		};
 	}
 
 	initialized_ = true;
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 database::result<void> mongodb_backend::shutdown()
 {
 	if (!initialized_) {
-		return database::result<void>::ok(std::monostate{}); // Already shutdown
+		return kcenon::common::ok(); // Already shutdown
 	}
 
 	// Rollback any active transaction before disconnecting
@@ -91,12 +99,16 @@ database::result<void> mongodb_backend::shutdown()
 
 	if (!manager_->disconnect()) {
 		last_error_ = "Failed to disconnect from MongoDB server";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::connection_failed),
+			last_error_,
+			"mongodb_backend"
+		};
 	}
 
 	initialized_ = false;
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 bool mongodb_backend::is_initialized() const
@@ -108,76 +120,108 @@ database::result<uint64_t> mongodb_backend::insert_query(const std::string& quer
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<uint64_t>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"mongodb_backend"
+		};
 	}
 
 	unsigned int affected = manager_->insert_query(query_string);
 	last_error_.clear();
-	return database::result<uint64_t>::ok(static_cast<uint64_t>(affected));
+	return static_cast<uint64_t>(affected);
 }
 
 database::result<uint64_t> mongodb_backend::update_query(const std::string& query_string)
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<uint64_t>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"mongodb_backend"
+		};
 	}
 
 	unsigned int affected = manager_->update_query(query_string);
 	last_error_.clear();
-	return database::result<uint64_t>::ok(static_cast<uint64_t>(affected));
+	return static_cast<uint64_t>(affected);
 }
 
 database::result<uint64_t> mongodb_backend::delete_query(const std::string& query_string)
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<uint64_t>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"mongodb_backend"
+		};
 	}
 
 	unsigned int affected = manager_->delete_query(query_string);
 	last_error_.clear();
-	return database::result<uint64_t>::ok(static_cast<uint64_t>(affected));
+	return static_cast<uint64_t>(affected);
 }
 
 database::result<database_result> mongodb_backend::select_query(const std::string& query_string)
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<database_result>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"mongodb_backend"
+		};
 	}
 
 	database_result result = manager_->select_query(query_string);
 	last_error_.clear();
-	return database::result<database_result>::ok(std::move(result));
+	return result;
 }
 
 database::result<void> mongodb_backend::execute_query(const std::string& query_string)
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"mongodb_backend"
+		};
 	}
 
 	if (!manager_->execute_query(query_string)) {
 		last_error_ = "Query execution failed";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"mongodb_backend"
+		};
 	}
 
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 database::result<void> mongodb_backend::begin_transaction()
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"mongodb_backend"
+		};
 	}
 
 	if (in_transaction_) {
 		last_error_ = "Transaction already active";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"mongodb_backend"
+		};
 	}
 
 	// MongoDB transactions require replica sets or sharded clusters
@@ -185,41 +229,53 @@ database::result<void> mongodb_backend::begin_transaction()
 	// The actual transaction implementation is handled by mongodb_manager
 	in_transaction_ = true;
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 database::result<void> mongodb_backend::commit_transaction()
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"mongodb_backend"
+		};
 	}
 
 	if (!in_transaction_) {
 		last_error_ = "No active transaction";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"mongodb_backend"
+		};
 	}
 
 	in_transaction_ = false;
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 database::result<void> mongodb_backend::rollback_transaction()
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"mongodb_backend"
+		};
 	}
 
 	if (!in_transaction_) {
 		// Not an error - already rolled back or never started
-		return database::result<void>::ok(std::monostate{});
+		return kcenon::common::ok();
 	}
 
 	in_transaction_ = false;
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 bool mongodb_backend::in_transaction() const

--- a/database/backends/mysql_backend.cpp
+++ b/database/backends/mysql_backend.cpp
@@ -63,7 +63,11 @@ database_types mysql_backend::type() const
 database::result<void> mysql_backend::initialize(const core::connection_config& config)
 {
 	if (initialized_) {
-		return database::result<void>::err(database::error_info("Backend already initialized"));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			"Backend already initialized",
+			"mysql_backend"
+		};
 	}
 
 	connection_config_ = config;
@@ -71,18 +75,22 @@ database::result<void> mysql_backend::initialize(const core::connection_config& 
 
 	if (!manager_->connect(conn_str)) {
 		last_error_ = "Failed to connect to MySQL server";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::connection_failed),
+			last_error_,
+			"mysql_backend"
+		};
 	}
 
 	initialized_ = true;
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 database::result<void> mysql_backend::shutdown()
 {
 	if (!initialized_) {
-		return database::result<void>::ok(std::monostate{}); // Already shutdown
+		return kcenon::common::ok(); // Already shutdown
 	}
 
 	// Rollback any active transaction before disconnecting
@@ -92,12 +100,16 @@ database::result<void> mysql_backend::shutdown()
 
 	if (!manager_->disconnect()) {
 		last_error_ = "Failed to disconnect from MySQL server";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::connection_failed),
+			last_error_,
+			"mysql_backend"
+		};
 	}
 
 	initialized_ = false;
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 bool mysql_backend::is_initialized() const
@@ -109,131 +121,187 @@ database::result<uint64_t> mysql_backend::insert_query(const std::string& query_
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<uint64_t>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"mysql_backend"
+		};
 	}
 
 	unsigned int affected = manager_->insert_query(query_string);
 	last_error_.clear();
-	return database::result<uint64_t>::ok(static_cast<uint64_t>(affected));
+	return static_cast<uint64_t>(affected);
 }
 
 database::result<uint64_t> mysql_backend::update_query(const std::string& query_string)
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<uint64_t>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"mysql_backend"
+		};
 	}
 
 	unsigned int affected = manager_->update_query(query_string);
 	last_error_.clear();
-	return database::result<uint64_t>::ok(static_cast<uint64_t>(affected));
+	return static_cast<uint64_t>(affected);
 }
 
 database::result<uint64_t> mysql_backend::delete_query(const std::string& query_string)
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<uint64_t>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"mysql_backend"
+		};
 	}
 
 	unsigned int affected = manager_->delete_query(query_string);
 	last_error_.clear();
-	return database::result<uint64_t>::ok(static_cast<uint64_t>(affected));
+	return static_cast<uint64_t>(affected);
 }
 
 database::result<database_result> mysql_backend::select_query(const std::string& query_string)
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<database_result>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"mysql_backend"
+		};
 	}
 
 	database_result result = manager_->select_query(query_string);
 	last_error_.clear();
-	return database::result<database_result>::ok(std::move(result));
+	return result;
 }
 
 database::result<void> mysql_backend::execute_query(const std::string& query_string)
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"mysql_backend"
+		};
 	}
 
 	if (!manager_->execute_query(query_string)) {
 		last_error_ = "Query execution failed";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"mysql_backend"
+		};
 	}
 
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 database::result<void> mysql_backend::begin_transaction()
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"mysql_backend"
+		};
 	}
 
 	if (in_transaction_) {
 		last_error_ = "Transaction already active";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"mysql_backend"
+		};
 	}
 
 	if (!manager_->execute_query("START TRANSACTION")) {
 		last_error_ = "Failed to begin transaction";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"mysql_backend"
+		};
 	}
 
 	in_transaction_ = true;
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 database::result<void> mysql_backend::commit_transaction()
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"mysql_backend"
+		};
 	}
 
 	if (!in_transaction_) {
 		last_error_ = "No active transaction";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"mysql_backend"
+		};
 	}
 
 	if (!manager_->execute_query("COMMIT")) {
 		last_error_ = "Failed to commit transaction";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"mysql_backend"
+		};
 	}
 
 	in_transaction_ = false;
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 database::result<void> mysql_backend::rollback_transaction()
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"mysql_backend"
+		};
 	}
 
 	if (!in_transaction_) {
 		// Not an error - already rolled back or never started
-		return database::result<void>::ok(std::monostate{});
+		return kcenon::common::ok();
 	}
 
 	if (!manager_->execute_query("ROLLBACK")) {
 		last_error_ = "Failed to rollback transaction";
 		in_transaction_ = false; // Force state reset even on error
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"mysql_backend"
+		};
 	}
 
 	in_transaction_ = false;
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 bool mysql_backend::in_transaction() const

--- a/database/backends/postgresql_backend.cpp
+++ b/database/backends/postgresql_backend.cpp
@@ -63,7 +63,11 @@ database_types postgresql_backend::type() const
 database::result<void> postgresql_backend::initialize(const core::connection_config& config)
 {
 	if (initialized_) {
-		return database::result<void>::err(database::error_info("Backend already initialized"));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			"Backend already initialized",
+			"postgresql_backend"
+		};
 	}
 
 	connection_config_ = config;
@@ -71,18 +75,22 @@ database::result<void> postgresql_backend::initialize(const core::connection_con
 
 	if (!manager_->connect(conn_str)) {
 		last_error_ = "Failed to connect to PostgreSQL server";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::connection_failed),
+			last_error_,
+			"postgresql_backend"
+		};
 	}
 
 	initialized_ = true;
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 database::result<void> postgresql_backend::shutdown()
 {
 	if (!initialized_) {
-		return database::result<void>::ok(std::monostate{}); // Already shutdown
+		return kcenon::common::ok(); // Already shutdown
 	}
 
 	// Rollback any active transaction before disconnecting
@@ -92,12 +100,16 @@ database::result<void> postgresql_backend::shutdown()
 
 	if (!manager_->disconnect()) {
 		last_error_ = "Failed to disconnect from PostgreSQL server";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::connection_failed),
+			last_error_,
+			"postgresql_backend"
+		};
 	}
 
 	initialized_ = false;
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 bool postgresql_backend::is_initialized() const
@@ -109,131 +121,187 @@ database::result<uint64_t> postgresql_backend::insert_query(const std::string& q
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<uint64_t>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"postgresql_backend"
+		};
 	}
 
 	unsigned int affected = manager_->insert_query(query_string);
 	last_error_.clear();
-	return database::result<uint64_t>::ok(static_cast<uint64_t>(affected));
+	return static_cast<uint64_t>(affected);
 }
 
 database::result<uint64_t> postgresql_backend::update_query(const std::string& query_string)
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<uint64_t>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"postgresql_backend"
+		};
 	}
 
 	unsigned int affected = manager_->update_query(query_string);
 	last_error_.clear();
-	return database::result<uint64_t>::ok(static_cast<uint64_t>(affected));
+	return static_cast<uint64_t>(affected);
 }
 
 database::result<uint64_t> postgresql_backend::delete_query(const std::string& query_string)
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<uint64_t>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"postgresql_backend"
+		};
 	}
 
 	unsigned int affected = manager_->delete_query(query_string);
 	last_error_.clear();
-	return database::result<uint64_t>::ok(static_cast<uint64_t>(affected));
+	return static_cast<uint64_t>(affected);
 }
 
 database::result<database_result> postgresql_backend::select_query(const std::string& query_string)
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<database_result>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"postgresql_backend"
+		};
 	}
 
 	database_result result = manager_->select_query(query_string);
 	last_error_.clear();
-	return database::result<database_result>::ok(std::move(result));
+	return result;
 }
 
 database::result<void> postgresql_backend::execute_query(const std::string& query_string)
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"postgresql_backend"
+		};
 	}
 
 	if (!manager_->execute_query(query_string)) {
 		last_error_ = "Query execution failed";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"postgresql_backend"
+		};
 	}
 
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 database::result<void> postgresql_backend::begin_transaction()
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"postgresql_backend"
+		};
 	}
 
 	if (in_transaction_) {
 		last_error_ = "Transaction already active";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"postgresql_backend"
+		};
 	}
 
 	if (!manager_->execute_query("BEGIN")) {
 		last_error_ = "Failed to begin transaction";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"postgresql_backend"
+		};
 	}
 
 	in_transaction_ = true;
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 database::result<void> postgresql_backend::commit_transaction()
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"postgresql_backend"
+		};
 	}
 
 	if (!in_transaction_) {
 		last_error_ = "No active transaction";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"postgresql_backend"
+		};
 	}
 
 	if (!manager_->execute_query("COMMIT")) {
 		last_error_ = "Failed to commit transaction";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"postgresql_backend"
+		};
 	}
 
 	in_transaction_ = false;
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 database::result<void> postgresql_backend::rollback_transaction()
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"postgresql_backend"
+		};
 	}
 
 	if (!in_transaction_) {
 		// Not an error - already rolled back or never started
-		return database::result<void>::ok(std::monostate{});
+		return kcenon::common::ok();
 	}
 
 	if (!manager_->execute_query("ROLLBACK")) {
 		last_error_ = "Failed to rollback transaction";
 		in_transaction_ = false; // Force state reset even on error
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"postgresql_backend"
+		};
 	}
 
 	in_transaction_ = false;
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 bool postgresql_backend::in_transaction() const

--- a/database/backends/redis_backend.cpp
+++ b/database/backends/redis_backend.cpp
@@ -62,7 +62,11 @@ database_types redis_backend::type() const
 database::result<void> redis_backend::initialize(const core::connection_config& config)
 {
 	if (initialized_) {
-		return database::result<void>::err(database::error_info("Backend already initialized"));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			"Backend already initialized",
+			"redis_backend"
+		};
 	}
 
 	connection_config_ = config;
@@ -70,18 +74,22 @@ database::result<void> redis_backend::initialize(const core::connection_config& 
 
 	if (!manager_->connect(conn_str)) {
 		last_error_ = "Failed to connect to Redis server";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::connection_failed),
+			last_error_,
+			"redis_backend"
+		};
 	}
 
 	initialized_ = true;
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 database::result<void> redis_backend::shutdown()
 {
 	if (!initialized_) {
-		return database::result<void>::ok(std::monostate{}); // Already shutdown
+		return kcenon::common::ok(); // Already shutdown
 	}
 
 	// Discard any active transaction before disconnecting
@@ -91,12 +99,16 @@ database::result<void> redis_backend::shutdown()
 
 	if (!manager_->disconnect()) {
 		last_error_ = "Failed to disconnect from Redis server";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::connection_failed),
+			last_error_,
+			"redis_backend"
+		};
 	}
 
 	initialized_ = false;
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 bool redis_backend::is_initialized() const
@@ -108,134 +120,190 @@ database::result<uint64_t> redis_backend::insert_query(const std::string& query_
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<uint64_t>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"redis_backend"
+		};
 	}
 
 	unsigned int affected = manager_->insert_query(query_string);
 	last_error_.clear();
-	return database::result<uint64_t>::ok(static_cast<uint64_t>(affected));
+	return static_cast<uint64_t>(affected);
 }
 
 database::result<uint64_t> redis_backend::update_query(const std::string& query_string)
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<uint64_t>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"redis_backend"
+		};
 	}
 
 	unsigned int affected = manager_->update_query(query_string);
 	last_error_.clear();
-	return database::result<uint64_t>::ok(static_cast<uint64_t>(affected));
+	return static_cast<uint64_t>(affected);
 }
 
 database::result<uint64_t> redis_backend::delete_query(const std::string& query_string)
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<uint64_t>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"redis_backend"
+		};
 	}
 
 	unsigned int affected = manager_->delete_query(query_string);
 	last_error_.clear();
-	return database::result<uint64_t>::ok(static_cast<uint64_t>(affected));
+	return static_cast<uint64_t>(affected);
 }
 
 database::result<database_result> redis_backend::select_query(const std::string& query_string)
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<database_result>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"redis_backend"
+		};
 	}
 
 	database_result result = manager_->select_query(query_string);
 	last_error_.clear();
-	return database::result<database_result>::ok(std::move(result));
+	return result;
 }
 
 database::result<void> redis_backend::execute_query(const std::string& query_string)
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"redis_backend"
+		};
 	}
 
 	if (!manager_->execute_query(query_string)) {
 		last_error_ = "Query execution failed";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"redis_backend"
+		};
 	}
 
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 database::result<void> redis_backend::begin_transaction()
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"redis_backend"
+		};
 	}
 
 	if (in_transaction_) {
 		last_error_ = "Transaction already active";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"redis_backend"
+		};
 	}
 
 	// Redis uses MULTI to begin a transaction
 	if (!manager_->execute_query("MULTI")) {
 		last_error_ = "Failed to begin transaction";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"redis_backend"
+		};
 	}
 
 	in_transaction_ = true;
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 database::result<void> redis_backend::commit_transaction()
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"redis_backend"
+		};
 	}
 
 	if (!in_transaction_) {
 		last_error_ = "No active transaction";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"redis_backend"
+		};
 	}
 
 	// Redis uses EXEC to commit a transaction
 	if (!manager_->execute_query("EXEC")) {
 		last_error_ = "Failed to commit transaction";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"redis_backend"
+		};
 	}
 
 	in_transaction_ = false;
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 database::result<void> redis_backend::rollback_transaction()
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"redis_backend"
+		};
 	}
 
 	if (!in_transaction_) {
 		// Not an error - already discarded or never started
-		return database::result<void>::ok(std::monostate{});
+		return kcenon::common::ok();
 	}
 
 	// Redis uses DISCARD to rollback a transaction
 	if (!manager_->execute_query("DISCARD")) {
 		last_error_ = "Failed to rollback transaction";
 		in_transaction_ = false; // Force state reset even on error
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"redis_backend"
+		};
 	}
 
 	in_transaction_ = false;
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 bool redis_backend::in_transaction() const

--- a/database/backends/sqlite_backend.cpp
+++ b/database/backends/sqlite_backend.cpp
@@ -61,7 +61,11 @@ database_types sqlite_backend::type() const
 database::result<void> sqlite_backend::initialize(const core::connection_config& config)
 {
 	if (initialized_) {
-		return database::result<void>::err(database::error_info("Backend already initialized"));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			"Backend already initialized",
+			"sqlite_backend"
+		};
 	}
 
 	connection_config_ = config;
@@ -69,18 +73,22 @@ database::result<void> sqlite_backend::initialize(const core::connection_config&
 
 	if (!manager_->connect(db_path)) {
 		last_error_ = "Failed to connect to SQLite database";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::connection_failed),
+			last_error_,
+			"sqlite_backend"
+		};
 	}
 
 	initialized_ = true;
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 database::result<void> sqlite_backend::shutdown()
 {
 	if (!initialized_) {
-		return database::result<void>::ok(std::monostate{}); // Already shutdown
+		return kcenon::common::ok(); // Already shutdown
 	}
 
 	// Rollback any active transaction before disconnecting
@@ -90,12 +98,16 @@ database::result<void> sqlite_backend::shutdown()
 
 	if (!manager_->disconnect()) {
 		last_error_ = "Failed to disconnect from SQLite database";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::connection_failed),
+			last_error_,
+			"sqlite_backend"
+		};
 	}
 
 	initialized_ = false;
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 bool sqlite_backend::is_initialized() const
@@ -107,131 +119,187 @@ database::result<uint64_t> sqlite_backend::insert_query(const std::string& query
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<uint64_t>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"sqlite_backend"
+		};
 	}
 
 	unsigned int affected = manager_->insert_query(query_string);
 	last_error_.clear();
-	return database::result<uint64_t>::ok(static_cast<uint64_t>(affected));
+	return static_cast<uint64_t>(affected);
 }
 
 database::result<uint64_t> sqlite_backend::update_query(const std::string& query_string)
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<uint64_t>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"sqlite_backend"
+		};
 	}
 
 	unsigned int affected = manager_->update_query(query_string);
 	last_error_.clear();
-	return database::result<uint64_t>::ok(static_cast<uint64_t>(affected));
+	return static_cast<uint64_t>(affected);
 }
 
 database::result<uint64_t> sqlite_backend::delete_query(const std::string& query_string)
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<uint64_t>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"sqlite_backend"
+		};
 	}
 
 	unsigned int affected = manager_->delete_query(query_string);
 	last_error_.clear();
-	return database::result<uint64_t>::ok(static_cast<uint64_t>(affected));
+	return static_cast<uint64_t>(affected);
 }
 
 database::result<database_result> sqlite_backend::select_query(const std::string& query_string)
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<database_result>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"sqlite_backend"
+		};
 	}
 
 	database_result result = manager_->select_query(query_string);
 	last_error_.clear();
-	return database::result<database_result>::ok(std::move(result));
+	return result;
 }
 
 database::result<void> sqlite_backend::execute_query(const std::string& query_string)
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"sqlite_backend"
+		};
 	}
 
 	if (!manager_->execute_query(query_string)) {
 		last_error_ = "Query execution failed";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"sqlite_backend"
+		};
 	}
 
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 database::result<void> sqlite_backend::begin_transaction()
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"sqlite_backend"
+		};
 	}
 
 	if (in_transaction_) {
 		last_error_ = "Transaction already active";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"sqlite_backend"
+		};
 	}
 
 	if (!manager_->execute_query("BEGIN TRANSACTION")) {
 		last_error_ = "Failed to begin transaction";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"sqlite_backend"
+		};
 	}
 
 	in_transaction_ = true;
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 database::result<void> sqlite_backend::commit_transaction()
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"sqlite_backend"
+		};
 	}
 
 	if (!in_transaction_) {
 		last_error_ = "No active transaction";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"sqlite_backend"
+		};
 	}
 
 	if (!manager_->execute_query("COMMIT")) {
 		last_error_ = "Failed to commit transaction";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"sqlite_backend"
+		};
 	}
 
 	in_transaction_ = false;
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 database::result<void> sqlite_backend::rollback_transaction()
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"sqlite_backend"
+		};
 	}
 
 	if (!in_transaction_) {
 		// Not an error - already rolled back or never started
-		return database::result<void>::ok(std::monostate{});
+		return kcenon::common::ok();
 	}
 
 	if (!manager_->execute_query("ROLLBACK")) {
 		last_error_ = "Failed to rollback transaction";
 		in_transaction_ = false; // Force state reset even on error
-		return database::result<void>::err(database::error_info(last_error_));
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"sqlite_backend"
+		};
 	}
 
 	in_transaction_ = false;
 	last_error_.clear();
-	return database::result<void>::ok(std::monostate{});
+	return kcenon::common::ok();
 }
 
 bool sqlite_backend::in_transaction() const


### PR DESCRIPTION
## Summary

- Migrate all database backends from deprecated `database::result<T>` factory methods to `common::Result<T>` API
- Use `kcenon::common::ok()` for success returns instead of `database::result<void>::ok(std::monostate{})`
- Use `kcenon::common::error_info{code, message, context}` for error returns
- Apply appropriate `database::error_code` values for better error categorization

## Changes

### Files Modified
- `database/backends/sqlite_backend.cpp`
- `database/backends/redis_backend.cpp`
- `database/backends/postgresql_backend.cpp`
- `database/backends/mysql_backend.cpp`
- `database/backends/mongodb_backend.cpp`

### Migration Pattern
```cpp
// Before
return database::result<void>::ok(std::monostate{});
return database::result<void>::err(database::error_info("message"));

// After
return kcenon::common::ok();
return kcenon::common::error_info{
    static_cast<int>(database::error_code::invalid_state),
    "message",
    "backend_name"
};
```

## Test Plan

- [x] Build succeeds on all platforms
- [x] All existing unit tests pass
- [x] All integration tests pass

## Related Issues

Closes #241 (Sub-task 2: Migrate backends module to common::Result<T>)
Parent: #239 (Adopt common_system Result<T> for Unified Error Handling)