### PR TITLE
test(orm): add unit tests for entity metadata and immutable_query_builder

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -506,6 +506,90 @@ if(USE_CONTAINER_SYSTEM AND (GTest_FOUND OR gtest_FOUND))
 endif()
 
 ##################################################
+# ORM Entity Metadata Tests (Issue #377)
+##################################################
+
+if(GTest_FOUND OR gtest_FOUND)
+    add_executable(entity_metadata_test
+        orm/test_entity_metadata.cpp
+    )
+
+    if(GTest_FOUND)
+        target_link_libraries(entity_metadata_test PRIVATE
+            database
+            GTest::gtest
+            GTest::gtest_main
+            Threads::Threads
+        )
+    else()
+        target_link_libraries(entity_metadata_test PRIVATE
+            database
+            gtest
+            gtest_main
+            Threads::Threads
+        )
+    endif()
+
+    set_target_properties(entity_metadata_test PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED ON
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+    )
+
+    add_test(NAME EntityMetadataTests COMMAND entity_metadata_test)
+
+    gtest_discover_tests(entity_metadata_test
+        PROPERTIES
+            TIMEOUT ${TEST_TIMEOUT}
+        DISCOVERY_TIMEOUT 60
+    )
+
+    message(STATUS "ORM entity metadata tests configured (Issue #377)")
+endif()
+
+##################################################
+# Immutable Query Builder Tests (Issue #377)
+##################################################
+
+if(GTest_FOUND OR gtest_FOUND)
+    add_executable(immutable_query_builder_test
+        query/test_immutable_query_builder.cpp
+    )
+
+    if(GTest_FOUND)
+        target_link_libraries(immutable_query_builder_test PRIVATE
+            database
+            GTest::gtest
+            GTest::gtest_main
+            Threads::Threads
+        )
+    else()
+        target_link_libraries(immutable_query_builder_test PRIVATE
+            database
+            gtest
+            gtest_main
+            Threads::Threads
+        )
+    endif()
+
+    set_target_properties(immutable_query_builder_test PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED ON
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+    )
+
+    add_test(NAME ImmutableQueryBuilderTests COMMAND immutable_query_builder_test)
+
+    gtest_discover_tests(immutable_query_builder_test
+        PROPERTIES
+            TIMEOUT ${TEST_TIMEOUT}
+        DISCOVERY_TIMEOUT 60
+    )
+
+    message(STATUS "Immutable query builder tests configured (Issue #377)")
+endif()
+
+##################################################
 # Async Unit Tests (Issue #369)
 ##################################################
 

