### PR TITLE
refactor(backends): remove *_manager dependency from all backends

### DIFF
--- a/database/backends/mongodb_backend.cpp
+++ b/database/backends/mongodb_backend.cpp
@@ -365,7 +365,7 @@ kcenon::common::Result<uint64_t> mongodb_backend::delete_query(const std::string
 #endif
 }
 
-kcenon::common::Result<database_result> mongodb_backend::select_query(const std::string& query_string)
+kcenon::common::Result<core::database_result> mongodb_backend::select_query(const std::string& query_string)
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
@@ -376,7 +376,7 @@ kcenon::common::Result<database_result> mongodb_backend::select_query(const std:
 		};
 	}
 
-	database_result result;
+	core::database_result result;
 
 #ifdef USE_MONGODB
 	if (!database_) {
@@ -410,7 +410,7 @@ kcenon::common::Result<database_result> mongodb_backend::select_query(const std:
 		auto cursor = collection.find(filter_doc.view());
 
 		for (auto&& doc : cursor) {
-			database_row row;
+			core::database_row row;
 
 			// Convert BSON document to database_row
 			auto json_string = bsoncxx::to_json(doc);
@@ -444,7 +444,7 @@ kcenon::common::Result<database_result> mongodb_backend::select_query(const std:
 #else
 	MONGODB_LOG_WARNING("MongoDB support not compiled. Select query: " + query_string.substr(0, 20) + "...");
 	// Return mock data for testing
-	database_row mock_row;
+	core::database_row mock_row;
 	mock_row["_id"] = std::string("mock_object_id");
 	mock_row["name"] = std::string("mongodb_mock_data");
 	mock_row["_document"] = std::string("{\"_id\":\"mock_object_id\",\"name\":\"mongodb_mock_data\"}");

--- a/database/backends/mongodb_backend.h
+++ b/database/backends/mongodb_backend.h
@@ -137,7 +137,7 @@ public:
 
 	kcenon::common::Result<uint64_t> delete_query(const std::string& query_string) override;
 
-	kcenon::common::Result<database_result> select_query(const std::string& query_string) override;
+	kcenon::common::Result<core::database_result> select_query(const std::string& query_string) override;
 
 	kcenon::common::VoidResult execute_query(const std::string& query_string) override;
 

--- a/database/backends/mysql_backend.cpp
+++ b/database/backends/mysql_backend.cpp
@@ -270,7 +270,7 @@ kcenon::common::Result<uint64_t> mysql_backend::delete_query(const std::string& 
 	return static_cast<uint64_t>(affected);
 }
 
-kcenon::common::Result<database_result> mysql_backend::select_query(const std::string& query_string)
+kcenon::common::Result<core::database_result> mysql_backend::select_query(const std::string& query_string)
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
@@ -281,7 +281,7 @@ kcenon::common::Result<database_result> mysql_backend::select_query(const std::s
 		};
 	}
 
-	database_result result;
+	core::database_result result;
 
 #ifdef USE_MYSQL
 	if (!connection_) {
@@ -331,7 +331,7 @@ kcenon::common::Result<database_result> mysql_backend::select_query(const std::s
 		// Process rows
 		MYSQL_ROW row;
 		while ((row = mysql_fetch_row(res))) {
-			database_row db_row;
+			core::database_row db_row;
 			unsigned long* lengths = mysql_fetch_lengths(res);
 
 			for (unsigned int i = 0; i < num_fields; i++) {
@@ -381,7 +381,7 @@ kcenon::common::Result<database_result> mysql_backend::select_query(const std::s
 	MYSQL_LOG_WARNING("MySQL support not compiled. Select query: " + query_string.substr(0, 20) + "...");
 	// Return mock data for testing
 	if (query_string.find("SELECT") != std::string::npos) {
-		database_row mock_row;
+		core::database_row mock_row;
 		mock_row["id"] = int64_t(1);
 		mock_row["name"] = std::string("mysql_mock_data");
 		mock_row["active"] = true;
@@ -456,7 +456,7 @@ kcenon::common::VoidResult mysql_backend::begin_transaction()
 	}
 
 	auto result = execute_query("START TRANSACTION");
-	if (!result) {
+	if (result.is_err()) {
 		return result;
 	}
 
@@ -486,7 +486,7 @@ kcenon::common::VoidResult mysql_backend::commit_transaction()
 	}
 
 	auto result = execute_query("COMMIT");
-	if (!result) {
+	if (result.is_err()) {
 		return result;
 	}
 
@@ -514,7 +514,7 @@ kcenon::common::VoidResult mysql_backend::rollback_transaction()
 	auto result = execute_query("ROLLBACK");
 	in_transaction_ = false; // Force state reset even on error
 
-	if (!result) {
+	if (result.is_err()) {
 		return result;
 	}
 

--- a/database/backends/mysql_backend.h
+++ b/database/backends/mysql_backend.h
@@ -136,7 +136,7 @@ public:
 
 	kcenon::common::Result<uint64_t> delete_query(const std::string& query_string) override;
 
-	kcenon::common::Result<database_result> select_query(const std::string& query_string) override;
+	kcenon::common::Result<core::database_result> select_query(const std::string& query_string) override;
 
 	kcenon::common::VoidResult execute_query(const std::string& query_string) override;
 

--- a/database/backends/postgresql_backend.cpp
+++ b/database/backends/postgresql_backend.cpp
@@ -297,7 +297,7 @@ kcenon::common::Result<uint64_t> postgresql_backend::delete_query(const std::str
 	return static_cast<uint64_t>(affected);
 }
 
-kcenon::common::Result<database_result> postgresql_backend::select_query(const std::string& query_string)
+kcenon::common::Result<core::database_result> postgresql_backend::select_query(const std::string& query_string)
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
@@ -308,7 +308,7 @@ kcenon::common::Result<database_result> postgresql_backend::select_query(const s
 		};
 	}
 
-	database_result result;
+	core::database_result result;
 
 #ifdef USE_POSTGRESQL
 	if (!connection_) {
@@ -326,7 +326,7 @@ kcenon::common::Result<database_result> postgresql_backend::select_query(const s
 		txn.commit();
 
 		for (const auto& row : pqxx_result) {
-			database_row db_row;
+			core::database_row db_row;
 			for (size_t i = 0; i < row.size(); ++i) {
 				std::string column_name = pqxx_result.column_name(i);
 				if (row[i].is_null()) {
@@ -382,7 +382,7 @@ kcenon::common::Result<database_result> postgresql_backend::select_query(const s
 		int cols = PQnfields(pg_result);
 
 		for (int row = 0; row < rows; ++row) {
-			database_row db_row;
+			core::database_row db_row;
 			for (int col = 0; col < cols; ++col) {
 				std::string column_name = PQfname(pg_result, col);
 				if (PQgetisnull(pg_result, row, col)) {
@@ -419,7 +419,7 @@ kcenon::common::Result<database_result> postgresql_backend::select_query(const s
 	POSTGRES_LOG_WARNING("PostgreSQL support not compiled. Select query: " + query_string.substr(0, 20) + "...");
 	// Return mock data for testing
 	if (query_string.find("SELECT") != std::string::npos) {
-		database_row mock_row;
+		core::database_row mock_row;
 		mock_row["id"] = int64_t(1);
 		mock_row["name"] = std::string("mock_data");
 		mock_row["active"] = true;
@@ -536,7 +536,7 @@ kcenon::common::VoidResult postgresql_backend::begin_transaction()
 	}
 
 	auto result = execute_query("BEGIN");
-	if (!result) {
+	if (result.is_err()) {
 		return result;
 	}
 
@@ -566,7 +566,7 @@ kcenon::common::VoidResult postgresql_backend::commit_transaction()
 	}
 
 	auto result = execute_query("COMMIT");
-	if (!result) {
+	if (result.is_err()) {
 		return result;
 	}
 
@@ -594,7 +594,7 @@ kcenon::common::VoidResult postgresql_backend::rollback_transaction()
 	auto result = execute_query("ROLLBACK");
 	in_transaction_ = false; // Force state reset even on error
 
-	if (!result) {
+	if (result.is_err()) {
 		return result;
 	}
 

--- a/database/backends/postgresql_backend.h
+++ b/database/backends/postgresql_backend.h
@@ -136,7 +136,7 @@ public:
 
 	kcenon::common::Result<uint64_t> delete_query(const std::string& query_string) override;
 
-	kcenon::common::Result<database_result> select_query(const std::string& query_string) override;
+	kcenon::common::Result<core::database_result> select_query(const std::string& query_string) override;
 
 	kcenon::common::VoidResult execute_query(const std::string& query_string) override;
 

--- a/database/backends/redis_backend.cpp
+++ b/database/backends/redis_backend.cpp
@@ -358,7 +358,7 @@ kcenon::common::Result<uint64_t> redis_backend::delete_query(const std::string& 
 #endif
 }
 
-kcenon::common::Result<database_result> redis_backend::select_query(const std::string& query_string)
+kcenon::common::Result<core::database_result> redis_backend::select_query(const std::string& query_string)
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
@@ -369,7 +369,7 @@ kcenon::common::Result<database_result> redis_backend::select_query(const std::s
 		};
 	}
 
-	database_result result;
+	core::database_result result;
 
 #ifdef USE_REDIS
 	if (!context_) {
@@ -391,7 +391,7 @@ kcenon::common::Result<database_result> redis_backend::select_query(const std::s
 
 		if (reply != nullptr && reply->type != REDIS_REPLY_ERROR &&
 			reply->type != REDIS_REPLY_NIL) {
-			database_row row;
+			core::database_row row;
 			row["key"] = key;
 
 			if (reply->type == REDIS_REPLY_STRING) {
@@ -419,7 +419,7 @@ kcenon::common::Result<database_result> redis_backend::select_query(const std::s
 	REDIS_LOG_WARNING("Redis support not compiled. Select query: " + query_string.substr(0, 20) + "...");
 	// Return mock data for testing
 	if (!query_string.empty()) {
-		database_row mock_row;
+		core::database_row mock_row;
 		mock_row["key"] = query_string;
 		mock_row["value"] = std::string("redis_mock_value");
 		result.push_back(mock_row);
@@ -526,7 +526,7 @@ kcenon::common::VoidResult redis_backend::begin_transaction()
 
 	// Redis uses MULTI to begin a transaction
 	auto result = execute_query("MULTI");
-	if (!result) {
+	if (result.is_err()) {
 		return result;
 	}
 
@@ -557,7 +557,7 @@ kcenon::common::VoidResult redis_backend::commit_transaction()
 
 	// Redis uses EXEC to commit a transaction
 	auto result = execute_query("EXEC");
-	if (!result) {
+	if (result.is_err()) {
 		return result;
 	}
 
@@ -586,7 +586,7 @@ kcenon::common::VoidResult redis_backend::rollback_transaction()
 	auto result = execute_query("DISCARD");
 	in_transaction_ = false; // Force state reset even on error
 
-	if (!result) {
+	if (result.is_err()) {
 		return result;
 	}
 

--- a/database/backends/redis_backend.h
+++ b/database/backends/redis_backend.h
@@ -135,7 +135,7 @@ public:
 
 	kcenon::common::Result<uint64_t> delete_query(const std::string& query_string) override;
 
-	kcenon::common::Result<database_result> select_query(const std::string& query_string) override;
+	kcenon::common::Result<core::database_result> select_query(const std::string& query_string) override;
 
 	kcenon::common::VoidResult execute_query(const std::string& query_string) override;
 

--- a/database/backends/sqlite_backend.cpp
+++ b/database/backends/sqlite_backend.cpp
@@ -183,7 +183,7 @@ bool sqlite_backend::is_initialized() const
 	return initialized_;
 }
 
-database_value sqlite_backend::convert_sqlite_value(void* stmt, int column_index)
+core::database_value sqlite_backend::convert_sqlite_value(void* stmt, int column_index)
 {
 #ifdef USE_SQLITE
 	sqlite3_stmt* sqlite_stmt = static_cast<sqlite3_stmt*>(stmt);
@@ -320,7 +320,7 @@ kcenon::common::Result<uint64_t> sqlite_backend::delete_query(const std::string&
 	return static_cast<uint64_t>(affected);
 }
 
-kcenon::common::Result<database_result> sqlite_backend::select_query(const std::string& query_string)
+kcenon::common::Result<core::database_result> sqlite_backend::select_query(const std::string& query_string)
 {
 	if (!initialized_) {
 		last_error_ = "Backend not initialized";
@@ -331,7 +331,7 @@ kcenon::common::Result<database_result> sqlite_backend::select_query(const std::
 		};
 	}
 
-	database_result result;
+	core::database_result result;
 
 #ifdef USE_SQLITE
 	if (!connection_) {
@@ -368,7 +368,7 @@ kcenon::common::Result<database_result> sqlite_backend::select_query(const std::
 
 		// Execute and fetch results
 		while (sqlite3_step(stmt) == SQLITE_ROW) {
-			database_row row;
+			core::database_row row;
 
 			for (int i = 0; i < column_count; i++) {
 				const std::string& column_name = column_names[i];
@@ -394,7 +394,7 @@ kcenon::common::Result<database_result> sqlite_backend::select_query(const std::
 	SQLITE_LOG_WARNING("SQLite support not compiled. Select query: " + query_string.substr(0, 20) + "...");
 	// Return mock data for testing
 	if (query_string.find("SELECT") != std::string::npos) {
-		database_row mock_row;
+		core::database_row mock_row;
 		mock_row["id"] = int64_t(1);
 		mock_row["name"] = std::string("sqlite_mock_data");
 		mock_row["active"] = true;
@@ -476,7 +476,7 @@ kcenon::common::VoidResult sqlite_backend::begin_transaction()
 	}
 
 	auto result = execute_query("BEGIN TRANSACTION");
-	if (!result) {
+	if (result.is_err()) {
 		return result;
 	}
 
@@ -506,7 +506,7 @@ kcenon::common::VoidResult sqlite_backend::commit_transaction()
 	}
 
 	auto result = execute_query("COMMIT");
-	if (!result) {
+	if (result.is_err()) {
 		return result;
 	}
 
@@ -534,7 +534,7 @@ kcenon::common::VoidResult sqlite_backend::rollback_transaction()
 	auto result = execute_query("ROLLBACK");
 	in_transaction_ = false; // Force state reset even on error
 
-	if (!result) {
+	if (result.is_err()) {
 		return result;
 	}
 

--- a/database/backends/sqlite_backend.h
+++ b/database/backends/sqlite_backend.h
@@ -134,7 +134,7 @@ public:
 
 	kcenon::common::Result<uint64_t> delete_query(const std::string& query_string) override;
 
-	kcenon::common::Result<database_result> select_query(const std::string& query_string) override;
+	kcenon::common::Result<core::database_result> select_query(const std::string& query_string) override;
 
 	kcenon::common::VoidResult execute_query(const std::string& query_string) override;
 
@@ -164,7 +164,7 @@ private:
 	 * @param column_index Column index in the result set
 	 * @return database_value containing the converted value
 	 */
-	database_value convert_sqlite_value(void* stmt, int column_index);
+	core::database_value convert_sqlite_value(void* stmt, int column_index);
 
 	void* connection_{nullptr};                      ///< SQLite connection (sqlite3*)
 	std::atomic<bool> initialized_{false};           ///< Initialization state


### PR DESCRIPTION
## Summary

- Remove dependency on legacy `*_manager` classes (which derive from `database_base`) from all database backends
- All backends now directly implement `database_backend` interface using native database APIs
- Backends compile in mock mode when database libraries are not available (for testing without dependencies)

### Changes per backend:
- **postgresql_backend**: Removed `postgres_manager` dependency, directly uses libpq/pqxx
- **mysql_backend**: Removed `mysql_manager` dependency, directly uses MySQL C API
- **sqlite_backend**: Removed `sqlite_manager` dependency, directly uses SQLite3 C API
- **mongodb_backend**: Removed `mongodb_manager` dependency, directly uses mongocxx driver
- **redis_backend**: Removed `redis_manager` dependency, directly uses hiredis

## Test plan

- [x] Build database library successfully
- [ ] Run unit tests with mock mode
- [ ] Test with actual database connections (if available)

Closes #286