### PR TITLE
Add vcpkg version overrides for IEC 62304 compliance

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -14,6 +14,20 @@
     },
     "asio"
   ],
+  "overrides": [
+    { "name": "fmt", "version": "10.2.1" },
+    { "name": "asio", "version": "1.30.2" },
+    { "name": "openssl", "version": "3.3.0" },
+    { "name": "libpq", "version": "16.2" },
+    { "name": "libpqxx", "version": "7.9.0" },
+    { "name": "libmysql", "version": "8.0.34" },
+    { "name": "sqlite3", "version": "3.45.3" },
+    { "name": "mongo-cxx-driver", "version": "3.10.1" },
+    { "name": "hiredis", "version": "1.2.0" },
+    { "name": "spdlog", "version": "1.13.0" },
+    { "name": "gtest", "version": "1.14.0" },
+    { "name": "benchmark", "version": "1.8.3" }
+  ],
   "features": {
     "ecosystem": {
       "description": "Enable kcenon ecosystem integration (requires ecosystem packages in vcpkg registry)",


### PR DESCRIPTION
## Summary
Add vcpkg version overrides to pin exact SOUP versions for IEC 62304 Clause 8.1.2 compliance (configuration items shall be uniquely identified).

Versions are pinned from vcpkg baseline c4af3593e1f1aa9e14a560a09e45ea2cb0dfd74d.

## Motivation
- Closes the gap between web/server SOUP version pinning (npm ci, pip --require-hashes) and C++ ecosystem
- Ensures reproducible builds even if vcpkg baseline is updated
- Refs kcenon/flonics_project#245

## Test plan
- [x] Verify vcpkg.json is valid JSON
- [x] Verify overrides match baseline versions
- [x] Verify CI build succeeds with pinned versions