### PR TITLE
test(di): add service_container integration tests and fix public headers

### DIFF
--- a/include/kcenon/database/adapters/common_system_database_adapter.h
+++ b/include/kcenon/database/adapters/common_system_database_adapter.h
@@ -27,8 +27,8 @@
 #include <kcenon/common/patterns/result.h>
 
 // Include database_system headers
-#include "../../database/database_manager.h"
-#include "../../database/core/database_context.h"
+#include "database/database_manager.h"
+#include "database/core/database_context.h"
 
 namespace kcenon::database::adapters {
 
@@ -53,7 +53,7 @@ public:
      * @param db_type The database type to use (defaults to PostgreSQL)
      */
     explicit common_system_database_adapter(
-        ::database::database_types db_type = ::database::database_types::postgresql)
+        ::database::database_types db_type = ::database::database_types::postgres)
         : context_(std::make_shared<::database::database_context>())
         , manager_(std::make_shared<::database::database_manager>(context_))
         , db_type_(db_type)
@@ -68,7 +68,7 @@ public:
     explicit common_system_database_adapter(
         std::shared_ptr<::database::database_manager> manager)
         : manager_(std::move(manager))
-        , db_type_(manager_ ? manager_->database_type() : ::database::database_types::postgresql)
+        , db_type_(manager_ ? manager_->database_type() : ::database::database_types::postgres)
         , connected_(false) {}
 
     ~common_system_database_adapter() override {

--- a/include/kcenon/database/di/service_registration.h
+++ b/include/kcenon/database/di/service_registration.h
@@ -25,8 +25,8 @@
 #include <kcenon/common/interfaces/database_interface.h>
 
 #include "../adapters/common_system_database_adapter.h"
-#include "../../database/database_manager.h"
-#include "../../database/core/database_context.h"
+#include "database/database_manager.h"
+#include "database/core/database_context.h"
 
 namespace kcenon::database::di {
 
@@ -35,7 +35,7 @@ namespace kcenon::database::di {
  */
 struct database_registration_config {
     /// Database type (postgresql, mysql, sqlite, etc.)
-    ::database::database_types db_type = ::database::database_types::postgresql;
+    ::database::database_types db_type = ::database::database_types::postgres;
 
     /// Connection string (optional - can be set later via connect())
     std::string connection_string;
@@ -124,7 +124,7 @@ inline common::VoidResult register_database_services(
  * // Create database_manager manually
  * auto context = std::make_shared<::database::database_context>();
  * auto manager = std::make_shared<::database::database_manager>(context);
- * manager->set_mode(::database::database_types::postgresql);
+ * manager->set_mode(::database::database_types::postgres);
  * manager->connect("host=localhost dbname=mydb");
  *
  * // Register the instance

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -506,6 +506,52 @@ if(USE_CONTAINER_SYSTEM AND (GTest_FOUND OR gtest_FOUND))
 endif()
 
 ##################################################
+# DI Service Registration Tests (Issue #369)
+##################################################
+
+if(BUILD_WITH_COMMON_SYSTEM AND (GTest_FOUND OR gtest_FOUND))
+    add_executable(di_service_registration_test
+        di/test_service_registration.cpp
+    )
+
+    if(GTest_FOUND)
+        target_link_libraries(di_service_registration_test PRIVATE
+            database
+            GTest::gtest
+            GTest::gtest_main
+            Threads::Threads
+        )
+    else()
+        target_link_libraries(di_service_registration_test PRIVATE
+            database
+            gtest
+            gtest_main
+            Threads::Threads
+        )
+    endif()
+
+    target_include_directories(di_service_registration_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../include
+    )
+
+    set_target_properties(di_service_registration_test PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED ON
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+    )
+
+    add_test(NAME DIServiceRegistrationTests COMMAND di_service_registration_test)
+
+    gtest_discover_tests(di_service_registration_test
+        PROPERTIES
+            TIMEOUT ${TEST_TIMEOUT}
+        DISCOVERY_TIMEOUT 60
+    )
+
+    message(STATUS "DI service registration tests configured (Issue #369)")
+endif()
+
+##################################################
 # ORM Entity Metadata Tests (Issue #377)
 ##################################################
 

--- a/tests/di/test_service_registration.cpp
+++ b/tests/di/test_service_registration.cpp
@@ -1,0 +1,388 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file test_service_registration.cpp
+ * @brief Unit tests for database_system's service_container integration.
+ *
+ * Tests validate that database_system types (IDatabase, database_manager)
+ * work correctly with common_system's service_container through the
+ * service_registration.h API.
+ *
+ * Part of kcenon/common_system#369
+ */
+
+#include <gtest/gtest.h>
+
+#include <kcenon/common/di/service_container.h>
+#include <kcenon/common/interfaces/database_interface.h>
+#include <kcenon/database/config/feature_flags.h>
+
+#if KCENON_HAS_COMMON_SYSTEM
+
+#include <kcenon/database/di/service_registration.h>
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace kcenon::common::di;
+using namespace kcenon::database::di;
+using namespace kcenon::common::interfaces;
+
+/**
+ * Test fixture for database DI registration tests
+ */
+class DatabaseServiceRegistrationTest : public ::testing::Test
+{
+protected:
+    service_container container_;
+
+    void TearDown() override { container_.clear(); }
+};
+
+// --- Registration Tests ---
+
+TEST_F(DatabaseServiceRegistrationTest, RegisterDatabaseServices_DefaultConfig_Succeeds)
+{
+    auto result = register_database_services(container_);
+
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_TRUE(container_.is_registered<IDatabase>());
+}
+
+TEST_F(DatabaseServiceRegistrationTest, RegisterDatabaseServices_CustomConfig_Succeeds)
+{
+    database_registration_config config;
+    config.db_type = ::database::database_types::sqlite;
+    config.lifetime = service_lifetime::singleton;
+
+    auto result = register_database_services(container_, config);
+
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_TRUE(container_.is_registered<IDatabase>());
+}
+
+TEST_F(DatabaseServiceRegistrationTest, RegisterDatabaseServices_TransientLifetime_Succeeds)
+{
+    database_registration_config config;
+    config.lifetime = service_lifetime::transient;
+
+    auto result = register_database_services(container_, config);
+
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_TRUE(container_.is_registered<IDatabase>());
+}
+
+TEST_F(DatabaseServiceRegistrationTest, RegisterDatabaseServices_Duplicate_Fails)
+{
+    auto result1 = register_database_services(container_);
+    ASSERT_TRUE(result1.is_ok());
+
+    auto result2 = register_database_services(container_);
+    EXPECT_TRUE(result2.is_err());
+}
+
+TEST_F(DatabaseServiceRegistrationTest, RegisterAllDatabaseServices_Succeeds)
+{
+    auto result = register_all_database_services(container_);
+
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_TRUE(container_.is_registered<IDatabase>());
+}
+
+TEST_F(DatabaseServiceRegistrationTest, RegisterAllDatabaseServices_Duplicate_Fails)
+{
+    auto result1 = register_all_database_services(container_);
+    ASSERT_TRUE(result1.is_ok());
+
+    auto result2 = register_all_database_services(container_);
+    EXPECT_TRUE(result2.is_err());
+}
+
+// --- Resolution Tests ---
+
+TEST_F(DatabaseServiceRegistrationTest, Resolve_DefaultSingleton_ReturnsSameInstance)
+{
+    register_database_services(container_);
+
+    auto result1 = container_.resolve<IDatabase>();
+    auto result2 = container_.resolve<IDatabase>();
+
+    ASSERT_TRUE(result1.is_ok());
+    ASSERT_TRUE(result2.is_ok());
+
+    // Default lifetime is singleton
+    EXPECT_EQ(result1.value(), result2.value());
+}
+
+TEST_F(DatabaseServiceRegistrationTest, Resolve_Transient_ReturnsDifferentInstances)
+{
+    database_registration_config config;
+    config.lifetime = service_lifetime::transient;
+
+    register_database_services(container_, config);
+
+    auto result1 = container_.resolve<IDatabase>();
+    auto result2 = container_.resolve<IDatabase>();
+
+    ASSERT_TRUE(result1.is_ok());
+    ASSERT_TRUE(result2.is_ok());
+
+    EXPECT_NE(result1.value(), result2.value());
+}
+
+TEST_F(DatabaseServiceRegistrationTest, Resolve_ReturnsValidIDatabase)
+{
+    register_database_services(container_);
+
+    auto result = container_.resolve<IDatabase>();
+
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_NE(result.value(), nullptr);
+
+    // Initially not connected
+    EXPECT_FALSE(result.value()->is_connected());
+}
+
+TEST_F(DatabaseServiceRegistrationTest, ResolveOrNull_Unregistered_ReturnsNull)
+{
+    auto ptr = container_.resolve_or_null<IDatabase>();
+
+    EXPECT_EQ(ptr, nullptr);
+}
+
+TEST_F(DatabaseServiceRegistrationTest, ResolveOrNull_Registered_ReturnsInstance)
+{
+    register_database_services(container_);
+
+    auto ptr = container_.resolve_or_null<IDatabase>();
+
+    EXPECT_NE(ptr, nullptr);
+}
+
+// --- Instance Registration Tests ---
+
+TEST_F(DatabaseServiceRegistrationTest, RegisterInstance_Succeeds)
+{
+    auto manager = std::make_shared<::database::database_manager>(
+        std::make_shared<::database::database_context>());
+
+    auto result = register_database_instance(container_, manager);
+
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_TRUE(container_.is_registered<IDatabase>());
+}
+
+TEST_F(DatabaseServiceRegistrationTest, RegisterInstance_NullManager_Fails)
+{
+    auto result = register_database_instance(container_, nullptr);
+
+    EXPECT_TRUE(result.is_err());
+}
+
+TEST_F(DatabaseServiceRegistrationTest, RegisterInstance_ResolveReturnsSameAdapter)
+{
+    auto manager = std::make_shared<::database::database_manager>(
+        std::make_shared<::database::database_context>());
+
+    register_database_instance(container_, manager);
+
+    auto result1 = container_.resolve<IDatabase>();
+    auto result2 = container_.resolve<IDatabase>();
+
+    ASSERT_TRUE(result1.is_ok());
+    ASSERT_TRUE(result2.is_ok());
+
+    // Instance registration is always singleton
+    EXPECT_EQ(result1.value(), result2.value());
+}
+
+// --- Unregister Tests ---
+
+TEST_F(DatabaseServiceRegistrationTest, UnregisterDatabaseServices_Succeeds)
+{
+    register_database_services(container_);
+    EXPECT_TRUE(container_.is_registered<IDatabase>());
+
+    auto result = unregister_database_services(container_);
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_FALSE(container_.is_registered<IDatabase>());
+}
+
+TEST_F(DatabaseServiceRegistrationTest, UnregisterDatabaseServices_NotRegistered_Fails)
+{
+    auto result = unregister_database_services(container_);
+    EXPECT_TRUE(result.is_err());
+}
+
+// --- Underlying Manager Utility Tests ---
+
+TEST_F(DatabaseServiceRegistrationTest, GetUnderlyingManager_FactoryRegistered_ReturnsManager)
+{
+    register_database_services(container_);
+
+    auto db_result = container_.resolve<IDatabase>();
+    ASSERT_TRUE(db_result.is_ok());
+
+    auto manager = get_underlying_database_manager(db_result.value());
+    EXPECT_NE(manager, nullptr);
+}
+
+TEST_F(DatabaseServiceRegistrationTest, GetUnderlyingManager_InstanceRegistered_ReturnsOriginal)
+{
+    auto original_manager = std::make_shared<::database::database_manager>(
+        std::make_shared<::database::database_context>());
+
+    register_database_instance(container_, original_manager);
+
+    auto db_result = container_.resolve<IDatabase>();
+    ASSERT_TRUE(db_result.is_ok());
+
+    auto retrieved_manager = get_underlying_database_manager(db_result.value());
+    EXPECT_EQ(retrieved_manager, original_manager);
+}
+
+// --- Clear Tests ---
+
+TEST_F(DatabaseServiceRegistrationTest, Clear_RemovesRegistration)
+{
+    register_database_services(container_);
+    EXPECT_TRUE(container_.is_registered<IDatabase>());
+
+    container_.clear();
+
+    EXPECT_FALSE(container_.is_registered<IDatabase>());
+
+    auto result = container_.resolve<IDatabase>();
+    EXPECT_TRUE(result.is_err());
+}
+
+// --- Freeze Tests ---
+
+TEST_F(DatabaseServiceRegistrationTest, Freeze_PreventsRegistration)
+{
+    register_database_services(container_);
+    container_.freeze();
+
+    EXPECT_TRUE(container_.is_frozen());
+
+    // Trying to register another service after freeze should fail
+    auto result = container_.register_simple_factory<IDatabase>(
+        []() -> std::shared_ptr<IDatabase> { return nullptr; },
+        service_lifetime::singleton);
+
+    EXPECT_TRUE(result.is_err());
+}
+
+TEST_F(DatabaseServiceRegistrationTest, Freeze_AllowsResolution)
+{
+    register_database_services(container_);
+    container_.freeze();
+
+    auto result = container_.resolve<IDatabase>();
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_NE(result.value(), nullptr);
+}
+
+// --- Thread Safety Tests ---
+
+TEST_F(DatabaseServiceRegistrationTest, ConcurrentResolve_Singleton_ThreadSafe)
+{
+    register_database_services(container_);
+
+    const int num_threads = 8;
+    std::vector<std::thread> threads;
+    std::vector<std::shared_ptr<IDatabase>> results(num_threads);
+
+    for (int i = 0; i < num_threads; ++i)
+    {
+        threads.emplace_back(
+            [this, &results, i]()
+            {
+                auto result = container_.resolve<IDatabase>();
+                if (result.is_ok())
+                {
+                    results[i] = result.value();
+                }
+            });
+    }
+
+    for (auto& t : threads)
+    {
+        t.join();
+    }
+
+    // All threads should get the same singleton instance
+    EXPECT_NE(results[0], nullptr);
+    for (int i = 1; i < num_threads; ++i)
+    {
+        EXPECT_EQ(results[0], results[i]);
+    }
+}
+
+TEST_F(DatabaseServiceRegistrationTest, ConcurrentResolve_Transient_ThreadSafe)
+{
+    database_registration_config config;
+    config.lifetime = service_lifetime::transient;
+    register_database_services(container_, config);
+
+    const int num_threads = 8;
+    const int ops_per_thread = 50;
+    std::vector<std::thread> threads;
+    std::atomic<int> success_count{0};
+
+    for (int i = 0; i < num_threads; ++i)
+    {
+        threads.emplace_back(
+            [this, &success_count, ops_per_thread]()
+            {
+                for (int j = 0; j < ops_per_thread; ++j)
+                {
+                    auto result = container_.resolve<IDatabase>();
+                    if (result.is_ok())
+                    {
+                        ++success_count;
+                    }
+                }
+            });
+    }
+
+    for (auto& t : threads)
+    {
+        t.join();
+    }
+
+    EXPECT_EQ(success_count.load(), num_threads * ops_per_thread);
+}
+
+// --- Service Descriptor Tests ---
+
+TEST_F(DatabaseServiceRegistrationTest, RegisteredServices_ReturnsDescriptors)
+{
+    register_database_services(container_);
+
+    auto services = container_.registered_services();
+    EXPECT_GE(services.size(), 1u);
+}
+
+// --- Scoped Container Tests ---
+
+TEST_F(DatabaseServiceRegistrationTest, ScopedContainer_InheritsRegistration)
+{
+    register_database_services(container_);
+
+    auto scope = container_.create_scope();
+    ASSERT_NE(scope, nullptr);
+
+    EXPECT_TRUE(scope->is_registered<IDatabase>());
+
+    auto result = scope->resolve<IDatabase>();
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_NE(result.value(), nullptr);
+}
+
+#endif // KCENON_HAS_COMMON_SYSTEM


### PR DESCRIPTION
Closes kcenon/common_system#369

## Summary

- Add 25 unit tests for `service_registration.h` validating integration with `common_system::di::service_container`
- Fix broken relative include paths in `service_registration.h` and `common_system_database_adapter.h` (`../../database/` → `database/`)
- Fix renamed enum value: `database_types::postgresql` → `database_types::postgres`
- Add DI test target to `tests/CMakeLists.txt` gated on `BUILD_WITH_COMMON_SYSTEM`

## Context

Part of the DI container consolidation effort (kcenon/common_system#363, Phase 5).

database_system has no legacy internal DI container — `service_registration.h` already correctly uses `service_container`. However, the public headers under `include/kcenon/database/` had never been compiled and contained broken include paths and a renamed enum reference. This PR fixes those issues and adds comprehensive test coverage.

The `database_coordinator` intentionally manages adapter lifecycle with phase-aware initialization ordering (Logger → Monitor → Thread) and is not a DI container. No refactoring of the coordinator is needed.

## Test Coverage (25 tests)

| Category | Tests |
|----------|-------|
| Registration | Default config, custom config, transient, duplicate error, register_all, instance, null instance error |
| Resolution | Singleton same instance, transient different instances, valid IDatabase, resolve_or_null |
| Unregister | Success, not-registered error |
| Utilities | get_underlying_manager (factory), get_underlying_manager (instance) |
| Container | Clear, freeze prevents registration, freeze allows resolution |
| Thread safety | Concurrent singleton resolve, concurrent transient resolve |
| Descriptors | registered_services returns descriptors |
| Scoping | Scoped container inherits registration |

## Test Plan

- [x] All 25 new DI tests pass
- [x] All 660 existing tests pass (6 pre-existing failures in CredentialSecurityTest unrelated to this change)
- [x] Full build succeeds with `USE_CONTAINER_SYSTEM=OFF`