### PR TITLE
refactor(query_builder): add core SQL dialect methods for cross-database portability

### DIFF
--- a/database/query_builder/sql_dialect.cpp
+++ b/database/query_builder/sql_dialect.cpp
@@ -26,6 +26,75 @@ std::unique_ptr<sql_dialect> sql_dialect::create(database_types type) {
 
 // PostgreSQL Dialect Implementation
 
+std::string postgresql_dialect::placeholder(int index) const {
+    return "$" + std::to_string(index);
+}
+
+std::string postgresql_dialect::quote_identifier(std::string_view name) const {
+    std::string result;
+    result.reserve(name.size() + 2);
+    result += '"';
+    for (char c : name) {
+        if (c == '"') {
+            result += "\"\"";  // Escape double quotes by doubling
+        } else {
+            result += c;
+        }
+    }
+    result += '"';
+    return result;
+}
+
+std::string postgresql_dialect::escape_string(std::string_view str) const {
+    std::string result;
+    result.reserve(str.size());
+    for (char c : str) {
+        if (c == '\'') {
+            result += "''";  // Escape single quotes by doubling
+        } else if (c == '\\') {
+            result += "\\\\";  // Escape backslashes
+        } else {
+            result += c;
+        }
+    }
+    return result;
+}
+
+std::string postgresql_dialect::returning_clause(std::string_view column) const {
+    if (column.empty()) {
+        return " RETURNING *";
+    }
+    return " RETURNING " + quote_identifier(column);
+}
+
+std::string postgresql_dialect::upsert_clause(
+    const std::vector<std::string>& conflict_columns,
+    const std::vector<std::string>& update_columns) const {
+
+    if (conflict_columns.empty()) {
+        return "";
+    }
+
+    std::string result = "ON CONFLICT (";
+    for (size_t i = 0; i < conflict_columns.size(); ++i) {
+        if (i > 0) result += ", ";
+        result += quote_identifier(conflict_columns[i]);
+    }
+    result += ")";
+
+    if (update_columns.empty()) {
+        result += " DO NOTHING";
+    } else {
+        result += " DO UPDATE SET ";
+        for (size_t i = 0; i < update_columns.size(); ++i) {
+            if (i > 0) result += ", ";
+            std::string quoted = quote_identifier(update_columns[i]);
+            result += quoted + " = EXCLUDED." + quoted;
+        }
+    }
+    return result;
+}
+
 std::string postgresql_dialect::limit_clause(size_t limit, size_t offset) const {
     std::string clause = "LIMIT " + std::to_string(limit);
     if (offset > 0) {
@@ -61,6 +130,71 @@ bool postgresql_dialect::supports_feature(const std::string& feature) const {
 
 // MySQL Dialect Implementation
 
+std::string mysql_dialect::placeholder(int index) const {
+    (void)index;  // MySQL uses positional ? placeholders
+    return "?";
+}
+
+std::string mysql_dialect::quote_identifier(std::string_view name) const {
+    std::string result;
+    result.reserve(name.size() + 2);
+    result += '`';
+    for (char c : name) {
+        if (c == '`') {
+            result += "``";  // Escape backticks by doubling
+        } else {
+            result += c;
+        }
+    }
+    result += '`';
+    return result;
+}
+
+std::string mysql_dialect::escape_string(std::string_view str) const {
+    std::string result;
+    result.reserve(str.size());
+    for (char c : str) {
+        switch (c) {
+            case '\'': result += "\\'"; break;
+            case '"':  result += "\\\""; break;
+            case '\\': result += "\\\\"; break;
+            case '\0': result += "\\0"; break;
+            case '\n': result += "\\n"; break;
+            case '\r': result += "\\r"; break;
+            case '\x1a': result += "\\Z"; break;  // Ctrl+Z
+            default: result += c;
+        }
+    }
+    return result;
+}
+
+std::string mysql_dialect::returning_clause(std::string_view column) const {
+    (void)column;
+    // MySQL does not support RETURNING clause
+    // Use LAST_INSERT_ID() instead
+    return "";
+}
+
+std::string mysql_dialect::upsert_clause(
+    const std::vector<std::string>& conflict_columns,
+    const std::vector<std::string>& update_columns) const {
+
+    (void)conflict_columns;  // MySQL uses ON DUPLICATE KEY based on unique constraints
+
+    if (update_columns.empty()) {
+        // MySQL 8.0.19+ supports INSERT IGNORE, but for compatibility:
+        return "ON DUPLICATE KEY UPDATE " + quote_identifier(update_columns.empty() ? "id" : update_columns[0]) + " = " + quote_identifier(update_columns.empty() ? "id" : update_columns[0]);
+    }
+
+    std::string result = "ON DUPLICATE KEY UPDATE ";
+    for (size_t i = 0; i < update_columns.size(); ++i) {
+        if (i > 0) result += ", ";
+        std::string quoted = quote_identifier(update_columns[i]);
+        result += quoted + " = VALUES(" + quoted + ")";
+    }
+    return result;
+}
+
 std::string mysql_dialect::limit_clause(size_t limit, size_t offset) const {
     if (offset > 0) {
         // MySQL uses "LIMIT offset, limit" syntax
@@ -94,6 +228,74 @@ bool mysql_dialect::supports_feature(const std::string& feature) const {
 }
 
 // SQLite Dialect Implementation
+
+std::string sqlite_dialect::placeholder(int index) const {
+    return "?" + std::to_string(index);
+}
+
+std::string sqlite_dialect::quote_identifier(std::string_view name) const {
+    std::string result;
+    result.reserve(name.size() + 2);
+    result += '"';
+    for (char c : name) {
+        if (c == '"') {
+            result += "\"\"";  // Escape double quotes by doubling
+        } else {
+            result += c;
+        }
+    }
+    result += '"';
+    return result;
+}
+
+std::string sqlite_dialect::escape_string(std::string_view str) const {
+    std::string result;
+    result.reserve(str.size());
+    for (char c : str) {
+        if (c == '\'') {
+            result += "''";  // Escape single quotes by doubling
+        } else {
+            result += c;
+        }
+    }
+    return result;
+}
+
+std::string sqlite_dialect::returning_clause(std::string_view column) const {
+    // SQLite 3.35+ supports RETURNING
+    if (column.empty()) {
+        return " RETURNING *";
+    }
+    return " RETURNING " + quote_identifier(column);
+}
+
+std::string sqlite_dialect::upsert_clause(
+    const std::vector<std::string>& conflict_columns,
+    const std::vector<std::string>& update_columns) const {
+
+    if (conflict_columns.empty()) {
+        return "";
+    }
+
+    std::string result = "ON CONFLICT (";
+    for (size_t i = 0; i < conflict_columns.size(); ++i) {
+        if (i > 0) result += ", ";
+        result += quote_identifier(conflict_columns[i]);
+    }
+    result += ")";
+
+    if (update_columns.empty()) {
+        result += " DO NOTHING";
+    } else {
+        result += " DO UPDATE SET ";
+        for (size_t i = 0; i < update_columns.size(); ++i) {
+            if (i > 0) result += ", ";
+            std::string quoted = quote_identifier(update_columns[i]);
+            result += quoted + " = excluded." + quoted;
+        }
+    }
+    return result;
+}
 
 std::string sqlite_dialect::limit_clause(size_t limit, size_t offset) const {
     std::string clause = "LIMIT " + std::to_string(limit);

--- a/database/query_builder/sql_dialect.h
+++ b/database/query_builder/sql_dialect.h
@@ -9,7 +9,9 @@ All rights reserved.
 
 #include "../database_types.h"
 #include <string>
+#include <string_view>
 #include <memory>
+#include <vector>
 
 namespace database::query {
 
@@ -23,15 +25,78 @@ namespace database::query {
  * - Makes it easy to add new database support
  *
  * Responsibilities:
+ * - Placeholder style formatting ($1 vs ? vs ?1)
+ * - Identifier quoting ("col" vs `col` vs [col])
  * - LIMIT/OFFSET clause formatting
+ * - RETURNING clause support
+ * - UPSERT clause formatting
  * - Auto-increment column definition
  * - Current timestamp functions
+ * - String escaping
  * - Boolean literals
  * - Data type mappings
  */
 class sql_dialect {
 public:
     virtual ~sql_dialect() = default;
+
+    /**
+     * @brief Generate parameter placeholder
+     * @param index 1-based parameter index
+     * @return Database-specific placeholder string
+     *
+     * Examples:
+     * - PostgreSQL: "$1", "$2", "$3"
+     * - MySQL: "?"
+     * - SQLite: "?1", "?2", "?3"
+     */
+    virtual std::string placeholder(int index) const = 0;
+
+    /**
+     * @brief Quote an identifier (table or column name)
+     * @param name The identifier to quote
+     * @return Quoted identifier
+     *
+     * Examples:
+     * - PostgreSQL: "\"column_name\""
+     * - MySQL: "`column_name`"
+     * - SQLite: "\"column_name\""
+     */
+    virtual std::string quote_identifier(std::string_view name) const = 0;
+
+    /**
+     * @brief Escape a string value for safe SQL inclusion
+     * @param str The string to escape
+     * @return Escaped string (without surrounding quotes)
+     */
+    virtual std::string escape_string(std::string_view str) const = 0;
+
+    /**
+     * @brief Generate RETURNING clause for INSERT/UPDATE
+     * @param column The column to return (empty for all)
+     * @return Database-specific RETURNING clause or empty if unsupported
+     *
+     * Examples:
+     * - PostgreSQL: " RETURNING id"
+     * - MySQL: "" (not supported, use LAST_INSERT_ID())
+     * - SQLite: " RETURNING id" (3.35+)
+     */
+    virtual std::string returning_clause(std::string_view column = "") const = 0;
+
+    /**
+     * @brief Generate UPSERT (INSERT OR UPDATE) clause
+     * @param conflict_columns Columns that define conflict
+     * @param update_columns Columns to update on conflict
+     * @return Database-specific upsert clause
+     *
+     * Examples:
+     * - PostgreSQL: "ON CONFLICT (id) DO UPDATE SET ..."
+     * - MySQL: "ON DUPLICATE KEY UPDATE ..."
+     * - SQLite: "ON CONFLICT (id) DO UPDATE SET ..."
+     */
+    virtual std::string upsert_clause(
+        const std::vector<std::string>& conflict_columns,
+        const std::vector<std::string>& update_columns) const = 0;
 
     /**
      * @brief Generate LIMIT clause
@@ -100,6 +165,13 @@ public:
  */
 class postgresql_dialect : public sql_dialect {
 public:
+    std::string placeholder(int index) const override;
+    std::string quote_identifier(std::string_view name) const override;
+    std::string escape_string(std::string_view str) const override;
+    std::string returning_clause(std::string_view column = "") const override;
+    std::string upsert_clause(
+        const std::vector<std::string>& conflict_columns,
+        const std::vector<std::string>& update_columns) const override;
     std::string limit_clause(size_t limit, size_t offset) const override;
     std::string auto_increment() const override;
     std::string current_timestamp() const override;
@@ -113,6 +185,13 @@ public:
  */
 class mysql_dialect : public sql_dialect {
 public:
+    std::string placeholder(int index) const override;
+    std::string quote_identifier(std::string_view name) const override;
+    std::string escape_string(std::string_view str) const override;
+    std::string returning_clause(std::string_view column = "") const override;
+    std::string upsert_clause(
+        const std::vector<std::string>& conflict_columns,
+        const std::vector<std::string>& update_columns) const override;
     std::string limit_clause(size_t limit, size_t offset) const override;
     std::string auto_increment() const override;
     std::string current_timestamp() const override;
@@ -126,6 +205,13 @@ public:
  */
 class sqlite_dialect : public sql_dialect {
 public:
+    std::string placeholder(int index) const override;
+    std::string quote_identifier(std::string_view name) const override;
+    std::string escape_string(std::string_view str) const override;
+    std::string returning_clause(std::string_view column = "") const override;
+    std::string upsert_clause(
+        const std::vector<std::string>& conflict_columns,
+        const std::vector<std::string>& update_columns) const override;
     std::string limit_clause(size_t limit, size_t offset) const override;
     std::string auto_increment() const override;
     std::string current_timestamp() const override;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -420,6 +420,42 @@ if(GTest_FOUND OR gtest_FOUND)
         DISCOVERY_TIMEOUT 60
     )
 
+    # SQL Dialect Tests (Issue #332)
+    add_executable(sql_dialect_test
+        query_builder/sql_dialect_test.cpp
+    )
+
+    if(GTest_FOUND)
+        target_link_libraries(sql_dialect_test PRIVATE
+            database
+            GTest::gtest
+            GTest::gtest_main
+            Threads::Threads
+        )
+    else()
+        target_link_libraries(sql_dialect_test PRIVATE
+            database
+            gtest
+            gtest_main
+            Threads::Threads
+        )
+    endif()
+
+    set_target_properties(sql_dialect_test PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED ON
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+    )
+
+    add_test(NAME SQLDialectTests COMMAND sql_dialect_test)
+
+    gtest_discover_tests(sql_dialect_test
+        PROPERTIES
+            TIMEOUT ${TEST_TIMEOUT}
+        DISCOVERY_TIMEOUT 60
+    )
+
+    message(STATUS "SQL dialect tests configured (Issue #332)")
     message(STATUS "Query builder tests configured (DB-002)")
 endif()
 

--- a/tests/query_builder/sql_dialect_test.cpp
+++ b/tests/query_builder/sql_dialect_test.cpp
@@ -1,0 +1,380 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+*****************************************************************************/
+
+/**
+ * @file sql_dialect_test.cpp
+ * @brief Unit tests for SQL dialect abstraction (Issue #332)
+ *
+ * Tests for database-specific SQL syntax:
+ * - Placeholder style ($1 vs ? vs ?1)
+ * - Identifier quoting ("col" vs `col`)
+ * - String escaping
+ * - RETURNING clause support
+ * - UPSERT clause generation
+ */
+
+#include <gtest/gtest.h>
+#include "database/query_builder/sql_dialect.h"
+#include <memory>
+
+namespace database::query::tests
+{
+
+//=============================================================================
+// PostgreSQL Dialect Tests
+//=============================================================================
+
+class PostgreSQLDialectTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        dialect_ = sql_dialect::create(database_types::postgres);
+    }
+
+    std::unique_ptr<sql_dialect> dialect_;
+};
+
+TEST_F(PostgreSQLDialectTest, PlaceholderStyle)
+{
+    EXPECT_EQ(dialect_->placeholder(1), "$1");
+    EXPECT_EQ(dialect_->placeholder(2), "$2");
+    EXPECT_EQ(dialect_->placeholder(10), "$10");
+    EXPECT_EQ(dialect_->placeholder(100), "$100");
+}
+
+TEST_F(PostgreSQLDialectTest, QuoteIdentifier)
+{
+    EXPECT_EQ(dialect_->quote_identifier("users"), "\"users\"");
+    EXPECT_EQ(dialect_->quote_identifier("user_name"), "\"user_name\"");
+    EXPECT_EQ(dialect_->quote_identifier("SELECT"), "\"SELECT\"");  // Reserved word
+}
+
+TEST_F(PostgreSQLDialectTest, QuoteIdentifierWithSpecialChars)
+{
+    // Double quotes should be escaped by doubling
+    EXPECT_EQ(dialect_->quote_identifier("user\"name"), "\"user\"\"name\"");
+}
+
+TEST_F(PostgreSQLDialectTest, EscapeString)
+{
+    EXPECT_EQ(dialect_->escape_string("hello"), "hello");
+    EXPECT_EQ(dialect_->escape_string("it's"), "it''s");  // Single quote doubled
+    EXPECT_EQ(dialect_->escape_string("back\\slash"), "back\\\\slash");  // Backslash escaped
+    EXPECT_EQ(dialect_->escape_string("O'Brien's"), "O''Brien''s");
+}
+
+TEST_F(PostgreSQLDialectTest, ReturningClause)
+{
+    EXPECT_EQ(dialect_->returning_clause("id"), " RETURNING \"id\"");
+    EXPECT_EQ(dialect_->returning_clause(""), " RETURNING *");
+}
+
+TEST_F(PostgreSQLDialectTest, UpsertClause)
+{
+    std::vector<std::string> conflict_cols = {"id"};
+    std::vector<std::string> update_cols = {"name", "email"};
+
+    std::string result = dialect_->upsert_clause(conflict_cols, update_cols);
+
+    EXPECT_TRUE(result.find("ON CONFLICT") != std::string::npos);
+    EXPECT_TRUE(result.find("\"id\"") != std::string::npos);
+    EXPECT_TRUE(result.find("DO UPDATE SET") != std::string::npos);
+    EXPECT_TRUE(result.find("EXCLUDED") != std::string::npos);
+}
+
+TEST_F(PostgreSQLDialectTest, UpsertClauseDoNothing)
+{
+    std::vector<std::string> conflict_cols = {"id"};
+    std::vector<std::string> update_cols;  // Empty = DO NOTHING
+
+    std::string result = dialect_->upsert_clause(conflict_cols, update_cols);
+
+    EXPECT_TRUE(result.find("DO NOTHING") != std::string::npos);
+}
+
+TEST_F(PostgreSQLDialectTest, UpsertClauseMultipleConflictColumns)
+{
+    std::vector<std::string> conflict_cols = {"tenant_id", "user_id"};
+    std::vector<std::string> update_cols = {"updated_at"};
+
+    std::string result = dialect_->upsert_clause(conflict_cols, update_cols);
+
+    EXPECT_TRUE(result.find("\"tenant_id\"") != std::string::npos);
+    EXPECT_TRUE(result.find("\"user_id\"") != std::string::npos);
+}
+
+TEST_F(PostgreSQLDialectTest, SupportsFeatureReturning)
+{
+    EXPECT_TRUE(dialect_->supports_feature("returning"));
+    EXPECT_TRUE(dialect_->supports_feature("upsert"));
+    EXPECT_TRUE(dialect_->supports_feature("full_outer_join"));
+}
+
+//=============================================================================
+// MySQL Dialect Tests
+//=============================================================================
+
+class MySQLDialectTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        dialect_ = sql_dialect::create(database_types::mysql);
+    }
+
+    std::unique_ptr<sql_dialect> dialect_;
+};
+
+TEST_F(MySQLDialectTest, PlaceholderStyle)
+{
+    // MySQL uses positional ? placeholders
+    EXPECT_EQ(dialect_->placeholder(1), "?");
+    EXPECT_EQ(dialect_->placeholder(2), "?");
+    EXPECT_EQ(dialect_->placeholder(100), "?");
+}
+
+TEST_F(MySQLDialectTest, QuoteIdentifier)
+{
+    EXPECT_EQ(dialect_->quote_identifier("users"), "`users`");
+    EXPECT_EQ(dialect_->quote_identifier("user_name"), "`user_name`");
+    EXPECT_EQ(dialect_->quote_identifier("SELECT"), "`SELECT`");  // Reserved word
+}
+
+TEST_F(MySQLDialectTest, QuoteIdentifierWithBackticks)
+{
+    // Backticks should be escaped by doubling
+    EXPECT_EQ(dialect_->quote_identifier("user`name"), "`user``name`");
+}
+
+TEST_F(MySQLDialectTest, EscapeString)
+{
+    EXPECT_EQ(dialect_->escape_string("hello"), "hello");
+    EXPECT_EQ(dialect_->escape_string("it's"), "it\\'s");  // MySQL uses backslash escape
+    EXPECT_EQ(dialect_->escape_string("back\\slash"), "back\\\\slash");
+    EXPECT_EQ(dialect_->escape_string("line\nbreak"), "line\\nbreak");
+}
+
+TEST_F(MySQLDialectTest, ReturningClauseNotSupported)
+{
+    // MySQL does not support RETURNING clause
+    EXPECT_EQ(dialect_->returning_clause("id"), "");
+    EXPECT_EQ(dialect_->returning_clause(""), "");
+}
+
+TEST_F(MySQLDialectTest, UpsertClause)
+{
+    std::vector<std::string> conflict_cols = {"id"};  // Ignored in MySQL
+    std::vector<std::string> update_cols = {"name", "email"};
+
+    std::string result = dialect_->upsert_clause(conflict_cols, update_cols);
+
+    EXPECT_TRUE(result.find("ON DUPLICATE KEY UPDATE") != std::string::npos);
+    EXPECT_TRUE(result.find("VALUES(") != std::string::npos);
+}
+
+TEST_F(MySQLDialectTest, SupportsFeatureReturning)
+{
+    EXPECT_FALSE(dialect_->supports_feature("returning"));
+    EXPECT_TRUE(dialect_->supports_feature("upsert"));
+    EXPECT_FALSE(dialect_->supports_feature("full_outer_join"));
+}
+
+TEST_F(MySQLDialectTest, LimitClauseSyntax)
+{
+    // MySQL uses different LIMIT syntax with offset
+    EXPECT_EQ(dialect_->limit_clause(10, 0), "LIMIT 10");
+    EXPECT_EQ(dialect_->limit_clause(10, 20), "LIMIT 20, 10");  // offset, limit
+}
+
+//=============================================================================
+// SQLite Dialect Tests
+//=============================================================================
+
+class SQLiteDialectTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        dialect_ = sql_dialect::create(database_types::sqlite);
+    }
+
+    std::unique_ptr<sql_dialect> dialect_;
+};
+
+TEST_F(SQLiteDialectTest, PlaceholderStyle)
+{
+    // SQLite uses ?N numbered placeholders
+    EXPECT_EQ(dialect_->placeholder(1), "?1");
+    EXPECT_EQ(dialect_->placeholder(2), "?2");
+    EXPECT_EQ(dialect_->placeholder(10), "?10");
+}
+
+TEST_F(SQLiteDialectTest, QuoteIdentifier)
+{
+    EXPECT_EQ(dialect_->quote_identifier("users"), "\"users\"");
+    EXPECT_EQ(dialect_->quote_identifier("user_name"), "\"user_name\"");
+    EXPECT_EQ(dialect_->quote_identifier("SELECT"), "\"SELECT\"");
+}
+
+TEST_F(SQLiteDialectTest, QuoteIdentifierWithQuotes)
+{
+    // Double quotes should be escaped by doubling
+    EXPECT_EQ(dialect_->quote_identifier("user\"name"), "\"user\"\"name\"");
+}
+
+TEST_F(SQLiteDialectTest, EscapeString)
+{
+    EXPECT_EQ(dialect_->escape_string("hello"), "hello");
+    EXPECT_EQ(dialect_->escape_string("it's"), "it''s");  // Single quote doubled
+    EXPECT_EQ(dialect_->escape_string("O'Brien's"), "O''Brien''s");
+}
+
+TEST_F(SQLiteDialectTest, ReturningClause)
+{
+    // SQLite 3.35+ supports RETURNING
+    EXPECT_EQ(dialect_->returning_clause("id"), " RETURNING \"id\"");
+    EXPECT_EQ(dialect_->returning_clause(""), " RETURNING *");
+}
+
+TEST_F(SQLiteDialectTest, UpsertClause)
+{
+    std::vector<std::string> conflict_cols = {"id"};
+    std::vector<std::string> update_cols = {"name", "email"};
+
+    std::string result = dialect_->upsert_clause(conflict_cols, update_cols);
+
+    EXPECT_TRUE(result.find("ON CONFLICT") != std::string::npos);
+    EXPECT_TRUE(result.find("\"id\"") != std::string::npos);
+    EXPECT_TRUE(result.find("DO UPDATE SET") != std::string::npos);
+    EXPECT_TRUE(result.find("excluded") != std::string::npos);  // SQLite uses lowercase
+}
+
+TEST_F(SQLiteDialectTest, UpsertClauseDoNothing)
+{
+    std::vector<std::string> conflict_cols = {"id"};
+    std::vector<std::string> update_cols;
+
+    std::string result = dialect_->upsert_clause(conflict_cols, update_cols);
+
+    EXPECT_TRUE(result.find("DO NOTHING") != std::string::npos);
+}
+
+TEST_F(SQLiteDialectTest, SupportsFeatureReturning)
+{
+    EXPECT_TRUE(dialect_->supports_feature("returning"));
+    EXPECT_TRUE(dialect_->supports_feature("upsert"));
+    EXPECT_FALSE(dialect_->supports_feature("full_outer_join"));
+}
+
+TEST_F(SQLiteDialectTest, LimitClauseSyntax)
+{
+    EXPECT_EQ(dialect_->limit_clause(10, 0), "LIMIT 10");
+    EXPECT_EQ(dialect_->limit_clause(10, 20), "LIMIT 10 OFFSET 20");
+}
+
+//=============================================================================
+// Factory Method Tests
+//=============================================================================
+
+TEST(SqlDialectFactoryTest, CreatePostgreSQLDialect)
+{
+    auto dialect = sql_dialect::create(database_types::postgres);
+    ASSERT_NE(dialect, nullptr);
+    EXPECT_EQ(dialect->placeholder(1), "$1");
+}
+
+TEST(SqlDialectFactoryTest, CreateMySQLDialect)
+{
+    auto dialect = sql_dialect::create(database_types::mysql);
+    ASSERT_NE(dialect, nullptr);
+    EXPECT_EQ(dialect->placeholder(1), "?");
+}
+
+TEST(SqlDialectFactoryTest, CreateSQLiteDialect)
+{
+    auto dialect = sql_dialect::create(database_types::sqlite);
+    ASSERT_NE(dialect, nullptr);
+    EXPECT_EQ(dialect->placeholder(1), "?1");
+}
+
+TEST(SqlDialectFactoryTest, CreateUnsupportedDialectThrows)
+{
+    EXPECT_THROW(
+        sql_dialect::create(database_types::mongodb),
+        std::invalid_argument
+    );
+    EXPECT_THROW(
+        sql_dialect::create(database_types::redis),
+        std::invalid_argument
+    );
+}
+
+//=============================================================================
+// Cross-Dialect Comparison Tests
+//=============================================================================
+
+class CrossDialectTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        postgres_ = sql_dialect::create(database_types::postgres);
+        mysql_ = sql_dialect::create(database_types::mysql);
+        sqlite_ = sql_dialect::create(database_types::sqlite);
+    }
+
+    std::unique_ptr<sql_dialect> postgres_;
+    std::unique_ptr<sql_dialect> mysql_;
+    std::unique_ptr<sql_dialect> sqlite_;
+};
+
+TEST_F(CrossDialectTest, PlaceholderStylesDiffer)
+{
+    // All three dialects should produce different placeholders
+    EXPECT_NE(postgres_->placeholder(1), mysql_->placeholder(1));
+    EXPECT_NE(postgres_->placeholder(1), sqlite_->placeholder(1));
+    EXPECT_NE(mysql_->placeholder(1), sqlite_->placeholder(1));
+}
+
+TEST_F(CrossDialectTest, QuoteIdentifierStyles)
+{
+    std::string col = "user_id";
+
+    // PostgreSQL and SQLite use double quotes
+    EXPECT_EQ(postgres_->quote_identifier(col), "\"user_id\"");
+    EXPECT_EQ(sqlite_->quote_identifier(col), "\"user_id\"");
+
+    // MySQL uses backticks
+    EXPECT_EQ(mysql_->quote_identifier(col), "`user_id`");
+}
+
+TEST_F(CrossDialectTest, ConcatOperatorDiffers)
+{
+    // PostgreSQL and SQLite use ||
+    EXPECT_EQ(postgres_->concat_operator(), "||");
+    EXPECT_EQ(sqlite_->concat_operator(), "||");
+
+    // MySQL uses CONCAT function
+    EXPECT_EQ(mysql_->concat_operator(), "CONCAT");
+}
+
+TEST_F(CrossDialectTest, AutoIncrementSyntax)
+{
+    EXPECT_EQ(postgres_->auto_increment(), "SERIAL");
+    EXPECT_EQ(mysql_->auto_increment(), "AUTO_INCREMENT");
+    EXPECT_EQ(sqlite_->auto_increment(), "AUTOINCREMENT");
+}
+
+TEST_F(CrossDialectTest, CurrentTimestampFunction)
+{
+    EXPECT_EQ(postgres_->current_timestamp(), "CURRENT_TIMESTAMP");
+    EXPECT_EQ(mysql_->current_timestamp(), "NOW()");
+    EXPECT_EQ(sqlite_->current_timestamp(), "CURRENT_TIMESTAMP");
+}
+
+} // namespace database::query::tests


### PR DESCRIPTION
## Summary

This PR implements Phase 1 of Issue #332, adding core SQL dialect abstraction methods to eliminate query builder duplication across database backends.

### Changes

- **`sql_dialect.h`**: Added pure virtual methods to base class and declarations to derived classes:
  - `placeholder(int index)` - Generate DB-specific parameter placeholders
  - `quote_identifier(string_view)` - Quote identifiers with proper escaping
  - `escape_string(string_view)` - Escape string literals safely
  - `returning_clause(string_view)` - Generate RETURNING clause
  - `upsert_clause(vectors)` - Generate UPSERT clauses

- **`sql_dialect.cpp`**: Implemented all methods for PostgreSQL, MySQL, and SQLite dialects:
  | Method | PostgreSQL | MySQL | SQLite |
  |--------|------------|-------|--------|
  | placeholder | `$1`, `$2` | `?` | `?1`, `?2` |
  | quote_identifier | `"col"` | `` `col` `` | `"col"` |
  | escape_string | `''` doubled | `\'` escaped | `''` doubled |
  | returning_clause | Supported | Not supported | Supported |
  | upsert_clause | `ON CONFLICT...EXCLUDED` | `ON DUPLICATE KEY...VALUES` | `ON CONFLICT...excluded` |

- **`sql_dialect_test.cpp`**: Added comprehensive unit tests (35 test cases)

### Test Plan

- [x] All 35 unit tests pass
- [x] Build succeeds with no warnings
- [x] Cross-dialect behavior verified

Closes #332