### PR TITLE
chore(deps): upgrade ASIO version to ecosystem standard (1.30.2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,9 +166,10 @@ find_package(Threads REQUIRED)
 # Version must be kept in sync with vcpkg.json "version>=" field.
 #
 # Version history:
-#   1.29.0 - Initial pinned version (aligned with ecosystem)
+#   1.29.0 - Initial pinned version
+#   1.30.2 - Upgraded to ecosystem standard (aligned with network_system)
 ##################################################
-set(DATABASE_SYSTEM_ASIO_PINNED_VERSION "1.29.0")
+set(DATABASE_SYSTEM_ASIO_PINNED_VERSION "1.30.2")
 
 find_package(asio QUIET CONFIG)
 if(TARGET asio::asio)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "asio",
-      "version>=": "1.29.0"
+      "version>=": "1.30.2"
     }
   ],
   "overrides": [


### PR DESCRIPTION
## Summary

- Upgrade ASIO minimum version from 1.29.0 to 1.30.2 (ecosystem standard)
- Update both `vcpkg.json` constraint and `CMakeLists.txt` pinned version

## Why

SBOM analysis revealed ASIO version drift:
- database_system: ASIO >= 1.29.0
- network_system: ASIO 1.30.2 (pinned)

When both systems are composed in the same application (e.g., PACS_SYSTEM),
version mismatch can cause ODR violations. ASIO 1.30.x includes fixes for
async operations and socket handling.

Closes #400

## Where

| File | Change |
|------|--------|
| `vcpkg.json` | `version>=` 1.29.0 -> 1.30.2 |
| `CMakeLists.txt` | `DATABASE_SYSTEM_ASIO_PINNED_VERSION` 1.29.0 -> 1.30.2 |

## Test plan

- [x] vcpkg install resolves ASIO 1.30.2 successfully
- [x] CMake configuration detects correct ASIO version
- [x] All database backend unit tests pass
- [x] Async database operations work correctly