### PR TITLE
docs: mark MongoDB and Redis backends as experimental

### DIFF
--- a/README.kr.md
+++ b/README.kr.md
@@ -260,8 +260,39 @@ if (void_result.is_ok()) {
 | PostgreSQL | ✅ Full | JSONB, Arrays, CTEs, Prepared Statements | Excellent | ✅ | TLS/SSL |
 | MySQL | ✅ Full | Full-text search, Transactions, Prepared Statements | Very Good | ✅ | TLS/SSL |
 | SQLite | ✅ Full | WAL mode, FTS5, In-memory databases | Good | ✅ | Encryption |
-| MongoDB | ✅ Full | Documents, Aggregation, GridFS | Very Good | ✅ | TLS/SSL |
-| Redis | ✅ Full | All data types, Pub/Sub, Transactions | Excellent | ✅ | TLS/SSL |
+| MongoDB | 🧪 Experimental | Documents, Aggregation, GridFS | Very Good | ✅ | TLS/SSL |
+| Redis | 🧪 Experimental | All data types, Pub/Sub, Transactions | Excellent | ✅ | TLS/SSL |
+
+### 🧪 실험적 기능
+
+> ⚠️ **참고**: 다음 백엔드는 실험적이며 기본적으로 비활성화되어 있습니다.
+> 이 백엔드들은 완전히 기능하지만 향후 릴리스에서 지원이 제한되거나 Breaking Changes가 발생할 수 있습니다.
+
+| 백엔드 | CMake 옵션 | vcpkg Feature | 상태 | 비고 |
+|--------|------------|---------------|------|------|
+| **MongoDB** | `USE_MONGODB=ON` | `mongodb` | 🧪 Experimental | NoSQL 문서 저장소 |
+| **Redis** | `USE_REDIS=ON` | `redis` | 🧪 Experimental | 인메모리 데이터 저장소 |
+
+**실험적 백엔드 활성화:**
+
+```bash
+# MongoDB 지원 활성화
+cmake -DUSE_MONGODB=ON ..
+
+# Redis 지원 활성화
+cmake -DUSE_REDIS=ON ..
+
+# 둘 다 활성화
+cmake -DUSE_MONGODB=ON -DUSE_REDIS=ON ..
+```
+
+**vcpkg features (선택 사항):**
+```bash
+# 특정 features와 함께 설치
+vcpkg install database-system[mongodb,redis]
+```
+
+자세한 빌드 지침은 [빌드 가이드 →](docs/guides/BUILD_GUIDE.kr.md#실험적-백엔드)를 참조하세요.
 
 ### 📊 Database 타입
 

--- a/README.md
+++ b/README.md
@@ -146,10 +146,41 @@ auto query = builder
 | **PostgreSQL** | ✅ Full | JSONB, Arrays, CTEs, FTS | 1.2ms SELECT, 5K TPS |
 | **MySQL** | ✅ Full | Full-text search, Transactions | 1.5ms SELECT, 4.2K TPS |
 | **SQLite** | ✅ Full | WAL mode, FTS5, In-memory | 0.8ms SELECT |
-| **MongoDB** | ✅ Full | Documents, Aggregation, GridFS | 2.1ms insertOne |
-| **Redis** | ✅ Full | All data types, Pub/Sub, Lua | 0.3ms GET/SET |
+| **MongoDB** | 🧪 Experimental | Documents, Aggregation, GridFS | 2.1ms insertOne |
+| **Redis** | 🧪 Experimental | All data types, Pub/Sub, Lua | 0.3ms GET/SET |
 
 [📚 Detailed Backend Features →](docs/FEATURES.md)
+
+### Experimental Features
+
+> ⚠️ **Note**: The following backends are experimental and disabled by default.
+> These backends are fully functional but may have limited support or undergo breaking changes in future releases.
+
+| Backend | CMake Option | vcpkg Feature | Status | Notes |
+|---------|--------------|---------------|--------|-------|
+| **MongoDB** | `USE_MONGODB=ON` | `mongodb` | 🧪 Experimental | NoSQL document store |
+| **Redis** | `USE_REDIS=ON` | `redis` | 🧪 Experimental | In-memory data store |
+
+**To enable experimental backends:**
+
+```bash
+# Enable MongoDB support
+cmake -DUSE_MONGODB=ON ..
+
+# Enable Redis support
+cmake -DUSE_REDIS=ON ..
+
+# Enable both
+cmake -DUSE_MONGODB=ON -DUSE_REDIS=ON ..
+```
+
+**vcpkg features (optional):**
+```bash
+# Install with specific features
+vcpkg install database-system[mongodb,redis]
+```
+
+For detailed build instructions, see [Build Guide →](docs/guides/BUILD_GUIDE.md#experimental-backends)
 
 ### Server-Side Connection Pooling (ProxyMode)
 

--- a/docs/CHANGELOG.kr.md
+++ b/docs/CHANGELOG.kr.md
@@ -24,7 +24,28 @@
 
 ---
 
-## [Unreleased] - 2026-01-20
+## [Unreleased] - 2026-01-23
+
+### 📚 **문서화**
+
+#### **MongoDB 및 Redis 백엔드를 실험적으로 표시 (Issue #339)**
+- **README.md 및 README.kr.md 업데이트**:
+  - MongoDB와 Redis를 실험적으로 문서화하는 "Experimental Features" 섹션 추가
+  - Multi-Backend Support 테이블에 실험적 상태 (🧪) 표시
+  - 실험적 백엔드 활성화를 위한 CMake 옵션 및 vcpkg features 추가
+- **docs/FEATURES.md 및 docs/FEATURES.kr.md 업데이트**:
+  - MongoDB 및 Redis 백엔드 상태를 "✅ 완전 지원"에서 "🧪 실험적"으로 변경
+  - 실험적 특성 및 활성화 방법에 대한 경고 메모 추가
+- **docs/guides/BUILD_GUIDE.md 및 BUILD_GUIDE.kr.md 업데이트**:
+  - 활성화 지침이 포함된 "실험적 백엔드" 섹션 추가
+  - CMake 옵션 테이블에 실험적 상태 표시
+  - vcpkg features 및 향후 계획 문서화
+- **관련**: Issue #333 (향후 contrib 패키지로의 분리 가능성)
+- **완료된 의존성**: Issue #337 (CMake 옵션), Issue #338 (vcpkg features)
+
+---
+
+## [Previous] - 2026-01-20
 
 ### 💥 **Breaking Changes**
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,7 +24,28 @@
 
 ---
 
-## [Unreleased] - 2026-01-20
+## [Unreleased] - 2026-01-23
+
+### 📚 **Documentation**
+
+#### **Mark MongoDB and Redis Backends as Experimental (Issue #339)**
+- **Updated README.md and README.kr.md**:
+  - Added "Experimental Features" section documenting MongoDB and Redis as experimental
+  - Updated Multi-Backend Support table to show experimental status (🧪)
+  - Added CMake options and vcpkg features for enabling experimental backends
+- **Updated docs/FEATURES.md and docs/FEATURES.kr.md**:
+  - Changed MongoDB and Redis backend status from "✅ Full Support" to "🧪 Experimental"
+  - Added warning notes about experimental nature and how to enable
+- **Updated docs/guides/BUILD_GUIDE.md and BUILD_GUIDE.kr.md**:
+  - Added "Experimental Backends" section with enable instructions
+  - Updated CMake options table to indicate experimental status
+  - Documented vcpkg features and future plans
+- **Related to**: Issue #333 (potential future separation into contrib packages)
+- **Dependencies completed**: Issue #337 (CMake options), Issue #338 (vcpkg features)
+
+---
+
+## [Previous] - 2026-01-20
 
 ### 💥 **Breaking Changes**
 

--- a/docs/FEATURES.kr.md
+++ b/docs/FEATURES.kr.md
@@ -114,8 +114,10 @@ auto cte_result = db.create_query_builder(database_types::postgres)
 
 ### MongoDB 백엔드
 
-**상태**: ✅ 완전 지원
+**상태**: 🧪 실험적 (기본 비활성화)
 **구현**: `mongodb/mongodb_manager.h/cpp`
+
+> ⚠️ **실험적**: MongoDB 지원은 기능적이지만 실험적입니다. CMake 옵션 `USE_MONGODB=ON`으로 활성화하세요.
 
 **기능**:
 - BSON을 통한 문서 기반 저장
@@ -130,8 +132,10 @@ auto cte_result = db.create_query_builder(database_types::postgres)
 
 ### Redis 백엔드
 
-**상태**: ✅ 완전 지원
+**상태**: 🧪 실험적 (기본 비활성화)
 **구현**: `redis/redis_manager.h/cpp`
+
+> ⚠️ **실험적**: Redis 지원은 기능적이지만 실험적입니다. CMake 옵션 `USE_REDIS=ON`으로 활성화하세요.
 
 **기능**:
 - 모든 데이터 타입 (문자열, 해시, 리스트, 셋, 정렬된 셋)

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -191,8 +191,10 @@ auto json_result = db.create_query_builder(database_types::sqlite)
 
 ### MongoDB Backend
 
-**Status**: ✅ Full Support
+**Status**: 🧪 Experimental (disabled by default)
 **Implementation**: `mongodb/mongodb_manager.h/cpp`
+
+> ⚠️ **Experimental**: MongoDB support is functional but experimental. Enable with `USE_MONGODB=ON` CMake option.
 
 **Features**:
 - Document-based storage with BSON
@@ -252,8 +254,10 @@ stream->on_change([](const change_event& event) {
 
 ### Redis Backend
 
-**Status**: ✅ Full Support
+**Status**: 🧪 Experimental (disabled by default)
 **Implementation**: `redis/redis_manager.h/cpp`
+
+> ⚠️ **Experimental**: Redis support is functional but experimental. Enable with `USE_REDIS=ON` CMake option.
 
 **Features**:
 - All data types (Strings, Hashes, Lists, Sets, Sorted Sets)

--- a/docs/guides/BUILD_GUIDE.kr.md
+++ b/docs/guides/BUILD_GUIDE.kr.md
@@ -84,11 +84,54 @@ ninja
 | `USE_POSTGRESQL` | ON | PostgreSQL 지원 활성화 (libpqxx 필요) |
 | `USE_MYSQL` | OFF | MySQL 지원 활성화 (libmysql 필요) |
 | `USE_SQLITE` | OFF | SQLite 지원 활성화 (sqlite3 필요) |
-| `USE_MONGODB` | OFF | MongoDB 지원 활성화 (mongocxx 필요) |
-| `USE_REDIS` | OFF | Redis 지원 활성화 (hiredis 필요) |
+| `USE_MONGODB` | OFF | MongoDB 지원 활성화 (mongocxx 필요) - **실험적** |
+| `USE_REDIS` | OFF | Redis 지원 활성화 (hiredis 필요) - **실험적** |
 | `BUILD_DATABASE_SAMPLES` | ON | 샘플 프로그램 빌드 |
 | `USE_UNIT_TEST` | ON | 단위 테스트 빌드 |
 | `BUILD_SHARED_LIBS` | OFF | 공유 라이브러리로 빌드 |
+
+### 실험적 백엔드
+
+> ⚠️ **참고**: MongoDB와 Redis 백엔드는 실험적이며 기본적으로 비활성화되어 있습니다.
+> 이 백엔드들은 완전히 기능하지만 향후 릴리스에서 지원이 제한되거나 Breaking Changes가 발생할 수 있습니다.
+
+#### 실험적 백엔드 활성화
+
+```bash
+# MongoDB 활성화 (실험적)
+cmake .. -DUSE_MONGODB=ON
+
+# Redis 활성화 (실험적)
+cmake .. -DUSE_REDIS=ON
+
+# 두 실험적 백엔드 모두 활성화
+cmake .. -DUSE_MONGODB=ON -DUSE_REDIS=ON
+```
+
+#### 실험적 백엔드를 위한 vcpkg Features
+
+```bash
+# MongoDB 의존성 설치
+vcpkg install mongo-cxx-driver
+
+# Redis 의존성 설치
+vcpkg install hiredis
+
+# 실험적 백엔드로 빌드
+cmake .. \
+  -DCMAKE_TOOLCHAIN_FILE=/path/to/vcpkg/scripts/buildsystems/vcpkg.cmake \
+  -DUSE_MONGODB=ON \
+  -DUSE_REDIS=ON
+```
+
+#### 실험적 백엔드 상태
+
+| 백엔드 | 상태 | 의존성 | 비고 |
+|--------|------|--------|------|
+| MongoDB | 🧪 실험적 | mongocxx, bsoncxx | NoSQL 문서 저장소, 집계 지원 |
+| Redis | 🧪 실험적 | hiredis | 인메모리 데이터 저장소, Pub/Sub 지원 |
+
+**향후 계획**: 이 백엔드들은 향후 릴리스에서 선택적 contrib 패키지로 분리될 수 있습니다. 자세한 내용은 [Issue #333](https://github.com/kcenon/database_system/issues/333)을 참조하세요.
 
 ### 빌드 타입
 

--- a/docs/guides/BUILD_GUIDE.md
+++ b/docs/guides/BUILD_GUIDE.md
@@ -84,11 +84,54 @@ ninja
 | `USE_POSTGRESQL` | ON | Enable PostgreSQL support (requires libpqxx) |
 | `USE_MYSQL` | OFF | Enable MySQL support (requires libmysql) |
 | `USE_SQLITE` | OFF | Enable SQLite support (requires sqlite3) |
-| `USE_MONGODB` | OFF | Enable MongoDB support (requires mongocxx) |
-| `USE_REDIS` | OFF | Enable Redis support (requires hiredis) |
+| `USE_MONGODB` | OFF | Enable MongoDB support (requires mongocxx) - **Experimental** |
+| `USE_REDIS` | OFF | Enable Redis support (requires hiredis) - **Experimental** |
 | `BUILD_DATABASE_SAMPLES` | ON | Build sample programs |
 | `USE_UNIT_TEST` | ON | Build unit tests |
 | `BUILD_SHARED_LIBS` | OFF | Build as shared library |
+
+### Experimental Backends
+
+> ⚠️ **Note**: MongoDB and Redis backends are experimental and disabled by default.
+> These backends are fully functional but may have limited support or undergo breaking changes in future releases.
+
+#### Enabling Experimental Backends
+
+```bash
+# Enable MongoDB (experimental)
+cmake .. -DUSE_MONGODB=ON
+
+# Enable Redis (experimental)
+cmake .. -DUSE_REDIS=ON
+
+# Enable both experimental backends
+cmake .. -DUSE_MONGODB=ON -DUSE_REDIS=ON
+```
+
+#### vcpkg Features for Experimental Backends
+
+```bash
+# Install MongoDB dependencies
+vcpkg install mongo-cxx-driver
+
+# Install Redis dependencies
+vcpkg install hiredis
+
+# Build with experimental backends
+cmake .. \
+  -DCMAKE_TOOLCHAIN_FILE=/path/to/vcpkg/scripts/buildsystems/vcpkg.cmake \
+  -DUSE_MONGODB=ON \
+  -DUSE_REDIS=ON
+```
+
+#### Experimental Backend Status
+
+| Backend | Status | Dependencies | Notes |
+|---------|--------|--------------|-------|
+| MongoDB | 🧪 Experimental | mongocxx, bsoncxx | NoSQL document store, aggregation support |
+| Redis | 🧪 Experimental | hiredis | In-memory data store, Pub/Sub support |
+
+**Future Plans**: These backends may be separated into optional contrib packages in a future release. See [Issue #333](https://github.com/kcenon/database_system/issues/333) for details.
 
 ### Build Types
 


### PR DESCRIPTION
## Summary
- Update documentation to mark MongoDB and Redis backends as experimental and disabled by default
- Provide clear guidance on how to enable experimental backends via CMake options and vcpkg features
- Link to future plans for potential separation into contrib packages

## What Changed
### README.md / README.kr.md
- Added "Experimental Features" section documenting MongoDB and Redis as experimental
- Updated Multi-Backend Support table to show experimental status (🧪)
- Added CMake options and vcpkg features for enabling experimental backends

### docs/FEATURES.md / docs/FEATURES.kr.md
- Changed MongoDB and Redis backend status from "✅ Full Support" to "🧪 Experimental"
- Added warning notes about experimental nature and how to enable

### docs/guides/BUILD_GUIDE.md / BUILD_GUIDE.kr.md
- Added "Experimental Backends" section with detailed enable instructions
- Updated CMake options table to indicate experimental status
- Documented vcpkg features and future plans

### docs/CHANGELOG.md / docs/CHANGELOG.kr.md
- Added documentation entry for this change

## Related Issues
- Closes #339
- Part of #333 (potential future separation into contrib packages)
- Depends on: #337 (CMake options - completed), #338 (vcpkg features - completed)

## Test Plan
- [x] Build verification completed (100% tests passed)
- [x] Documentation changes reviewed for accuracy
- [x] Both English and Korean versions updated consistently