### PR TITLE
chore(deps): upgrade OpenSSL minimum version to ecosystem standard (3.3.0)

### DIFF
--- a/database/CMakeLists.txt
+++ b/database/CMakeLists.txt
@@ -364,8 +364,8 @@ endif()
 if(USE_POSTGRESQL)
     find_package(libpqxx CONFIG QUIET)
 
-    # OpenSSL 3.0+ required (1.1.1 reached EOL September 2023)
-    find_package(OpenSSL 3.0 QUIET)
+    # OpenSSL 3.3+ required (ecosystem standard, aligned with logger/network_system)
+    find_package(OpenSSL 3.3 QUIET)
 
     if(libpqxx_FOUND AND OPENSSL_FOUND)
         target_link_libraries(${PROJECT_NAME}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -54,7 +54,7 @@
         },
         {
           "name": "openssl",
-          "version>=": "3.0.0"
+          "version>=": "3.3.0"
         }
       ]
     },


### PR DESCRIPTION
## Summary

- Upgrade OpenSSL minimum version from 3.0.0 to 3.3.0 (ecosystem standard)
- Update `vcpkg.json` postgresql feature constraint and `database/CMakeLists.txt` find_package

## Why

SBOM analysis revealed OpenSSL version drift:
- logger_system: OpenSSL 3.3.0 (pinned)
- network_system: OpenSSL 3.3.0 (pinned)
- database_system: OpenSSL >= 3.0.0 (lower minimum)

OpenSSL 3.3 is the current stable branch. Composing database_system with
network_system in the same process requires compatible OpenSSL versions.

Closes #402

## Where

| File | Change |
|------|--------|
| `vcpkg.json` | postgresql feature OpenSSL `version>=` 3.0.0 -> 3.3.0 |
| `database/CMakeLists.txt` | `find_package(OpenSSL 3.0)` -> `find_package(OpenSSL 3.3)` |

## Test plan

- [x] vcpkg install resolves OpenSSL 3.3.0 successfully
- [x] PostgreSQL backend builds with OpenSSL 3.3
- [x] SSL/TLS database connections work correctly
- [x] No regression in non-PostgreSQL backends