### PR TITLE
build(vcpkg): add optional features for MongoDB and Redis dependencies

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -57,6 +57,22 @@
         }
       ]
     },
+    "mongodb": {
+      "description": "Enable MongoDB backend (experimental)",
+      "dependencies": [
+        {
+          "name": "mongo-cxx-driver"
+        }
+      ]
+    },
+    "redis": {
+      "description": "Enable Redis backend (experimental)",
+      "dependencies": [
+        {
+          "name": "hiredis"
+        }
+      ]
+    },
     "testing": {
       "description": "Enable unit testing and benchmarking",
       "dependencies": [


### PR DESCRIPTION
Closes #338

## Summary

Add vcpkg feature definitions for MongoDB and Redis backends to enable optional dependency installation.

- Add `mongodb` feature depending on `mongo-cxx-driver`
- Add `redis` feature depending on `hiredis`
- Both features marked as "(experimental)" in description

## Changes

| File | Change |
|------|--------|
| `vcpkg.json` | Added `mongodb` and `redis` features |

## Test Plan

- [x] Build succeeds with default options (no MongoDB/Redis)
- [ ] `vcpkg install kcenon-database-system[mongodb]` installs mongo-cxx-driver
- [ ] `vcpkg install kcenon-database-system[redis]` installs hiredis

## Related Issues

Part of #333 (Backend separation evaluation)
Depends on #337 (CMake options) - merged