### PR TITLE
chore(ci): Graduate sanitizer jobs from Phase 0 to Phase 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,11 +190,9 @@ jobs:
           build/CMakeFiles/*.log
           build/Testing/Temporary/
 
-  # Phase 0: Allow failures, just collect data
   sanitizers:
     name: Sanitizers (${{ matrix.sanitizer.name }})
     runs-on: ubuntu-24.04
-    continue-on-error: true
     timeout-minutes: 60
 
     strategy:
@@ -294,7 +292,7 @@ jobs:
         cd build
         export ${{ matrix.sanitizer.env }}
         # Run with timeout to prevent hanging
-        ctest -C Debug --output-on-failure --timeout 60 || echo "${{ matrix.sanitizer.name }} detected issues (expected in Phase 0)"
+        ctest -C Debug --output-on-failure --timeout 60
 
     - name: Upload sanitizer logs
       if: always()

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -108,7 +108,7 @@ jobs:
       run: |
         echo "# Sanitizer Test Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "## Phase 0: Baseline Establishment" >> $GITHUB_STEP_SUMMARY
+        echo "## Phase 1: Sanitizer Failures Block Merges" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "Sanitizer tests configured and running." >> $GITHUB_STEP_SUMMARY
-        echo "Warnings allowed in Phase 0 for baseline establishment." >> $GITHUB_STEP_SUMMARY
+        echo "Sanitizer failures now block merges (graduated from Phase 0)." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Remove `continue-on-error: true` from sanitizer job in ci.yml
- Remove `|| echo` fallbacks from sanitizer test execution
- Update sanitizers.yml summary text to Phase 1

## Test plan
- [x] ASan CI job passes
- [x] TSan CI job passes
- [x] UBSan CI job passes

Refs: kcenon/common_system#394