### PR TITLE
docs(unified_database_system): document CRUD method relationship to execute()

### DIFF
--- a/database/integrated/unified_database_system.h
+++ b/database/integrated/unified_database_system.h
@@ -464,6 +464,12 @@ public:
      * @param query SQL SELECT statement
      * @param params Optional query parameters
      * @return Result containing selected rows or error
+     *
+     * @note This is a convenience wrapper around execute() that returns
+     *       the full query_result. Use this method when you need all
+     *       columns and rows from a SELECT statement.
+     *
+     * @see execute() for the underlying implementation
      */
     kcenon::common::Result<query_result> select(
         const std::string& query,
@@ -474,6 +480,12 @@ public:
      * @param query SQL INSERT statement
      * @param params Optional query parameters
      * @return Result containing number of inserted rows or error
+     *
+     * @note This is a convenience wrapper around execute() that extracts
+     *       only the affected_rows count from the query_result. Use this
+     *       method when you only need to know how many rows were inserted.
+     *
+     * @see execute() for the underlying implementation
      */
     kcenon::common::Result<size_t> insert(
         const std::string& query,
@@ -484,6 +496,12 @@ public:
      * @param query SQL UPDATE statement
      * @param params Optional query parameters
      * @return Result containing number of updated rows or error
+     *
+     * @note This is a convenience wrapper around execute() that extracts
+     *       only the affected_rows count from the query_result. Use this
+     *       method when you only need to know how many rows were updated.
+     *
+     * @see execute() for the underlying implementation
      */
     kcenon::common::Result<size_t> update(
         const std::string& query,
@@ -494,6 +512,12 @@ public:
      * @param query SQL DELETE statement
      * @param params Optional query parameters
      * @return Result containing number of deleted rows or error
+     *
+     * @note This is a convenience wrapper around execute() that extracts
+     *       only the affected_rows count from the query_result. Use this
+     *       method when you only need to know how many rows were deleted.
+     *
+     * @see execute() for the underlying implementation
      */
     kcenon::common::Result<size_t> remove(
         const std::string& query,


### PR DESCRIPTION
Closes #318

## Summary
- Add `@note` documentation to `select()`, `insert()`, `update()`, and `remove()` methods clarifying their relationship to the base `execute()` method
- Add `@see` references to `execute()` for cross-referencing

## Changes
Each CRUD method is now documented as a convenience wrapper:
- `select()`: Returns full `query_result` from `execute()`
- `insert()`: Extracts `affected_rows` from `execute()` result
- `update()`: Extracts `affected_rows` from `execute()` result  
- `remove()`: Extracts `affected_rows` from `execute()` result

## Test Plan
- [x] Build succeeds without errors
- [x] All 224 tests pass
- [x] Documentation follows existing Doxygen style