--- a/tests/orm/test_entity_metadata.cpp
+++ b/tests/orm/test_entity_metadata.cpp
@@ -1,0 +1,311 @@
+/**
+ * BSD 3-Clause License
+ * Copyright (c) 2025, Database System Project
+ *
+ * Unit tests for ORM entity metadata: field_metadata, entity_metadata.
+ * Part of #367, sub-issue #377.
+ */
+
+#include <gtest/gtest.h>
+#include <string>
+
+#include "database/orm/entity.h"
+
+using namespace database::orm;
+
+//=============================================================================
+// field_metadata Tests
+//=============================================================================
+
+class FieldMetadataTest : public ::testing::Test {};
+
+// -- Constructor and accessors --
+
+TEST_F(FieldMetadataTest, ConstructsWithNameAndType) {
+	field_metadata field("id", "int64_t");
+	EXPECT_EQ(field.name(), "id");
+	EXPECT_EQ(field.type_name(), "int64_t");
+}
+
+TEST_F(FieldMetadataTest, DefaultConstraintIsNone) {
+	field_metadata field("name", "std::string");
+	EXPECT_FALSE(field.is_primary_key());
+	EXPECT_FALSE(field.is_not_null());
+	EXPECT_FALSE(field.is_unique());
+	EXPECT_FALSE(field.is_auto_increment());
+	EXPECT_FALSE(field.has_index());
+	EXPECT_FALSE(field.is_foreign_key());
+	EXPECT_FALSE(field.has_default_now());
+}
+
+TEST_F(FieldMetadataTest, PrimaryKeyConstraint) {
+	field_metadata field("id", "int64_t", field_constraint::primary_key);
+	EXPECT_TRUE(field.is_primary_key());
+	EXPECT_FALSE(field.is_not_null());
+}
+
+TEST_F(FieldMetadataTest, CombinedConstraints) {
+	field_metadata field("id", "int64_t",
+		field_constraint::primary_key | field_constraint::auto_increment);
+	EXPECT_TRUE(field.is_primary_key());
+	EXPECT_TRUE(field.is_auto_increment());
+	EXPECT_FALSE(field.is_not_null());
+}
+
+TEST_F(FieldMetadataTest, NotNullAndUniqueConstraints) {
+	field_metadata field("email", "std::string",
+		field_constraint::not_null | field_constraint::unique);
+	EXPECT_TRUE(field.is_not_null());
+	EXPECT_TRUE(field.is_unique());
+	EXPECT_FALSE(field.is_primary_key());
+}
+
+TEST_F(FieldMetadataTest, IndexConstraintWithName) {
+	field_metadata field("name", "std::string",
+		field_constraint::index, "idx_users_name");
+	EXPECT_TRUE(field.has_index());
+	EXPECT_EQ(field.index_name(), "idx_users_name");
+}
+
+TEST_F(FieldMetadataTest, ForeignKeyConstraint) {
+	field_metadata field("user_id", "int64_t",
+		field_constraint::foreign_key, "", "users", "id");
+	EXPECT_TRUE(field.is_foreign_key());
+	EXPECT_EQ(field.foreign_table(), "users");
+	EXPECT_EQ(field.foreign_field(), "id");
+}
+
+TEST_F(FieldMetadataTest, DefaultNowConstraint) {
+	field_metadata field("created_at", "std::chrono::system_clock::time_point",
+		field_constraint::default_now);
+	EXPECT_TRUE(field.has_default_now());
+}
+
+// -- to_sql_definition() --
+
+TEST_F(FieldMetadataTest, SqlDefinitionInt32) {
+	field_metadata field("count", "int32_t");
+	EXPECT_EQ(field.to_sql_definition(), "count INTEGER");
+}
+
+TEST_F(FieldMetadataTest, SqlDefinitionInt64) {
+	field_metadata field("id", "int64_t");
+	EXPECT_EQ(field.to_sql_definition(), "id BIGINT");
+}
+
+TEST_F(FieldMetadataTest, SqlDefinitionDouble) {
+	field_metadata field("price", "double");
+	EXPECT_EQ(field.to_sql_definition(), "price DOUBLE PRECISION");
+}
+
+TEST_F(FieldMetadataTest, SqlDefinitionString) {
+	field_metadata field("name", "std::string");
+	EXPECT_EQ(field.to_sql_definition(), "name VARCHAR(255)");
+}
+
+TEST_F(FieldMetadataTest, SqlDefinitionBool) {
+	field_metadata field("active", "bool");
+	EXPECT_EQ(field.to_sql_definition(), "active BOOLEAN");
+}
+
+TEST_F(FieldMetadataTest, SqlDefinitionTimestamp) {
+	field_metadata field("created_at", "std::chrono::system_clock::time_point");
+	EXPECT_EQ(field.to_sql_definition(), "created_at TIMESTAMP");
+}
+
+TEST_F(FieldMetadataTest, SqlDefinitionUnknownTypeFallsBackToText) {
+	field_metadata field("data", "custom_type");
+	EXPECT_EQ(field.to_sql_definition(), "data TEXT");
+}
+
+TEST_F(FieldMetadataTest, SqlDefinitionPrimaryKey) {
+	field_metadata field("id", "int64_t", field_constraint::primary_key);
+	std::string sql = field.to_sql_definition();
+	EXPECT_NE(sql.find("PRIMARY KEY"), std::string::npos);
+}
+
+TEST_F(FieldMetadataTest, SqlDefinitionAutoIncrement) {
+	field_metadata field("id", "int64_t",
+		field_constraint::primary_key | field_constraint::auto_increment);
+	std::string sql = field.to_sql_definition();
+	EXPECT_NE(sql.find("PRIMARY KEY"), std::string::npos);
+	EXPECT_NE(sql.find("AUTO_INCREMENT"), std::string::npos);
+}
+
+TEST_F(FieldMetadataTest, SqlDefinitionNotNull) {
+	field_metadata field("name", "std::string", field_constraint::not_null);
+	std::string sql = field.to_sql_definition();
+	EXPECT_NE(sql.find("NOT NULL"), std::string::npos);
+}
+
+TEST_F(FieldMetadataTest, SqlDefinitionUniqueNonPK) {
+	field_metadata field("email", "std::string", field_constraint::unique);
+	std::string sql = field.to_sql_definition();
+	EXPECT_NE(sql.find("UNIQUE"), std::string::npos);
+}
+
+TEST_F(FieldMetadataTest, SqlDefinitionPrimaryKeyOmitsNotNull) {
+	// Primary keys are implicitly NOT NULL, so NOT NULL should not appear
+	field_metadata field("id", "int64_t",
+		field_constraint::primary_key | field_constraint::not_null);
+	std::string sql = field.to_sql_definition();
+	EXPECT_NE(sql.find("PRIMARY KEY"), std::string::npos);
+	EXPECT_EQ(sql.find("NOT NULL"), std::string::npos);
+}
+
+TEST_F(FieldMetadataTest, SqlDefinitionPrimaryKeyOmitsUnique) {
+	// Primary keys are implicitly UNIQUE, so UNIQUE should not appear
+	field_metadata field("id", "int64_t",
+		field_constraint::primary_key | field_constraint::unique);
+	std::string sql = field.to_sql_definition();
+	EXPECT_NE(sql.find("PRIMARY KEY"), std::string::npos);
+	EXPECT_EQ(sql.find("UNIQUE"), std::string::npos);
+}
+
+TEST_F(FieldMetadataTest, SqlDefinitionDefaultNow) {
+	field_metadata field("created_at", "std::chrono::system_clock::time_point",
+		field_constraint::default_now);
+	std::string sql = field.to_sql_definition();
+	EXPECT_NE(sql.find("DEFAULT CURRENT_TIMESTAMP"), std::string::npos);
+}
+
+// -- has_constraint helper function --
+
+TEST_F(FieldMetadataTest, HasConstraintFunction) {
+	EXPECT_TRUE(has_constraint(
+		field_constraint::primary_key | field_constraint::not_null,
+		field_constraint::primary_key));
+	EXPECT_TRUE(has_constraint(
+		field_constraint::primary_key | field_constraint::not_null,
+		field_constraint::not_null));
+	EXPECT_FALSE(has_constraint(
+		field_constraint::primary_key | field_constraint::not_null,
+		field_constraint::unique));
+}
+
+//=============================================================================
+// entity_metadata Tests
+//=============================================================================
+
+class EntityMetadataTest : public ::testing::Test {
+protected:
+	void SetUp() override {
+		meta_ = std::make_unique<entity_metadata>("users");
+
+		meta_->add_field(field_metadata("id", "int64_t",
+			field_constraint::primary_key | field_constraint::auto_increment));
+		meta_->add_field(field_metadata("name", "std::string",
+			field_constraint::not_null));
+		meta_->add_field(field_metadata("email", "std::string",
+			field_constraint::not_null | field_constraint::unique | field_constraint::index,
+			"idx_users_email"));
+		meta_->add_field(field_metadata("department_id", "int64_t",
+			field_constraint::foreign_key, "", "departments", "id"));
+		meta_->add_field(field_metadata("created_at", "std::chrono::system_clock::time_point",
+			field_constraint::default_now));
+	}
+
+	std::unique_ptr<entity_metadata> meta_;
+};
+
+TEST_F(EntityMetadataTest, TableName) {
+	EXPECT_EQ(meta_->table_name(), "users");
+}
+
+TEST_F(EntityMetadataTest, FieldCount) {
+	EXPECT_EQ(meta_->fields().size(), 5u);
+}
+
+TEST_F(EntityMetadataTest, AddFieldStoresInOrder) {
+	EXPECT_EQ(meta_->fields()[0].name(), "id");
+	EXPECT_EQ(meta_->fields()[1].name(), "name");
+	EXPECT_EQ(meta_->fields()[2].name(), "email");
+	EXPECT_EQ(meta_->fields()[3].name(), "department_id");
+	EXPECT_EQ(meta_->fields()[4].name(), "created_at");
+}
+
+TEST_F(EntityMetadataTest, GetPrimaryKeyFindsId) {
+	const auto* pk = meta_->get_primary_key();
+	ASSERT_NE(pk, nullptr);
+	EXPECT_EQ(pk->name(), "id");
+	EXPECT_TRUE(pk->is_primary_key());
+}
+
+TEST_F(EntityMetadataTest, GetPrimaryKeyReturnsNullWhenMissing) {
+	entity_metadata meta("no_pk_table");
+	meta.add_field(field_metadata("name", "std::string"));
+	EXPECT_EQ(meta.get_primary_key(), nullptr);
+}
+
+TEST_F(EntityMetadataTest, GetIndexesFindsIndexedFields) {
+	auto indexes = meta_->get_indexes();
+	ASSERT_EQ(indexes.size(), 1u);
+	EXPECT_EQ(indexes[0]->name(), "email");
+}
+
+TEST_F(EntityMetadataTest, GetForeignKeysFindsFK) {
+	auto fks = meta_->get_foreign_keys();
+	ASSERT_EQ(fks.size(), 1u);
+	EXPECT_EQ(fks[0]->name(), "department_id");
+	EXPECT_EQ(fks[0]->foreign_table(), "departments");
+	EXPECT_EQ(fks[0]->foreign_field(), "id");
+}
+
+TEST_F(EntityMetadataTest, CreateTableSqlContainsTableName) {
+	std::string sql = meta_->create_table_sql();
+	EXPECT_NE(sql.find("CREATE TABLE IF NOT EXISTS users"), std::string::npos);
+}
+
+TEST_F(EntityMetadataTest, CreateTableSqlContainsAllColumns) {
+	std::string sql = meta_->create_table_sql();
+	EXPECT_NE(sql.find("id BIGINT PRIMARY KEY AUTO_INCREMENT"), std::string::npos);
+	EXPECT_NE(sql.find("name VARCHAR(255) NOT NULL"), std::string::npos);
+	EXPECT_NE(sql.find("email VARCHAR(255) NOT NULL UNIQUE"), std::string::npos);
+	EXPECT_NE(sql.find("department_id BIGINT"), std::string::npos);
+	EXPECT_NE(sql.find("created_at TIMESTAMP"), std::string::npos);
+}
+
+TEST_F(EntityMetadataTest, CreateTableSqlContainsForeignKeyConstraint) {
+	std::string sql = meta_->create_table_sql();
+	EXPECT_NE(sql.find("FOREIGN KEY (department_id) REFERENCES departments(id)"),
+		std::string::npos);
+}
+
+TEST_F(EntityMetadataTest, CreateIndexesSqlWithNamedIndex) {
+	std::string sql = meta_->create_indexes_sql();
+	EXPECT_NE(sql.find("CREATE INDEX IF NOT EXISTS idx_users_email ON users(email)"),
+		std::string::npos);
+}
+
+TEST_F(EntityMetadataTest, CreateIndexesSqlAutoGeneratesNameWhenMissing) {
+	entity_metadata meta("products");
+	meta.add_field(field_metadata("category", "std::string", field_constraint::index));
+
+	std::string sql = meta.create_indexes_sql();
+	EXPECT_NE(sql.find("CREATE INDEX IF NOT EXISTS idx_products_category ON products(category)"),
+		std::string::npos);
+}
+
+TEST_F(EntityMetadataTest, CreateIndexesSqlEmptyWhenNoIndexes) {
+	entity_metadata meta("simple");
+	meta.add_field(field_metadata("name", "std::string"));
+
+	std::string sql = meta.create_indexes_sql();
+	EXPECT_TRUE(sql.empty());
+}
+
+TEST_F(EntityMetadataTest, EmptyTableProducesMinimalDDL) {
+	entity_metadata meta("empty_table");
+	std::string sql = meta.create_table_sql();
+	EXPECT_NE(sql.find("CREATE TABLE IF NOT EXISTS empty_table"), std::string::npos);
+}
+
+// -- Constraint helper functions --
+
+TEST_F(EntityMetadataTest, ConstraintHelperFunctions) {
+	EXPECT_EQ(static_cast<int>(primary_key()), static_cast<int>(field_constraint::primary_key));
+	EXPECT_EQ(static_cast<int>(not_null()), static_cast<int>(field_constraint::not_null));
+	EXPECT_EQ(static_cast<int>(unique()), static_cast<int>(field_constraint::unique));
+	EXPECT_EQ(static_cast<int>(auto_increment()), static_cast<int>(field_constraint::auto_increment));
+	EXPECT_EQ(static_cast<int>(default_now()), static_cast<int>(field_constraint::default_now));
+}

