### PR TITLE
Add real SQLite I/O benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,18 +310,28 @@ For detailed information, see `database/core/result.h`.
 
 ### Benchmarks (Intel i7-9750H @ 2.6GHz, 16GB RAM, SSD)
 
-| Metric | Performance | Notes |
-|--------|-------------|-------|
-| **Simple SELECT (PostgreSQL)** | 1.2ms | Type-safe abstraction |
-| **Complex JOIN (PostgreSQL)** | 15ms | Minimal overhead |
-| **Bulk INSERT (1K rows)** | 45ms | Near-native speed |
-| **Transaction TPS** | 5,000 TPS | PostgreSQL ACID |
-| **Query Builder Overhead** | <20% | vs. raw SQL |
+| Metric | Performance | Measurement | Notes |
+|--------|-------------|-------------|-------|
+| **Simple SELECT (PostgreSQL)** | 1.2ms | Manual (PostgreSQL) | Type-safe abstraction |
+| **Complex JOIN (PostgreSQL)** | 15ms | Manual (PostgreSQL) | Minimal overhead |
+| **Bulk INSERT (1K rows)** | 45ms | Manual (PostgreSQL) | Near-native speed |
+| **Transaction TPS** | 5,000 TPS | Manual (PostgreSQL) | PostgreSQL ACID |
+| **Query Builder Overhead** | <20% | Automated (Synthetic) | vs. raw SQL |
+| **SQLite SELECT** | See benchmarks | Automated (SQLite in-memory) | Real I/O through SQLite engine |
+| **SQLite Batch INSERT** | See benchmarks | Automated (SQLite in-memory) | Includes SQL parsing + B-tree ops |
+| **SQLite Transaction** | See benchmarks | Automated (SQLite in-memory) | BEGIN + INSERT + COMMIT cycle |
 
 **Key Insights**:
 - ⚡ **Query overhead**: Minimal (<20%) for type safety and flexibility
 - 🔒 **ProxyMode**: Centralized pooling via database_server for production
 - 💾 **Memory efficiency**: Lightweight client library with server-side pooling
