### PR TITLE
chore(deps): pin MongoDB, Redis, and SQLite backend versions

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -56,7 +56,8 @@
       "description": "Enable SQLite database support",
       "dependencies": [
         {
-          "name": "sqlite3"
+          "name": "sqlite3",
+          "version>=": "3.45.0"
         }
       ]
     },
@@ -64,7 +65,8 @@
       "description": "Enable MongoDB backend (experimental)",
       "dependencies": [
         {
-          "name": "mongo-cxx-driver"
+          "name": "mongo-cxx-driver",
+          "version>=": "3.8.0"
         }
       ]
     },
@@ -72,7 +74,8 @@
       "description": "Enable Redis backend (experimental)",
       "dependencies": [
         {
-          "name": "hiredis"
+          "name": "hiredis",
+          "version>=": "1.2.0"
         }
       ]
     },


### PR DESCRIPTION
## Summary

- Pin `mongo-cxx-driver` to `>= 3.8.0` (stable C++17 API)
- Pin `hiredis` to `>= 1.2.0` (stable async API)
- Pin `sqlite3` to `>= 3.45.0` (JSON improvements, security fixes)

These version floors ensure SOUP traceability per IEC 62304.

## Test Plan

- [x] `vcpkg.json` passes JSON validation
- [x] CI build succeeds

Closes #392