### PR TITLE
test(protocol): add unit tests for protocol_serializer binary round-trip

### DIFF
--- a/database/CMakeLists.txt
+++ b/database/CMakeLists.txt
@@ -78,6 +78,8 @@ set(HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/backends/redis_backend.h
     # P1-2 Headers (Immutable Query Builder)
     ${CMAKE_CURRENT_SOURCE_DIR}/query/immutable_query_builder.h
+    # Protocol Serialization Headers
+    ${CMAKE_CURRENT_SOURCE_DIR}/protocol/database_protocol.h
 )
 
 # Collect all source files
@@ -106,6 +108,8 @@ set(SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/backends/redis_backend.cpp
     # P1-2 Sources (Immutable Query Builder)
     ${CMAKE_CURRENT_SOURCE_DIR}/query/immutable_query_builder.cpp
+    # Protocol Serialization Sources
+    ${CMAKE_CURRENT_SOURCE_DIR}/protocol/database_protocol.cpp
 )
 
 # Add container-based protocol serialization if container_system is available

--- a/database/protocol/database_protocol.cpp
+++ b/database/protocol/database_protocol.cpp
@@ -26,7 +26,7 @@ std::vector<uint8_t> protocol_serializer::serialize_header(const message_header&
 
 kcenon::common::Result<message_header> protocol_serializer::deserialize_header(const std::vector<uint8_t>& data) {
     if (data.size() < 20) {
-        return error{static_cast<int>(error_code::invalid_argument), "Header too small"};
+        return error_info{static_cast<int>(error_code::invalid_argument), "Header too small"};
     }
 
     message_header header;
@@ -39,7 +39,7 @@ kcenon::common::Result<message_header> protocol_serializer::deserialize_header(c
     header.payload_size = read_uint32(data, offset);
 
     if (!header.is_valid()) {
-        return error{static_cast<int>(error_code::invalid_argument), "Invalid header magic or version"};
+        return error_info{static_cast<int>(error_code::invalid_argument), "Invalid header magic or version"};
     }
 
     return header;
@@ -65,19 +65,19 @@ kcenon::common::Result<connect_request> protocol_serializer::deserialize_connect
     connect_request request;
     size_t offset = 0;
     if (data.size() < 4) {
-        return error{static_cast<int>(error_code::invalid_argument), "Data too small"};
+        return error_info{static_cast<int>(error_code::invalid_argument), "Data too small"};
     }
     request.database_type = read_string(data, offset);
     request.connection_string = read_string(data, offset);
 
     // Deserialize options map
     if (offset + 4 > data.size()) {
-        return error{static_cast<int>(error_code::invalid_argument), "Data too small for options"};
+        return error_info{static_cast<int>(error_code::invalid_argument), "Data too small for options"};
     }
     uint32_t options_count = read_uint32(data, offset);
     for (uint32_t i = 0; i < options_count; ++i) {
         if (offset >= data.size()) {
-            return error{static_cast<int>(error_code::invalid_argument), "Data truncated in options"};
+            return error_info{static_cast<int>(error_code::invalid_argument), "Data truncated in options"};
         }
         std::string key = read_string(data, offset);
         std::string value = read_string(data, offset);
@@ -105,20 +105,20 @@ kcenon::common::Result<query_request> protocol_serializer::deserialize_query_req
     query_request request;
     size_t offset = 0;
     if (data.empty()) {
-        return error{static_cast<int>(error_code::invalid_argument), "Empty data"};
+        return error_info{static_cast<int>(error_code::invalid_argument), "Empty data"};
     }
     request.operation = static_cast<query_operation>(read_uint8(data, offset));
     request.query_string = read_string(data, offset);
 
     // Deserialize parameters vector
     if (offset + 4 > data.size()) {
-        return error{static_cast<int>(error_code::invalid_argument), "Data too small for parameters"};
+        return error_info{static_cast<int>(error_code::invalid_argument), "Data too small for parameters"};
     }
     uint32_t param_count = read_uint32(data, offset);
     request.parameters.reserve(param_count);
     for (uint32_t i = 0; i < param_count; ++i) {
         if (offset >= data.size()) {
-            return error{static_cast<int>(error_code::invalid_argument), "Data truncated in parameters"};
+            return error_info{static_cast<int>(error_code::invalid_argument), "Data truncated in parameters"};
         }
         request.parameters.push_back(read_string(data, offset));
     }
@@ -158,7 +158,7 @@ kcenon::common::Result<query_response> protocol_serializer::deserialize_query_re
     query_response response;
     size_t offset = 0;
     if (data.empty()) {
-        return error{static_cast<int>(error_code::invalid_argument), "Empty data"};
+        return error_info{static_cast<int>(error_code::invalid_argument), "Empty data"};
     }
     response.success = (read_uint8(data, offset) != 0);
     response.affected_rows = read_uint64(data, offset);
@@ -168,32 +168,32 @@ kcenon::common::Result<query_response> protocol_serializer::deserialize_query_re
 
     // Deserialize column names
     if (offset + 4 > data.size()) {
-        return error{static_cast<int>(error_code::invalid_argument), "Data too small for column names"};
+        return error_info{static_cast<int>(error_code::invalid_argument), "Data too small for column names"};
     }
     uint32_t column_count = read_uint32(data, offset);
     response.column_names.reserve(column_count);
     for (uint32_t i = 0; i < column_count; ++i) {
         if (offset >= data.size()) {
-            return error{static_cast<int>(error_code::invalid_argument), "Data truncated in column names"};
+            return error_info{static_cast<int>(error_code::invalid_argument), "Data truncated in column names"};
         }
         response.column_names.push_back(read_string(data, offset));
     }
 
     // Deserialize rows
     if (offset + 4 > data.size()) {
-        return error{static_cast<int>(error_code::invalid_argument), "Data too small for rows"};
+        return error_info{static_cast<int>(error_code::invalid_argument), "Data too small for rows"};
     }
     uint32_t row_count = read_uint32(data, offset);
     response.rows.reserve(row_count);
     for (uint32_t i = 0; i < row_count; ++i) {
         if (offset + 4 > data.size()) {
-            return error{static_cast<int>(error_code::invalid_argument), "Data too small for row"};
+            return error_info{static_cast<int>(error_code::invalid_argument), "Data too small for row"};
         }
         uint32_t field_count = read_uint32(data, offset);
         std::map<std::string, std::string> row;
         for (uint32_t j = 0; j < field_count; ++j) {
             if (offset >= data.size()) {
-                return error{static_cast<int>(error_code::invalid_argument), "Data truncated in row fields"};
+                return error_info{static_cast<int>(error_code::invalid_argument), "Data truncated in row fields"};
             }
             std::string key = read_string(data, offset);
             std::string value = read_string(data, offset);
@@ -217,7 +217,7 @@ kcenon::common::Result<connect_response> protocol_serializer::deserialize_connec
     connect_response response;
     size_t offset = 0;
     if (data.empty()) {
-        return error{static_cast<int>(error_code::invalid_argument), "Empty data"};
+        return error_info{static_cast<int>(error_code::invalid_argument), "Empty data"};
     }
     response.success = (read_uint8(data, offset) != 0);
     response.session_id = read_string(data, offset);
@@ -235,7 +235,7 @@ kcenon::common::Result<transaction_request> protocol_serializer::deserialize_tra
     transaction_request request;
     size_t offset = 0;
     if (data.size() < 2) {
-        return error{static_cast<int>(error_code::invalid_argument), "Data too small"};
+        return error_info{static_cast<int>(error_code::invalid_argument), "Data too small"};
     }
     request.operation = static_cast<message_type>(read_uint16(data, offset));
     return request;
@@ -253,7 +253,7 @@ kcenon::common::Result<error_response> protocol_serializer::deserialize_error_re
     error_response response;
     size_t offset = 0;
     if (data.size() < 4) {
-        return error{static_cast<int>(error_code::invalid_argument), "Data too small"};
+        return error_info{static_cast<int>(error_code::invalid_argument), "Data too small"};
     }
     response.error_code = static_cast<int32_t>(read_uint32(data, offset));
     response.error_message = read_string(data, offset);
@@ -272,7 +272,7 @@ kcenon::common::Result<transaction_response> protocol_serializer::deserialize_tr
     transaction_response response;
     size_t offset = 0;
     if (data.empty()) {
-        return error{static_cast<int>(error_code::invalid_argument), "Empty data"};
+        return error_info{static_cast<int>(error_code::invalid_argument), "Empty data"};
     }
     response.success = (read_uint8(data, offset) != 0);
     response.error_message = read_string(data, offset);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -590,6 +590,48 @@ if(GTest_FOUND OR gtest_FOUND)
 endif()
 
 ##################################################
+# Protocol Serializer Tests (Issue #378)
+##################################################
+
+if(GTest_FOUND OR gtest_FOUND)
+    add_executable(protocol_serializer_test
+        protocol/test_protocol_serializer.cpp
+    )
+
+    if(GTest_FOUND)
+        target_link_libraries(protocol_serializer_test PRIVATE
+            database
+            GTest::gtest
+            GTest::gtest_main
+            Threads::Threads
+        )
+    else()
+        target_link_libraries(protocol_serializer_test PRIVATE
+            database
+            gtest
+            gtest_main
+            Threads::Threads
+        )
+    endif()
+
+    set_target_properties(protocol_serializer_test PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED ON
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+    )
+
+    add_test(NAME ProtocolSerializerTests COMMAND protocol_serializer_test)
+
+    gtest_discover_tests(protocol_serializer_test
+        PROPERTIES
+            TIMEOUT ${TEST_TIMEOUT}
+        DISCOVERY_TIMEOUT 60
+    )
+
+    message(STATUS "Protocol serializer tests configured (Issue #378)")
+endif()
+
+##################################################
 # Async Unit Tests (Issue #369)
 ##################################################
 

--- a/tests/protocol/test_protocol_serializer.cpp
+++ b/tests/protocol/test_protocol_serializer.cpp
@@ -1,0 +1,604 @@
+/**
+ * BSD 3-Clause License
+ * Copyright (c) 2025, Database System Project
+ *
+ * Unit tests for protocol_serializer binary round-trip serialization.
+ * Part of #367, sub-issue #378.
+ */
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <string>
+#include <vector>
+#include <map>
+
+#include "database/protocol/database_protocol.h"
+
+using namespace database::protocol;
+
+//=============================================================================
+// message_header Tests
+//=============================================================================
+
+class MessageHeaderTest : public ::testing::Test {};
+
+TEST_F(MessageHeaderTest, DefaultMagicAndVersion) {
+	message_header header;
+	EXPECT_EQ(header.magic, message_header::MAGIC);
+	EXPECT_EQ(header.version, message_header::PROTOCOL_VERSION);
+	EXPECT_TRUE(header.is_valid());
+}
+
+TEST_F(MessageHeaderTest, InvalidMagic) {
+	message_header header;
+	header.magic = 0xDEADBEEF;
+	EXPECT_FALSE(header.is_valid());
+}
+
+TEST_F(MessageHeaderTest, InvalidVersion) {
+	message_header header;
+	header.version = 99;
+	EXPECT_FALSE(header.is_valid());
+}
+
+TEST_F(MessageHeaderTest, SerializeDeserializeRoundTrip) {
+	message_header original;
+	original.type = message_type::QUERY_REQUEST;
+	original.request_id = 12345;
+	original.payload_size = 100;
+
+	auto bytes = protocol_serializer::serialize_header(original);
+	EXPECT_EQ(bytes.size(), 20u);
+
+	auto result = protocol_serializer::deserialize_header(bytes);
+	ASSERT_TRUE(result.is_ok());
+
+	auto recovered = result.value();
+	EXPECT_EQ(recovered.magic, original.magic);
+	EXPECT_EQ(recovered.version, original.version);
+	EXPECT_EQ(recovered.type, original.type);
+	EXPECT_EQ(recovered.request_id, original.request_id);
+	EXPECT_EQ(recovered.payload_size, original.payload_size);
+}
+
+TEST_F(MessageHeaderTest, DeserializeHeaderTooSmall) {
+	std::vector<uint8_t> data = {0x01, 0x02, 0x03};
+	auto result = protocol_serializer::deserialize_header(data);
+	EXPECT_TRUE(result.is_err());
+}
+
+TEST_F(MessageHeaderTest, DeserializeInvalidMagicReturnsError) {
+	// Build a 20-byte buffer with wrong magic
+	std::vector<uint8_t> data(20, 0);
+	// Write garbage magic (little-endian)
+	data[0] = 0xEF; data[1] = 0xBE; data[2] = 0xAD; data[3] = 0xDE;
+	// Write valid version (1, little-endian)
+	data[4] = 0x01; data[5] = 0x00;
+
+	auto result = protocol_serializer::deserialize_header(data);
+	EXPECT_TRUE(result.is_err());
+}
+
+TEST_F(MessageHeaderTest, AllMessageTypes) {
+	const message_type types[] = {
+		message_type::CONNECT_REQUEST, message_type::CONNECT_RESPONSE,
+		message_type::DISCONNECT, message_type::PING, message_type::PONG,
+		message_type::QUERY_REQUEST, message_type::QUERY_RESPONSE,
+		message_type::BEGIN_TRANSACTION, message_type::COMMIT_TRANSACTION,
+		message_type::ROLLBACK_TRANSACTION, message_type::TRANSACTION_RESPONSE,
+		message_type::PREPARE_STATEMENT, message_type::EXECUTE_PREPARED,
+		message_type::CLOSE_PREPARED, message_type::ERROR_RESPONSE
+	};
+
+	for (auto type : types) {
+		message_header header;
+		header.type = type;
+		header.request_id = 42;
+		header.payload_size = 0;
+
+		auto bytes = protocol_serializer::serialize_header(header);
+		auto result = protocol_serializer::deserialize_header(bytes);
+		ASSERT_TRUE(result.is_ok()) << "Failed for message_type " << static_cast<uint16_t>(type);
+		EXPECT_EQ(result.value().type, type);
+	}
+}
+
+TEST_F(MessageHeaderTest, LargeRequestIdAndPayload) {
+	message_header header;
+	header.type = message_type::QUERY_REQUEST;
+	header.request_id = UINT64_MAX;
+	header.payload_size = UINT32_MAX;
+
+	auto bytes = protocol_serializer::serialize_header(header);
+	auto result = protocol_serializer::deserialize_header(bytes);
+	ASSERT_TRUE(result.is_ok());
+	EXPECT_EQ(result.value().request_id, UINT64_MAX);
+	EXPECT_EQ(result.value().payload_size, UINT32_MAX);
+}
+
+//=============================================================================
+// connect_request / connect_response Tests
+//=============================================================================
+
+class ConnectProtocolTest : public ::testing::Test {};
+
+TEST_F(ConnectProtocolTest, ConnectRequestRoundTrip) {
+	connect_request original;
+	original.database_type = "postgresql";
+	original.connection_string = "host=localhost port=5432 dbname=testdb";
+	original.options = {{"timeout", "30"}, {"ssl", "true"}};
+
+	auto bytes = protocol_serializer::serialize(original);
+	EXPECT_FALSE(bytes.empty());
+
+	auto result = protocol_serializer::deserialize_connect_request(bytes);
+	ASSERT_TRUE(result.is_ok());
+
+	auto recovered = result.value();
+	EXPECT_EQ(recovered.database_type, original.database_type);
+	EXPECT_EQ(recovered.connection_string, original.connection_string);
+	EXPECT_EQ(recovered.options.size(), original.options.size());
+	EXPECT_EQ(recovered.options.at("timeout"), "30");
+	EXPECT_EQ(recovered.options.at("ssl"), "true");
+}
+
+TEST_F(ConnectProtocolTest, ConnectRequestEmptyOptions) {
+	connect_request original;
+	original.database_type = "mysql";
+	original.connection_string = "mysql://localhost/test";
+
+	auto bytes = protocol_serializer::serialize(original);
+	auto result = protocol_serializer::deserialize_connect_request(bytes);
+	ASSERT_TRUE(result.is_ok());
+
+	auto recovered = result.value();
+	EXPECT_EQ(recovered.database_type, "mysql");
+	EXPECT_EQ(recovered.connection_string, "mysql://localhost/test");
+	EXPECT_TRUE(recovered.options.empty());
+}
+
+TEST_F(ConnectProtocolTest, ConnectRequestTooSmall) {
+	std::vector<uint8_t> data = {0x01, 0x02};
+	auto result = protocol_serializer::deserialize_connect_request(data);
+	EXPECT_TRUE(result.is_err());
+}
+
+TEST_F(ConnectProtocolTest, ConnectResponseSuccessRoundTrip) {
+	connect_response original;
+	original.success = true;
+	original.session_id = "sess-abc-123-def-456";
+	original.error_message = "";
+
+	auto bytes = protocol_serializer::serialize(original);
+	auto result = protocol_serializer::deserialize_connect_response(bytes);
+	ASSERT_TRUE(result.is_ok());
+
+	auto recovered = result.value();
+	EXPECT_TRUE(recovered.success);
+	EXPECT_EQ(recovered.session_id, "sess-abc-123-def-456");
+	EXPECT_TRUE(recovered.error_message.empty());
+}
+
+TEST_F(ConnectProtocolTest, ConnectResponseFailureRoundTrip) {
+	connect_response original;
+	original.success = false;
+	original.session_id = "";
+	original.error_message = "Authentication failed: invalid credentials";
+
+	auto bytes = protocol_serializer::serialize(original);
+	auto result = protocol_serializer::deserialize_connect_response(bytes);
+	ASSERT_TRUE(result.is_ok());
+
+	auto recovered = result.value();
+	EXPECT_FALSE(recovered.success);
+	EXPECT_TRUE(recovered.session_id.empty());
+	EXPECT_EQ(recovered.error_message, "Authentication failed: invalid credentials");
+}
+
+TEST_F(ConnectProtocolTest, ConnectResponseEmptyData) {
+	std::vector<uint8_t> data;
+	auto result = protocol_serializer::deserialize_connect_response(data);
+	EXPECT_TRUE(result.is_err());
+}
+
+//=============================================================================
+// query_request / query_response Tests
+//=============================================================================
+
+class QueryProtocolTest : public ::testing::Test {};
+
+TEST_F(QueryProtocolTest, QueryRequestSelectRoundTrip) {
+	query_request original;
+	original.operation = query_operation::SELECT;
+	original.query_string = "SELECT * FROM users WHERE id = ?";
+	original.parameters = {"42"};
+
+	auto bytes = protocol_serializer::serialize(original);
+	auto result = protocol_serializer::deserialize_query_request(bytes);
+	ASSERT_TRUE(result.is_ok());
+
+	auto recovered = result.value();
+	EXPECT_EQ(recovered.operation, query_operation::SELECT);
+	EXPECT_EQ(recovered.query_string, original.query_string);
+	ASSERT_EQ(recovered.parameters.size(), 1u);
+	EXPECT_EQ(recovered.parameters[0], "42");
+}
+
+TEST_F(QueryProtocolTest, QueryRequestInsertWithMultipleParams) {
+	query_request original;
+	original.operation = query_operation::INSERT;
+	original.query_string = "INSERT INTO users (name, email, age) VALUES (?, ?, ?)";
+	original.parameters = {"Alice", "alice@example.com", "30"};
+
+	auto bytes = protocol_serializer::serialize(original);
+	auto result = protocol_serializer::deserialize_query_request(bytes);
+	ASSERT_TRUE(result.is_ok());
+
+	auto recovered = result.value();
+	EXPECT_EQ(recovered.operation, query_operation::INSERT);
+	ASSERT_EQ(recovered.parameters.size(), 3u);
+	EXPECT_EQ(recovered.parameters[0], "Alice");
+	EXPECT_EQ(recovered.parameters[1], "alice@example.com");
+	EXPECT_EQ(recovered.parameters[2], "30");
+}
+
+TEST_F(QueryProtocolTest, QueryRequestNoParameters) {
+	query_request original;
+	original.operation = query_operation::CREATE;
+	original.query_string = "CREATE TABLE test (id INTEGER PRIMARY KEY)";
+
+	auto bytes = protocol_serializer::serialize(original);
+	auto result = protocol_serializer::deserialize_query_request(bytes);
+	ASSERT_TRUE(result.is_ok());
+
+	auto recovered = result.value();
+	EXPECT_EQ(recovered.operation, query_operation::CREATE);
+	EXPECT_TRUE(recovered.parameters.empty());
+}
+
+TEST_F(QueryProtocolTest, QueryRequestAllOperationTypes) {
+	const query_operation ops[] = {
+		query_operation::SELECT, query_operation::INSERT,
+		query_operation::UPDATE, query_operation::DELETE,
+		query_operation::CREATE, query_operation::ALTER,
+		query_operation::DROP, query_operation::OTHER
+	};
+
+	for (auto op : ops) {
+		query_request original;
+		original.operation = op;
+		original.query_string = "test query";
+
+		auto bytes = protocol_serializer::serialize(original);
+		auto result = protocol_serializer::deserialize_query_request(bytes);
+		ASSERT_TRUE(result.is_ok()) << "Failed for operation " << static_cast<int>(op);
+		EXPECT_EQ(result.value().operation, op);
+	}
+}
+
+TEST_F(QueryProtocolTest, QueryRequestSpecialCharacters) {
+	query_request original;
+	original.operation = query_operation::SELECT;
+	original.query_string = "SELECT * FROM users WHERE name LIKE ?";
+	original.parameters = {"O'Brien", "50%", "tab\tchar", "newline\nchar"};
+
+	auto bytes = protocol_serializer::serialize(original);
+	auto result = protocol_serializer::deserialize_query_request(bytes);
+	ASSERT_TRUE(result.is_ok());
+
+	auto recovered = result.value();
+	ASSERT_EQ(recovered.parameters.size(), 4u);
+	EXPECT_EQ(recovered.parameters[0], "O'Brien");
+	EXPECT_EQ(recovered.parameters[1], "50%");
+	EXPECT_EQ(recovered.parameters[2], "tab\tchar");
+	EXPECT_EQ(recovered.parameters[3], "newline\nchar");
+}
+
+TEST_F(QueryProtocolTest, QueryRequestEmptyData) {
+	std::vector<uint8_t> data;
+	auto result = protocol_serializer::deserialize_query_request(data);
+	EXPECT_TRUE(result.is_err());
+}
+
+TEST_F(QueryProtocolTest, QueryResponseSuccessWithRows) {
+	query_response original;
+	original.success = true;
+	original.affected_rows = 0;
+	original.last_insert_id = 0;
+	original.error_code = 0;
+	original.column_names = {"id", "name", "email"};
+	original.rows = {
+		{{"id", "1"}, {"name", "Alice"}, {"email", "alice@test.com"}},
+		{{"id", "2"}, {"name", "Bob"}, {"email", "bob@test.com"}}
+	};
+
+	auto bytes = protocol_serializer::serialize(original);
+	auto result = protocol_serializer::deserialize_query_response(bytes);
+	ASSERT_TRUE(result.is_ok());
+
+	auto recovered = result.value();
+	EXPECT_TRUE(recovered.success);
+	EXPECT_EQ(recovered.affected_rows, 0u);
+	ASSERT_EQ(recovered.column_names.size(), 3u);
+	EXPECT_EQ(recovered.column_names[0], "id");
+	EXPECT_EQ(recovered.column_names[1], "name");
+	EXPECT_EQ(recovered.column_names[2], "email");
+	ASSERT_EQ(recovered.rows.size(), 2u);
+	EXPECT_EQ(recovered.rows[0].at("name"), "Alice");
+	EXPECT_EQ(recovered.rows[1].at("email"), "bob@test.com");
+}
+
+TEST_F(QueryProtocolTest, QueryResponseInsertResult) {
+	query_response original;
+	original.success = true;
+	original.affected_rows = 1;
+	original.last_insert_id = 42;
+	original.error_code = 0;
+
+	auto bytes = protocol_serializer::serialize(original);
+	auto result = protocol_serializer::deserialize_query_response(bytes);
+	ASSERT_TRUE(result.is_ok());
+
+	auto recovered = result.value();
+	EXPECT_TRUE(recovered.success);
+	EXPECT_EQ(recovered.affected_rows, 1u);
+	EXPECT_EQ(recovered.last_insert_id, 42u);
+	EXPECT_TRUE(recovered.column_names.empty());
+	EXPECT_TRUE(recovered.rows.empty());
+}
+
+TEST_F(QueryProtocolTest, QueryResponseFailure) {
+	query_response original;
+	original.success = false;
+	original.error_code = 1045;
+	original.error_message = "Access denied for user 'root'@'localhost'";
+
+	auto bytes = protocol_serializer::serialize(original);
+	auto result = protocol_serializer::deserialize_query_response(bytes);
+	ASSERT_TRUE(result.is_ok());
+
+	auto recovered = result.value();
+	EXPECT_FALSE(recovered.success);
+	EXPECT_EQ(recovered.error_code, 1045);
+	EXPECT_EQ(recovered.error_message, "Access denied for user 'root'@'localhost'");
+}
+
+TEST_F(QueryProtocolTest, QueryResponseEmptyData) {
+	std::vector<uint8_t> data;
+	auto result = protocol_serializer::deserialize_query_response(data);
+	EXPECT_TRUE(result.is_err());
+}
+
+TEST_F(QueryProtocolTest, QueryResponseLargePayload) {
+	query_response original;
+	original.success = true;
+	original.column_names = {"id", "data"};
+
+	for (int i = 0; i < 100; ++i) {
+		original.rows.push_back({
+			{"id", std::to_string(i)},
+			{"data", std::string(256, 'x')}
+		});
+	}
+
+	auto bytes = protocol_serializer::serialize(original);
+	auto result = protocol_serializer::deserialize_query_response(bytes);
+	ASSERT_TRUE(result.is_ok());
+
+	auto recovered = result.value();
+	ASSERT_EQ(recovered.rows.size(), 100u);
+	EXPECT_EQ(recovered.rows[50].at("id"), "50");
+	EXPECT_EQ(recovered.rows[50].at("data").size(), 256u);
+}
+
+//=============================================================================
+// transaction_request / transaction_response Tests
+//=============================================================================
+
+class TransactionProtocolTest : public ::testing::Test {};
+
+TEST_F(TransactionProtocolTest, BeginTransactionRoundTrip) {
+	transaction_request original;
+	original.operation = message_type::BEGIN_TRANSACTION;
+
+	auto bytes = protocol_serializer::serialize(original);
+	auto result = protocol_serializer::deserialize_transaction_request(bytes);
+	ASSERT_TRUE(result.is_ok());
+	EXPECT_EQ(result.value().operation, message_type::BEGIN_TRANSACTION);
+}
+
+TEST_F(TransactionProtocolTest, CommitTransactionRoundTrip) {
+	transaction_request original;
+	original.operation = message_type::COMMIT_TRANSACTION;
+
+	auto bytes = protocol_serializer::serialize(original);
+	auto result = protocol_serializer::deserialize_transaction_request(bytes);
+	ASSERT_TRUE(result.is_ok());
+	EXPECT_EQ(result.value().operation, message_type::COMMIT_TRANSACTION);
+}
+
+TEST_F(TransactionProtocolTest, RollbackTransactionRoundTrip) {
+	transaction_request original;
+	original.operation = message_type::ROLLBACK_TRANSACTION;
+
+	auto bytes = protocol_serializer::serialize(original);
+	auto result = protocol_serializer::deserialize_transaction_request(bytes);
+	ASSERT_TRUE(result.is_ok());
+	EXPECT_EQ(result.value().operation, message_type::ROLLBACK_TRANSACTION);
+}
+
+TEST_F(TransactionProtocolTest, TransactionRequestTooSmall) {
+	std::vector<uint8_t> data = {0x01};
+	auto result = protocol_serializer::deserialize_transaction_request(data);
+	EXPECT_TRUE(result.is_err());
+}
+
+TEST_F(TransactionProtocolTest, TransactionResponseSuccessRoundTrip) {
+	transaction_response original;
+	original.success = true;
+	original.error_message = "";
+
+	auto bytes = protocol_serializer::serialize(original);
+	auto result = protocol_serializer::deserialize_transaction_response(bytes);
+	ASSERT_TRUE(result.is_ok());
+
+	auto recovered = result.value();
+	EXPECT_TRUE(recovered.success);
+	EXPECT_TRUE(recovered.error_message.empty());
+}
+
+TEST_F(TransactionProtocolTest, TransactionResponseFailureRoundTrip) {
+	transaction_response original;
+	original.success = false;
+	original.error_message = "Deadlock detected";
+
+	auto bytes = protocol_serializer::serialize(original);
+	auto result = protocol_serializer::deserialize_transaction_response(bytes);
+	ASSERT_TRUE(result.is_ok());
+
+	auto recovered = result.value();
+	EXPECT_FALSE(recovered.success);
+	EXPECT_EQ(recovered.error_message, "Deadlock detected");
+}
+
+TEST_F(TransactionProtocolTest, TransactionResponseEmptyData) {
+	std::vector<uint8_t> data;
+	auto result = protocol_serializer::deserialize_transaction_response(data);
+	EXPECT_TRUE(result.is_err());
+}
+
+//=============================================================================
+// error_response Tests
+//=============================================================================
+
+class ErrorProtocolTest : public ::testing::Test {};
+
+TEST_F(ErrorProtocolTest, ErrorResponseRoundTrip) {
+	error_response original;
+	original.error_code = 1001;
+	original.error_message = "Table not found";
+	original.error_context = "SELECT * FROM nonexistent_table";
+
+	auto bytes = protocol_serializer::serialize(original);
+	auto result = protocol_serializer::deserialize_error_response(bytes);
+	ASSERT_TRUE(result.is_ok());
+
+	auto recovered = result.value();
+	EXPECT_EQ(recovered.error_code, 1001);
+	EXPECT_EQ(recovered.error_message, "Table not found");
+	EXPECT_EQ(recovered.error_context, "SELECT * FROM nonexistent_table");
+}
+
+TEST_F(ErrorProtocolTest, ErrorResponseNegativeCode) {
+	error_response original;
+	original.error_code = -1;
+	original.error_message = "Internal server error";
+	original.error_context = "";
+
+	auto bytes = protocol_serializer::serialize(original);
+	auto result = protocol_serializer::deserialize_error_response(bytes);
+	ASSERT_TRUE(result.is_ok());
+
+	auto recovered = result.value();
+	EXPECT_EQ(recovered.error_code, -1);
+	EXPECT_EQ(recovered.error_message, "Internal server error");
+	EXPECT_TRUE(recovered.error_context.empty());
+}
+
+TEST_F(ErrorProtocolTest, ErrorResponseTooSmall) {
+	std::vector<uint8_t> data = {0x01, 0x02};
+	auto result = protocol_serializer::deserialize_error_response(data);
+	EXPECT_TRUE(result.is_err());
+}
+
+//=============================================================================
+// Cross-cutting serialization concerns
+//=============================================================================
+
+class SerializerEdgeCaseTest : public ::testing::Test {};
+
+TEST_F(SerializerEdgeCaseTest, EmptyStringFields) {
+	connect_request original;
+	original.database_type = "";
+	original.connection_string = "";
+
+	auto bytes = protocol_serializer::serialize(original);
+	auto result = protocol_serializer::deserialize_connect_request(bytes);
+	ASSERT_TRUE(result.is_ok());
+
+	auto recovered = result.value();
+	EXPECT_TRUE(recovered.database_type.empty());
+	EXPECT_TRUE(recovered.connection_string.empty());
+}
+
+TEST_F(SerializerEdgeCaseTest, LongStringPreserved) {
+	connect_request original;
+	original.database_type = "postgresql";
+	original.connection_string = std::string(4096, 'A');
+
+	auto bytes = protocol_serializer::serialize(original);
+	auto result = protocol_serializer::deserialize_connect_request(bytes);
+	ASSERT_TRUE(result.is_ok());
+	EXPECT_EQ(result.value().connection_string.size(), 4096u);
+}
+
+TEST_F(SerializerEdgeCaseTest, UnicodeStringPreserved) {
+	connect_request original;
+	original.database_type = "postgresql";
+	original.connection_string = "dbname=\xE4\xB8\xAD\xE6\x96\x87\xE6\xB5\x8B\xE8\xAF\x95";
+
+	auto bytes = protocol_serializer::serialize(original);
+	auto result = protocol_serializer::deserialize_connect_request(bytes);
+	ASSERT_TRUE(result.is_ok());
+	EXPECT_EQ(result.value().connection_string, original.connection_string);
+}
+
+TEST_F(SerializerEdgeCaseTest, ManyOptionsMapPreserved) {
+	connect_request original;
+	original.database_type = "mysql";
+	original.connection_string = "localhost";
+
+	for (int i = 0; i < 50; ++i) {
+		original.options["key_" + std::to_string(i)] = "val_" + std::to_string(i);
+	}
+
+	auto bytes = protocol_serializer::serialize(original);
+	auto result = protocol_serializer::deserialize_connect_request(bytes);
+	ASSERT_TRUE(result.is_ok());
+
+	auto recovered = result.value();
+	EXPECT_EQ(recovered.options.size(), 50u);
+	EXPECT_EQ(recovered.options.at("key_25"), "val_25");
+}
+
+TEST_F(SerializerEdgeCaseTest, QueryRequestManyParameters) {
+	query_request original;
+	original.operation = query_operation::SELECT;
+	original.query_string = "BULK QUERY";
+
+	for (int i = 0; i < 100; ++i) {
+		original.parameters.push_back("param_" + std::to_string(i));
+	}
+
+	auto bytes = protocol_serializer::serialize(original);
+	auto result = protocol_serializer::deserialize_query_request(bytes);
+	ASSERT_TRUE(result.is_ok());
+
+	auto recovered = result.value();
+	ASSERT_EQ(recovered.parameters.size(), 100u);
+	EXPECT_EQ(recovered.parameters[0], "param_0");
+	EXPECT_EQ(recovered.parameters[99], "param_99");
+}
+
+TEST_F(SerializerEdgeCaseTest, HeaderZeroRequestId) {
+	message_header header;
+	header.type = message_type::PING;
+	header.request_id = 0;
+	header.payload_size = 0;
+
+	auto bytes = protocol_serializer::serialize_header(header);
+	auto result = protocol_serializer::deserialize_header(bytes);
+	ASSERT_TRUE(result.is_ok());
+	EXPECT_EQ(result.value().request_id, 0u);
+	EXPECT_EQ(result.value().payload_size, 0u);
+}


### PR DESCRIPTION
Closes #378

## Summary
- Add 41 GTest-based unit tests for `protocol_serializer` covering binary round-trip serialization of all protocol message types:
  - `message_header`: magic/version validation, all 15 message types, boundary values
  - `connect_request` / `connect_response`: options map, success/failure paths
  - `query_request` / `query_response`: all 8 operation types, parameterized queries, result rows with multiple columns
  - `transaction_request` / `transaction_response`: BEGIN/COMMIT/ROLLBACK round-trip
  - `error_response`: error codes including negative values
  - Edge cases: empty strings, Unicode, 4KB strings, 100 parameters, 50 options map entries
- Fix compile error in `database_protocol.cpp`: replace undefined `error` type with `error_info` (file was not previously compiled as part of the library)
- Add `database_protocol.h`/`.cpp` to the `database` library CMake source list
- Add `protocol_serializer_test` CMake test target

## Test Plan
- [x] All 41 new tests pass locally
- [x] All 560 existing unit tests unaffected (0 failures)
- [x] CI workflows pass