### PR TITLE
chore: unify version to 0.1.0.0

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "kcenon-database-system",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "port-version": 0,
   "description": "Advanced C++20 Database System with Multi-Backend Support",
   "homepage": "https://github.com/kcenon/database_system",


### PR DESCRIPTION
## Summary
- Unify vcpkg version to 0.1.0
- CMake VERSION already at 0.1.0.0 (no change needed)
- Part of ecosystem-wide version normalization for SOUP compliance

## Changes
- vcpkg.json: version 1.0.0 → 0.1.0

## Test plan
- [x] CI build passes on all platforms
- [x] No breaking changes (version number only)