### PR TITLE
docs: update compiler requirements to reflect thread_system dependency

### DIFF
--- a/README.kr.md
+++ b/README.kr.md
@@ -30,13 +30,15 @@ Database System Project는 프로덕션 수준의 엔터프라이즈급 C++20 da
 
 | 의존성 | 버전 | 필수 | 설명 |
 |--------|------|------|------|
-| C++20 컴파일러 | GCC 11+ / Clang 14+ / MSVC 2022+ / Apple Clang 14+ | 예 | C++20 기능 필요 |
+| C++20 컴파일러 | GCC **13+** / Clang **17+** / MSVC 2022+ / Apple Clang 14+ | 예 | thread_system 의존성으로 인한 높은 요구사항 |
 | CMake | 3.20+ | 예 | 빌드 시스템 |
 | [common_system](https://github.com/kcenon/common_system) | latest | 예 | 공통 인터페이스 및 Result<T> |
 | [thread_system](https://github.com/kcenon/thread_system) | latest | 예 | 스레드 풀 및 비동기 작업 |
 | [logger_system](https://github.com/kcenon/logger_system) | latest | 예 | 로깅 인프라 |
 | [container_system](https://github.com/kcenon/container_system) | latest | 예 | 데이터 컨테이너 작업 |
 | [monitoring_system](https://github.com/kcenon/monitoring_system) | latest | 예 | 성능 모니터링 |
+
+> **참고**: thread_system 의존성으로 인해 컴파일러 요구사항이 다른 시스템보다 높습니다. 자세한 내용은 [thread_system 요구사항](https://github.com/kcenon/thread_system#requirements)을 참조하세요.
 
 ### 데이터베이스 백엔드 (최소 하나 필요)
 

--- a/README.md
+++ b/README.md
@@ -55,13 +55,15 @@ A modern C++20 database abstraction layer providing unified access to multiple d
 
 | Dependency | Version | Required | Description |
 |------------|---------|----------|-------------|
-| C++20 Compiler | GCC 11+ / Clang 14+ / MSVC 2022+ / Apple Clang 14+ | Yes | C++20 features required |
+| C++20 Compiler | GCC **13+** / Clang **17+** / MSVC 2022+ / Apple Clang 14+ | Yes | Higher requirements due to thread_system dependency |
 | CMake | 3.20+ | Yes | Build system |
 | [common_system](https://github.com/kcenon/common_system) | latest | Yes | Common interfaces and Result<T> |
 | [thread_system](https://github.com/kcenon/thread_system) | latest | Yes | Thread pool and async operations |
 | [logger_system](https://github.com/kcenon/logger_system) | latest | Yes | Logging infrastructure |
 | [container_system](https://github.com/kcenon/container_system) | latest | Yes | Data container operations |
 | [monitoring_system](https://github.com/kcenon/monitoring_system) | latest | Yes | Performance monitoring |
+
+> **Note**: Compiler requirements are higher than some other systems due to thread_system dependency. See [thread_system requirements](https://github.com/kcenon/thread_system#requirements) for details.
 
 ### Database Backends (at least one required)
 
@@ -397,7 +399,7 @@ For detailed information, see `database/core/result.h`.
 
 ### Prerequisites
 
-- **Compiler**: C++20 capable (GCC 11+, Clang 14+, MSVC 2022+, Apple Clang 14+)
+- **Compiler**: C++20 capable (GCC 13+, Clang 17+, MSVC 2022+, Apple Clang 14+)
 - **CMake**: 3.20+
 - **Optional**: Database libraries (PostgreSQL, MySQL, SQLite, MongoDB, Redis)
 
@@ -722,7 +724,7 @@ BSD 3-Clause License - see [LICENSE](LICENSE) file for details.
 ## Acknowledgments
 
 - Inspired by modern database abstraction patterns and best practices
-- Built with C++20 features (GCC 11+, Clang 14+, MSVC 2022+) for maximum performance and safety
+- Built with C++20 features (GCC 13+, Clang 17+, MSVC 2022+) for maximum performance and safety
 - Maintained by kcenon@naver.com
 
 ---


### PR DESCRIPTION
Closes #351

## Summary
- Updated compiler requirements from GCC 11+/Clang 14+ to GCC 13+/Clang 17+ in README.md and README.kr.md
- Added explanatory note below the requirements table with link to thread_system requirements
- Updated all compiler version references consistently across both files:
  - Requirements table (with bold emphasis)
  - Quick Start Prerequisites section
  - Acknowledgments section

## Background
The current README states GCC 11+/Clang 14+, but database_system requires thread_system which needs GCC 13+/Clang 17+. This mismatch can cause unexpected build failures for users who meet the documented requirements but not the actual requirements.

## Test Plan
- [x] Verified markdown renders correctly
- [x] Verified links to thread_system requirements work
- [x] Consistent updates across all sections
- [x] Both English and Korean READMEs updated