--- a/tests/query/test_immutable_query_builder.cpp
+++ b/tests/query/test_immutable_query_builder.cpp
@@ -1,0 +1,262 @@
+/**
+ * BSD 3-Clause License
+ * Copyright (c) 2025, Database System Project
+ *
+ * Unit tests for immutable_query_builder SQL generation and
+ * immutable builder pattern.
+ * Part of #367, sub-issue #377.
+ */
+
+#include <gtest/gtest.h>
+#include <string>
+
+#include "database/query/immutable_query_builder.h"
+
+using namespace database;
+
+//=============================================================================
+// immutable_query_builder Tests
+//=============================================================================
+
+class ImmutableQueryBuilderTest : public ::testing::Test {
+protected:
+	// Default builder on "users" table
+	immutable_query_builder builder_{"users"};
+};
+
+// -- Construction --
+
+TEST_F(ImmutableQueryBuilderTest, DefaultBuildSelectsStar) {
+	std::string sql = builder_.build();
+	EXPECT_NE(sql.find("SELECT *"), std::string::npos);
+	EXPECT_NE(sql.find("\"users\""), std::string::npos);
+}
+
+// -- select() --
+
+TEST_F(ImmutableQueryBuilderTest, SelectSpecificColumns) {
+	auto q = builder_.select({"id", "name", "email"});
+	std::string sql = q.build();
+	EXPECT_NE(sql.find("\"id\""), std::string::npos);
+	EXPECT_NE(sql.find("\"name\""), std::string::npos);
+	EXPECT_NE(sql.find("\"email\""), std::string::npos);
+	EXPECT_EQ(sql.find("*"), std::string::npos);
+}
+
+// -- where() --
+
+TEST_F(ImmutableQueryBuilderTest, WhereWithFieldOpValue) {
+	auto q = builder_.where("active", "=", true);
+	std::string sql = q.build();
+	EXPECT_NE(sql.find("WHERE"), std::string::npos);
+}
+
+TEST_F(ImmutableQueryBuilderTest, WhereMultipleConditionsJoinedByAnd) {
+	auto q = builder_
+		.where("active", "=", true)
+		.where("age", ">", int64_t{18});
+	std::string sql = q.build();
+	EXPECT_NE(sql.find("AND"), std::string::npos);
+}
+
+TEST_F(ImmutableQueryBuilderTest, WhereWithQueryCondition) {
+	query_condition cond("status = 'active'");
+	auto q = builder_.where(cond);
+	std::string sql = q.build();
+	EXPECT_NE(sql.find("WHERE"), std::string::npos);
+	EXPECT_NE(sql.find("status = 'active'"), std::string::npos);
+}
+
+// -- order_by() --
+
+TEST_F(ImmutableQueryBuilderTest, OrderByAscending) {
+	auto q = builder_.order_by("name", sort_order::asc);
+	std::string sql = q.build();
+	EXPECT_NE(sql.find("ORDER BY"), std::string::npos);
+	EXPECT_NE(sql.find("ASC"), std::string::npos);
+}
+
+TEST_F(ImmutableQueryBuilderTest, OrderByDescending) {
+	auto q = builder_.order_by("created_at", sort_order::desc);
+	std::string sql = q.build();
+	EXPECT_NE(sql.find("DESC"), std::string::npos);
+}
+
+TEST_F(ImmutableQueryBuilderTest, OrderByMultipleFields) {
+	auto q = builder_
+		.order_by("name", sort_order::asc)
+		.order_by("created_at", sort_order::desc);
+	std::string sql = q.build();
+	EXPECT_NE(sql.find("ASC"), std::string::npos);
+	EXPECT_NE(sql.find("DESC"), std::string::npos);
+}
+
+// -- limit() and offset() --
+
+TEST_F(ImmutableQueryBuilderTest, LimitClause) {
+	auto q = builder_.limit(10);
+	std::string sql = q.build();
+	EXPECT_NE(sql.find("LIMIT 10"), std::string::npos);
+}
+
+TEST_F(ImmutableQueryBuilderTest, OffsetClause) {
+	auto q = builder_.offset(20);
+	std::string sql = q.build();
+	EXPECT_NE(sql.find("OFFSET 20"), std::string::npos);
+}
+
+TEST_F(ImmutableQueryBuilderTest, LimitAndOffset) {
+	auto q = builder_.limit(10).offset(20);
+	std::string sql = q.build();
+	EXPECT_NE(sql.find("LIMIT 10"), std::string::npos);
+	EXPECT_NE(sql.find("OFFSET 20"), std::string::npos);
+}
+
+// -- join() --
+
+TEST_F(ImmutableQueryBuilderTest, InnerJoin) {
+	auto q = builder_.join("orders", "users.id = orders.user_id", join_type::inner);
+	std::string sql = q.build();
+	EXPECT_NE(sql.find("INNER JOIN"), std::string::npos);
+	EXPECT_NE(sql.find("users.id = orders.user_id"), std::string::npos);
+}
+
+TEST_F(ImmutableQueryBuilderTest, LeftJoin) {
+	auto q = builder_.join("orders", "users.id = orders.user_id", join_type::left);
+	std::string sql = q.build();
+	EXPECT_NE(sql.find("LEFT JOIN"), std::string::npos);
+}
+
+TEST_F(ImmutableQueryBuilderTest, RightJoin) {
+	auto q = builder_.join("orders", "users.id = orders.user_id", join_type::right);
+	std::string sql = q.build();
+	EXPECT_NE(sql.find("RIGHT JOIN"), std::string::npos);
+}
+
+TEST_F(ImmutableQueryBuilderTest, FullOuterJoin) {
+	auto q = builder_.join("orders", "users.id = orders.user_id", join_type::full_outer);
+	std::string sql = q.build();
+	EXPECT_NE(sql.find("FULL OUTER JOIN"), std::string::npos);
+}
+
+TEST_F(ImmutableQueryBuilderTest, CrossJoin) {
+	auto q = builder_.join("roles", "1=1", join_type::cross);
+	std::string sql = q.build();
+	EXPECT_NE(sql.find("CROSS JOIN"), std::string::npos);
+}
+
+// -- group_by() and having() --
+
+TEST_F(ImmutableQueryBuilderTest, GroupBy) {
+	auto q = builder_.group_by({"department"});
+	std::string sql = q.build();
+	EXPECT_NE(sql.find("GROUP BY"), std::string::npos);
+	EXPECT_NE(sql.find("\"department\""), std::string::npos);
+}
+
+TEST_F(ImmutableQueryBuilderTest, GroupByMultipleFields) {
+	auto q = builder_.group_by({"department", "status"});
+	std::string sql = q.build();
+	EXPECT_NE(sql.find("GROUP BY"), std::string::npos);
+	EXPECT_NE(sql.find("\"department\""), std::string::npos);
+	EXPECT_NE(sql.find("\"status\""), std::string::npos);
+}
+
+TEST_F(ImmutableQueryBuilderTest, Having) {
+	auto q = builder_.group_by({"department"}).having("COUNT(*) > 5");
+	std::string sql = q.build();
+	EXPECT_NE(sql.find("HAVING COUNT(*) > 5"), std::string::npos);
+}
+
+// -- build_for_database() --
+
+TEST_F(ImmutableQueryBuilderTest, PostgresUsesDoubleQuotes) {
+	auto q = builder_.select({"id", "name"});
+	std::string sql = q.build_for_database(database_types::postgres);
+	EXPECT_NE(sql.find("\"id\""), std::string::npos);
+	EXPECT_NE(sql.find("\"name\""), std::string::npos);
+	EXPECT_NE(sql.find("\"users\""), std::string::npos);
+}
+
+TEST_F(ImmutableQueryBuilderTest, MySqlUsesBackticks) {
+	auto q = builder_.select({"id", "name"});
+	std::string sql = q.build_for_database(database_types::mysql);
+	EXPECT_NE(sql.find("`id`"), std::string::npos);
+	EXPECT_NE(sql.find("`name`"), std::string::npos);
+	EXPECT_NE(sql.find("`users`"), std::string::npos);
+}
+
+TEST_F(ImmutableQueryBuilderTest, SqliteUsesDoubleQuotes) {
+	auto q = builder_.select({"id"});
+	std::string sql = q.build_for_database(database_types::sqlite);
+	EXPECT_NE(sql.find("\"id\""), std::string::npos);
+	EXPECT_NE(sql.find("\"users\""), std::string::npos);
+}
+
+TEST_F(ImmutableQueryBuilderTest, DefaultBuildUsesPostgresDialect) {
+	auto q = builder_.select({"id"});
+	std::string default_sql = q.build();
+	std::string pg_sql = q.build_for_database(database_types::postgres);
+	EXPECT_EQ(default_sql, pg_sql);
+}
+
+// -- Immutability verification --
+
+TEST_F(ImmutableQueryBuilderTest, OriginalUnchangedAfterSelect) {
+	auto q = builder_.select({"id"});
+	std::string original_sql = builder_.build();
+	std::string new_sql = q.build();
+	EXPECT_NE(original_sql, new_sql);
+	EXPECT_NE(original_sql.find("*"), std::string::npos);
+	EXPECT_EQ(new_sql.find("*"), std::string::npos);
+}
+
+TEST_F(ImmutableQueryBuilderTest, OriginalUnchangedAfterWhere) {
+	auto q = builder_.where("id", "=", int64_t{1});
+	std::string original_sql = builder_.build();
+	EXPECT_EQ(original_sql.find("WHERE"), std::string::npos);
+}
+
+TEST_F(ImmutableQueryBuilderTest, OriginalUnchangedAfterLimit) {
+	auto q = builder_.limit(10);
+	std::string original_sql = builder_.build();
+	EXPECT_EQ(original_sql.find("LIMIT"), std::string::npos);
+}
+
+TEST_F(ImmutableQueryBuilderTest, ChainingProducesCorrectQuery) {
+	auto q = builder_
+		.select({"id", "name"})
+		.where("active", "=", true)
+		.order_by("name", sort_order::asc)
+		.limit(10)
+		.offset(0);
+
+	std::string sql = q.build();
+	EXPECT_NE(sql.find("SELECT"), std::string::npos);
+	EXPECT_NE(sql.find("WHERE"), std::string::npos);
+	EXPECT_NE(sql.find("ORDER BY"), std::string::npos);
+	EXPECT_NE(sql.find("LIMIT 10"), std::string::npos);
+	EXPECT_NE(sql.find("OFFSET 0"), std::string::npos);
+}
+
+// -- Full query composition --
+
+TEST_F(ImmutableQueryBuilderTest, ComplexQueryComposition) {
+	auto q = builder_
+		.select({"u.id", "u.name", "COUNT(o.id)"})
+		.join("orders", "u.id = o.user_id", join_type::left)
+		.where("u.active", "=", true)
+		.group_by({"u.id", "u.name"})
+		.having("COUNT(o.id) > 0")
+		.order_by("u.name", sort_order::asc)
+		.limit(50);
+
+	std::string sql = q.build();
+	EXPECT_NE(sql.find("SELECT"), std::string::npos);
+	EXPECT_NE(sql.find("LEFT JOIN"), std::string::npos);
+	EXPECT_NE(sql.find("WHERE"), std::string::npos);
+	EXPECT_NE(sql.find("GROUP BY"), std::string::npos);
+	EXPECT_NE(sql.find("HAVING"), std::string::npos);
+	EXPECT_NE(sql.find("ORDER BY"), std::string::npos);
+	EXPECT_NE(sql.find("LIMIT 50"), std::string::npos);
+}


### PR DESCRIPTION
Closes #377

## Summary
- Add 38 unit tests for ORM entity metadata (`field_metadata`, `entity_metadata`) covering constructors, constraint accessors, SQL definition generation, DDL output, index/FK queries, and constraint helper functions
- Add 28 unit tests for `immutable_query_builder` covering SELECT, WHERE, ORDER BY, LIMIT/OFFSET, JOIN (all 5 types), GROUP BY, HAVING, database dialect output (PostgreSQL/MySQL/SQLite), and immutability verification
- Add two new CMake test targets: `entity_metadata_test` and `immutable_query_builder_test`

## Test Plan
- [x] All 66 new tests pass locally
- [x] Existing tests unaffected
- [x] CI workflows pass