### PR TITLE
fix(protocol): migrate to new container_system API

### DIFF
--- a/database/protocol/database_protocol_container.cpp
+++ b/database/protocol/database_protocol_container.cpp
@@ -22,22 +22,26 @@ std::vector<uint8_t> container_protocol_serializer::serialize_container(
     container->set_message_type("query_request");
 
     // Serialize operation (as int since uint8 is promoted to int in variant)
-    container->add_value("operation", static_cast<int>(request.operation));
+    container->set("operation", static_cast<int>(request.operation));
 
     // Serialize query_string
-    container->add_value("query_string", std::string(request.query_string));
+    container->set("query_string", std::string(request.query_string));
 
     // Serialize parameters count
-    container->add_value("param_count", static_cast<unsigned int>(request.parameters.size()));
+    container->set("param_count", static_cast<unsigned int>(request.parameters.size()));
 
     // Serialize each parameter
     for (size_t i = 0; i < request.parameters.size(); ++i) {
         std::string param_key = "param_" + std::to_string(i);
-        container->add_value(param_key, std::string(request.parameters[i]));
+        container->set(param_key, std::string(request.parameters[i]));
     }
 
     // Serialize to bytes
-    return container->serialize_array();
+    auto result = container->serialize(value_container::serialization_format::binary);
+    if (result.is_ok()) {
+        return result.value();
+    }
+    return {};
 }
 
 kcenon::common::Result<query_request> container_protocol_serializer::deserialize_container_query_request(
@@ -57,7 +61,7 @@ kcenon::common::Result<query_request> container_protocol_serializer::deserialize
         query_request request;
 
         // Deserialize operation
-        auto operation_val = container->get_value("operation");
+        auto operation_val = container->get("operation");
         if (operation_val.has_value()) {
             if (std::holds_alternative<int>(operation_val->data)) {
                 request.operation = static_cast<query_operation>(
@@ -76,7 +80,7 @@ kcenon::common::Result<query_request> container_protocol_serializer::deserialize
         }
 
         // Deserialize query_string
-        auto query_val = container->get_value("query_string");
+        auto query_val = container->get("query_string");
         if (query_val.has_value()) {
             if (std::holds_alternative<std::string>(query_val->data)) {
                 request.query_string = std::get<std::string>(query_val->data);
@@ -94,7 +98,7 @@ kcenon::common::Result<query_request> container_protocol_serializer::deserialize
         }
 
         // Deserialize parameters count
-        auto param_count_val = container->get_value("param_count");
+        auto param_count_val = container->get("param_count");
         if (param_count_val.has_value()) {
             if (std::holds_alternative<unsigned int>(param_count_val->data)) {
                 uint32_t count = std::get<unsigned int>(param_count_val->data);
@@ -103,7 +107,7 @@ kcenon::common::Result<query_request> container_protocol_serializer::deserialize
                 // Deserialize each parameter
                 for (uint32_t i = 0; i < count; ++i) {
                     std::string param_key = "param_" + std::to_string(i);
-                    auto param_val = container->get_value(param_key);
+                    auto param_val = container->get(param_key);
                     if (param_val.has_value()) {
                         if (std::holds_alternative<std::string>(param_val->data)) {
                             request.parameters.push_back(std::get<std::string>(param_val->data));
@@ -147,18 +151,22 @@ std::string container_protocol_serializer::serialize_to_json(const query_request
     auto container = std::make_shared<value_container>();
     container->set_message_type("query_request");
 
-    // Serialize fields using template add_value for automatic type deduction
-    container->add_value("operation", static_cast<int>(request.operation));
-    container->add_value("query_string", std::string(request.query_string));
-    container->add_value("param_count", static_cast<unsigned int>(request.parameters.size()));
+    // Serialize fields using template set for automatic type deduction
+    container->set("operation", static_cast<int>(request.operation));
+    container->set("query_string", std::string(request.query_string));
+    container->set("param_count", static_cast<unsigned int>(request.parameters.size()));
 
     for (size_t i = 0; i < request.parameters.size(); ++i) {
         std::string param_key = "param_" + std::to_string(i);
-        container->add_value(param_key, std::string(request.parameters[i]));
+        container->set(param_key, std::string(request.parameters[i]));
     }
 
     // Serialize to JSON
-    return container->to_json();
+    auto result = container->serialize_string(value_container::serialization_format::json);
+    if (result.is_ok()) {
+        return result.value();
+    }
+    return {};
 }
 
 } // namespace database::protocol


### PR DESCRIPTION
## Summary

Update `database_protocol_container.cpp` to use the new unified `container_system` API.

## Changes

| Old API | New API |
|---------|---------|
| `add_value(key, val)` | `set(key, val)` |
| `serialize_array()` | `serialize(serialization_format::binary)` |
| `to_json()` | `serialize_string(serialization_format::json)` |
| `get_value(key)` | `get(key)` |

## Motivation

The `container_system` library has updated its API to a more unified and Result-based approach:
- `add_value()` was removed in favor of `set()`
- `serialize_array()` and `to_json()` were replaced with unified `serialize()` and `serialize_string()` methods
- `get_value()` was deprecated in favor of `get()`

This fix is required to build `pacs_system` with the latest `container_system`.

## Test Plan

- [x] Build `database_system` library
- [x] Build dependent project (`pacs_system`)