### PR TITLE
refactor(deps): remove unused fmt core dependency

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,16 +9,11 @@
   "supports": "!(uwp | xbox)",
   "dependencies": [
     {
-      "name": "fmt",
-      "version>=": "10.2.1"
-    },
-    {
       "name": "asio",
       "version>=": "1.30.2"
     }
   ],
   "overrides": [
-    { "name": "fmt", "version": "10.2.1" },
     { "name": "asio", "version": "1.30.2" },
     { "name": "openssl", "version": "3.3.0" },
     { "name": "libpq", "version": "16.2" },
@@ -107,19 +102,14 @@
     },
     "samples": {
       "description": "Enable sample applications",
-      "dependencies": [
-        {
-          "name": "fmt",
-          "version>=": "10.2.1"
-        }
-      ]
+      "dependencies": []
     },
     "logging": {
       "description": "Enable advanced logging capabilities",
       "dependencies": [
         {
           "name": "spdlog",
-          "features": ["fmt-external"]
+          "default-features": true
         }
       ]
     },
@@ -135,7 +125,7 @@
         },
         {
           "name": "spdlog",
-          "features": ["fmt-external"]
+          "default-features": true
         }
       ]
     }


### PR DESCRIPTION
## Summary

- Remove fmt from core dependencies and overrides in vcpkg.json
- Remove fmt from samples feature (no sample code uses fmt)
- Switch spdlog from `fmt-external` to default (bundled fmt) in logging/development features
- Source code already migrated to std::format

## Test plan

- [x] vcpkg.json is valid JSON
- [x] CI build passes without fmt as core dependency
- [x] No source files reference fmt headers or functions
- [x] spdlog logging feature still builds correctly with bundled fmt

Closes #399