### PR TITLE
fix(build): add complete CMake install/export infrastructure for find_package support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,13 +345,57 @@ endif()
 
 include(GNUInstallDirs)
 
-# Install header files
 if(BUILD_DATABASE)
+    # Install header files
     install(DIRECTORY database/
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/database_system/database
         FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
         PATTERN "tests" EXCLUDE
         PATTERN "samples" EXCLUDE
+    )
+
+    # Install library target with export set
+    install(TARGETS database
+        EXPORT DatabaseSystemTargets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/database_system
+    )
+
+    # Install export set with DatabaseSystem:: namespace
+    install(EXPORT DatabaseSystemTargets
+        FILE DatabaseSystemTargets.cmake
+        NAMESPACE DatabaseSystem::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/DatabaseSystem
+    )
+
+    # Generate and install package config files
+    include(CMakePackageConfigHelpers)
+
+    configure_package_config_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/DatabaseSystemConfig.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/DatabaseSystemConfig.cmake"
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/DatabaseSystem
+        PATH_VARS CMAKE_INSTALL_INCLUDEDIR
+    )
+
+    write_basic_package_version_file(
+        "${CMAKE_CURRENT_BINARY_DIR}/DatabaseSystemConfigVersion.cmake"
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY AnyNewerVersion
+    )
+
+    install(FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/DatabaseSystemConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/DatabaseSystemConfigVersion.cmake"
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/DatabaseSystem
+    )
+
+    # Build-tree export for FetchContent/add_subdirectory users
+    export(EXPORT DatabaseSystemTargets
+        FILE "${CMAKE_CURRENT_BINARY_DIR}/DatabaseSystemTargets.cmake"
+        NAMESPACE DatabaseSystem::
     )
 endif()
 

--- a/cmake/DatabaseSystemConfig.cmake.in
+++ b/cmake/DatabaseSystemConfig.cmake.in
@@ -2,19 +2,41 @@
 
 ##################################################
 # DatabaseSystem Package Configuration
+#
+# Provides imported targets:
+#   DatabaseSystem::database             - Core DAL library
+#   DatabaseSystem::integrated_database  - Integrated adapter layer (if built)
 ##################################################
 
 include(CMakeFindDependencyMacro)
 
-# Find required dependencies
+# Required dependencies
 find_dependency(Threads REQUIRED)
-find_dependency(PostgreSQL REQUIRED)
 
-# Find container system dependency
-find_dependency(ContainerSystem QUIET)
-if(NOT ContainerSystem_FOUND)
-    # Container system is required
-    message(FATAL_ERROR "DatabaseSystem requires ContainerSystem")
+# Backend-specific dependencies (configured at build time)
+if(@USE_POSTGRESQL@)
+    find_dependency(libpqxx CONFIG)
+    find_dependency(OpenSSL)
+endif()
+
+if(@USE_SQLITE@)
+    find_dependency(unofficial-sqlite3 CONFIG QUIET)
+endif()
+
+if(@USE_MONGODB@)
+    find_dependency(mongocxx CONFIG)
+    find_dependency(bsoncxx CONFIG)
+endif()
+
+if(@USE_REDIS@)
+    find_dependency(hiredis CONFIG)
+endif()
+
+# Ecosystem dependencies (optional)
+find_dependency(common_system CONFIG QUIET)
+
+if(@USE_CONTAINER_SYSTEM@)
+    find_dependency(ContainerSystem CONFIG QUIET)
 endif()
 
 # Include targets

--- a/database/integrated/CMakeLists.txt
+++ b/database/integrated/CMakeLists.txt
@@ -272,7 +272,7 @@ endif()
 ##################################################
 
 install(TARGETS ${INTEGRATED_DB_TARGET}
-    EXPORT database_system-targets
+    EXPORT DatabaseSystemTargets
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin


### PR DESCRIPTION
Closes #427

## Summary
- Add `install(TARGETS)` and `install(EXPORT)` for `database` and `integrated_database` targets with `DatabaseSystem::` namespace
- Generate and install `DatabaseSystemConfig.cmake`, `DatabaseSystemConfigVersion.cmake`, and `DatabaseSystemTargets.cmake` via `configure_package_config_file` + `write_basic_package_version_file`
- Fix `DatabaseSystemConfig.cmake.in`: replace hardcoded `find_dependency(PostgreSQL REQUIRED)` with conditional per-backend `find_dependency` based on build-time options
- Make `ContainerSystem` dependency optional (remove `FATAL_ERROR`)
- Add build-tree `export(EXPORT ...)` for FetchContent/add_subdirectory users
- Unify export set name to `DatabaseSystemTargets` across root and integrated subdirectory

## Installed CMake artifacts
After `cmake --install`:
```
lib/cmake/DatabaseSystem/
  DatabaseSystemConfig.cmake
  DatabaseSystemConfigVersion.cmake
  DatabaseSystemTargets.cmake
  DatabaseSystemTargets-release.cmake
```

Consumers can now use:
```cmake
find_package(DatabaseSystem CONFIG REQUIRED)
target_link_libraries(myapp PRIVATE DatabaseSystem::database)
```

## Test plan
- [x] CMake configure succeeds (MSVC 19.50, Windows 11)
- [x] Build succeeds (Release config)
- [x] `cmake --install` produces all expected config files
- [x] Installed `DatabaseSystemTargets.cmake` contains `DatabaseSystem::database` and `DatabaseSystem::integrated_database` imported targets
- [x] Config file correctly substitutes `@USE_POSTGRESQL@` etc. as conditional `if(OFF)`/`if(ON)`
- [x] CI passes on all platforms (Linux/macOS/Windows)