+
+**Reproducing Real I/O Benchmarks**:
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DDATABASE_BUILD_BENCHMARKS=ON -DUSE_SQLITE=ON
+cmake --build build -j
+./build/benchmarks/database_benchmarks --benchmark_filter=SQLite
+```
 
 [⚡ Complete Benchmarks →](docs/BENCHMARKS.md)
 

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -18,6 +18,7 @@ if(benchmark_FOUND OR BENCHMARK_FOUND)
     add_executable(database_benchmarks
         query_execution_bench.cpp
         transaction_bench.cpp
+        sqlite_io_bench.cpp
         main_bench.cpp
     )
 
@@ -30,6 +31,8 @@ if(benchmark_FOUND OR BENCHMARK_FOUND)
             benchmark::benchmark
             benchmark::benchmark_main
     )
+
+    target_compile_definitions(database_benchmarks PRIVATE USE_SQLITE=1)
 
     target_compile_features(database_benchmarks PRIVATE cxx_std_20)
 

--- a/benchmarks/sqlite_io_bench.cpp
+++ b/benchmarks/sqlite_io_bench.cpp
@@ -1,0 +1,246 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file sqlite_io_bench.cpp
+ * @brief Real I/O benchmarks using SQLite in-memory database
+ *
+ * Measures actual database I/O performance through SQLite :memory: backend.
+ * Unlike transaction_bench.cpp which uses mock backends, these benchmarks
+ * exercise real SQL parsing, query planning, and B-tree operations.
+ *
+ * Run: ./build/benchmarks/database_benchmarks --benchmark_filter=SQLite
+ */
+
+#ifndef USE_SQLITE
+// Provide empty translation unit when SQLite is not compiled in.
+// Benchmarks will simply not appear in the output.
+#else
+
+#include <benchmark/benchmark.h>
+#include "database/core/database_context.h"
+#include "database/database_manager.h"
+#include "database/database_types.h"
+#include <memory>
+#include <string>
+
+using namespace database;
+
+namespace {
+
+/**
+ * @brief Google Benchmark fixture for SQLite in-memory benchmarks.
+ *
+ * Creates a database_manager connected to SQLite :memory: with a seeded
+ * users table. Follows the same pattern as DatabaseSystemFixture in
+ * integration_tests/framework/system_fixture.h.
+ */
+class SQLiteBenchFixture : public benchmark::Fixture {
+public:
+    void SetUp(const ::benchmark::State&) override
+    {
+        context_ = std::make_shared<database_context>();
+        manager_ = std::make_shared<database_manager>(context_);
+        manager_->set_mode(database_types::sqlite);
+
+        auto connect_result = manager_->connect_result(":memory:");
+        if (connect_result.is_err())
+        {
+            setup_failed_ = true;
+            return;
+        }
+
+        // Create test table
+        manager_->create_query_result(
+            "CREATE TABLE IF NOT EXISTS users ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "name TEXT NOT NULL, "
+            "email TEXT UNIQUE NOT NULL, "
+            "age INTEGER"
+            ")");
+
+        // Seed 100 rows for SELECT benchmarks
+        for (int i = 0; i < 100; ++i)
+        {
+            std::string query =
+                "INSERT INTO users (name, email, age) VALUES ("
+                "'User" + std::to_string(i) + "', "
+                "'user" + std::to_string(i) + "@bench.com', " +
+                std::to_string(20 + (i % 50)) + ")";
+            manager_->insert_query_result(query);
+        }
+    }
+
+    void TearDown(const ::benchmark::State&) override
+    {
+        if (manager_)
+        {
+            manager_->disconnect_result();
+        }
+    }
+
+protected:
+    std::shared_ptr<database_context> context_;
+    std::shared_ptr<database_manager> manager_;
+    bool setup_failed_{false};
+};
+
+// ============================================================================
+// BM_SQLite_SingleSelect
+// Measures single SELECT with WHERE clause against real SQLite engine.
+// ============================================================================
+
+BENCHMARK_DEFINE_F(SQLiteBenchFixture, SQLite_SingleSelect)(benchmark::State& state)
+{
+    if (setup_failed_)
+    {
+        state.SkipWithError("SQLite setup failed");
+        return;
+    }
+
+    for (auto _ : state)
+    {
+        auto result = manager_->select_query_result(
+            "SELECT id, name, email, age FROM users WHERE id = 42");
+        benchmark::DoNotOptimize(result);
+    }
+}
+BENCHMARK_REGISTER_F(SQLiteBenchFixture, SQLite_SingleSelect);
+
+// ============================================================================
+// BM_SQLite_BatchInsert
+// Measures INSERT throughput at different batch sizes.
+// Each iteration re-inserts into a separate table to avoid unique violations.
+// ============================================================================
+
+BENCHMARK_DEFINE_F(SQLiteBenchFixture, SQLite_BatchInsert)(benchmark::State& state)
+{
+    if (setup_failed_)
+    {
+        state.SkipWithError("SQLite setup failed");
+        return;
+    }
+
+    const auto batch_size = state.range(0);
+
+    // Create a scratch table for inserts
+    manager_->create_query_result(
+        "CREATE TABLE IF NOT EXISTS bench_insert ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "name TEXT NOT NULL, "
+        "value INTEGER"
+        ")");
+
+    for (auto _ : state)
+    {
+        for (int64_t i = 0; i < batch_size; ++i)
+        {
+            auto result = manager_->insert_query_result(
+                "INSERT INTO bench_insert (name, value) VALUES ("
+                "'item" + std::to_string(i) + "', " + std::to_string(i) + ")");
+            benchmark::DoNotOptimize(result);
+        }
+    }
+
+    state.SetItemsProcessed(state.iterations() * batch_size);
+
+    // Cleanup
+    manager_->delete_query_result("DELETE FROM bench_insert");
+}
+BENCHMARK_REGISTER_F(SQLiteBenchFixture, SQLite_BatchInsert)
+    ->Arg(10)
+    ->Arg(100)
+    ->Arg(1000);
+
+// ============================================================================
+// BM_SQLite_TransactionCommit
+// Measures BEGIN + INSERT + COMMIT as a single unit.
+// ============================================================================
+
+BENCHMARK_DEFINE_F(SQLiteBenchFixture, SQLite_TransactionCommit)(benchmark::State& state)
+{
+    if (setup_failed_)
+    {
+        state.SkipWithError("SQLite setup failed");
+        return;
+    }
+
+    manager_->create_query_result(
+        "CREATE TABLE IF NOT EXISTS bench_txn ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "data TEXT"
+        ")");
+
+    for (auto _ : state)
+    {
+        manager_->begin_transaction();
+        auto result = manager_->insert_query_result(
+            "INSERT INTO bench_txn (data) VALUES ('txn_test')");
+        benchmark::DoNotOptimize(result);
+        manager_->commit_transaction();
+    }
+
+    // Cleanup
+    manager_->delete_query_result("DELETE FROM bench_txn");
+}
+BENCHMARK_REGISTER_F(SQLiteBenchFixture, SQLite_TransactionCommit);
+
+// ============================================================================
+// BM_SQLite_SelectThroughput
+// Measures SELECT throughput in batches of 100 queries, reporting items/sec.
+// ============================================================================
+
+BENCHMARK_DEFINE_F(SQLiteBenchFixture, SQLite_SelectThroughput)(benchmark::State& state)
+{
+    if (setup_failed_)
+    {
+        state.SkipWithError("SQLite setup failed");
+        return;
+    }
+
+    constexpr int batch_size = 100;
+
+    for (auto _ : state)
+    {
+        for (int i = 0; i < batch_size; ++i)
+        {
+            auto result = manager_->select_query_result(
+                "SELECT id, name, email FROM users WHERE age = " +
+                std::to_string(20 + (i % 50)));
+            benchmark::DoNotOptimize(result);
+        }
+    }
+
+    state.SetItemsProcessed(state.iterations() * batch_size);
+}
+BENCHMARK_REGISTER_F(SQLiteBenchFixture, SQLite_SelectThroughput);
+
+}  // namespace
+
+#endif  // USE_SQLITE


### PR DESCRIPTION
## Summary
- Add `sqlite_io_bench.cpp` with real SQLite in-memory benchmarks (single SELECT, batch INSERT, transaction commit, SELECT throughput)
- Update `benchmarks/CMakeLists.txt` to include new file and set `USE_SQLITE=1` compile definition
- Update `README.md` performance table to distinguish measurement types (Manual PostgreSQL vs Automated Synthetic vs Automated SQLite in-memory)

## Why
Current benchmarks run against mock backends that return immediately without any I/O. Performance claims in README (1.2ms SELECT, 5K TPS) are from manual PostgreSQL testing and cannot be reproduced from the repository. These SQLite in-memory benchmarks provide automated, reproducible real I/O measurements.

Relates to #405

## Test plan
- [x] CI build succeeds with benchmarks enabled
- [x] `database_benchmarks --benchmark_filter=SQLite` runs without errors
- [x] Benchmark output shows real timing data for all 4 SQLite benchmarks
- [x] Existing synthetic benchmarks (`--benchmark_filter=Database`) are unaffected