### PR TITLE
build: enable deprecation warnings for common_system API migration

### DIFF
--- a/database/CMakeLists.txt
+++ b/database/CMakeLists.txt
@@ -506,6 +506,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         -Wall
         -Wextra
         -Wpedantic
+        -Wdeprecated-declarations
         -Wno-unused-parameter
         -Wno-unused-variable
     )
@@ -513,6 +514,7 @@ elseif(MSVC)
     target_compile_options(${PROJECT_NAME} PRIVATE
         /W4
         /WX-
+        /w14996  # Enable deprecation warnings (C4996)
     )
 endif()
 

--- a/database/integrated/CMakeLists.txt
+++ b/database/integrated/CMakeLists.txt
@@ -218,6 +218,28 @@ if(USE_MONITORING_SYSTEM)
 endif()
 
 ##################################################
+# Compiler Options
+##################################################
+
+if(INTEGRATED_DB_SOURCES)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(${INTEGRATED_DB_TARGET} PRIVATE
+            -Wall
+            -Wextra
+            -Wpedantic
+            -Wdeprecated-declarations
+            -Wno-unused-parameter
+        )
+    elseif(MSVC)
+        target_compile_options(${INTEGRATED_DB_TARGET} PRIVATE
+            /W4
+            /WX-
+            /w14996  # Enable deprecation warnings (C4996)
+        )
+    endif()
+endif()
+
+##################################################
 # C++ Standard
 ##################################################
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,28 @@
 # Enable testing
 enable_testing()
 
+##################################################
+# Common Compiler Options for Tests
+##################################################
+
+# Function to apply deprecation warnings to test targets
+function(apply_test_compiler_options target)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(${target} PRIVATE
+            -Wall
+            -Wextra
+            -Wdeprecated-declarations
+            -Wno-unused-parameter
+        )
+    elseif(MSVC)
+        target_compile_options(${target} PRIVATE
+            /W4
+            /WX-
+            /w14996  # Enable deprecation warnings (C4996)
+        )
+    endif()
+endfunction()
+
 # Find test dependencies
 find_package(GTest QUIET)
 if(NOT GTest_FOUND)
@@ -73,6 +95,9 @@ if(GTest_FOUND OR gtest_FOUND)
         RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
     )
     
+    # Apply deprecation warnings
+    apply_test_compiler_options(database_unit_tests)
+
     # Add test
     add_test(NAME DatabaseUnitTests COMMAND database_unit_tests)
 


### PR DESCRIPTION
## Summary

- Enable `-Wdeprecated-declarations` compiler flag to catch deprecated common_system APIs at compile time
- Verify codebase has no deprecated API usage and is ready for common_system v3.0.0

## Changes

### CMake Configuration Updates

1. **database/CMakeLists.txt**
   - Added `-Wdeprecated-declarations` for GCC/Clang
   - Added `/w14996` for MSVC (equivalent deprecation warning)

2. **database/integrated/CMakeLists.txt**
   - Added new Compiler Options section with same flags

3. **tests/CMakeLists.txt**
   - Added `apply_test_compiler_options()` function for consistent warning flags
   - Applied to main test targets

## Migration Status

| Checklist Item | Status |
|---------------|--------|
| Search for deprecated API usage | ✅ None found |
| Update to new API patterns | ✅ Already compliant |
| Enable deprecation warnings in CI | ✅ This PR |
| Verify all tests pass | ✅ 351/351 tests pass |

## Notes

- Current codebase uses `->log(level, message)` pattern (new API)
- No `__FILE__, __LINE__, __func__` 5-arg patterns found
- No `THREAD_LOG_*` macros used
- Custom logging macros (POSTGRES_LOG_*, MYSQL_LOG_*, etc.) are internal to database_system

## Test plan

- [x] Build completes with deprecation warnings enabled
- [x] No deprecation warnings in build output
- [x] All 351 unit tests pass
- [x] Integration tests pass

Closes #274