### PR TITLE
chore(deps): reconcile removed MySQL backend references

### DIFF
--- a/README.kr.md
+++ b/README.kr.md
@@ -51,7 +51,6 @@ Database System Project는 프로덕션 수준의 엔터프라이즈급 C++20 da
 | 백엔드 | 버전 | 선택적 패키지 |
 |--------|------|--------------|
 | PostgreSQL | 12+ | `libpq-dev` |
-| MySQL | 8.0+ | `libmariadb-dev` (MariaDB Connector/C) |
 | SQLite | 3.35+ | `libsqlite3-dev` |
 | MongoDB | 5.0+ | `libmongoc-dev` |
 | Redis | 6.0+ | `libhiredis-dev` |
@@ -154,7 +153,7 @@ cmake --build build
 - **대량 작업**: 높은 처리량 시나리오를 위한 최적화된 배치 처리
 
 ### 🛡️ **고품질 안정성**
-- **다중 백엔드 지원**: PostgreSQL, MySQL, SQLite, MongoDB, Redis
+- **다중 백엔드 지원**: PostgreSQL, SQLite, MongoDB, Redis
 - **자동 failover**: 자동 연결 복구를 통한 상태 모니터링
 - **트랜잭션 관리**: ACID 준수
 - **포괄적인 오류 처리**: 우아한 성능 저하 및 복구 패턴
@@ -222,7 +221,7 @@ cmake --build build
 ## 기능
 
 ### 🎯 핵심 기능
-- **다중 백엔드 지원**: 통합 인터페이스로 PostgreSQL, MySQL, SQLite, MongoDB, Redis
+- **다중 백엔드 지원**: 통합 인터페이스로 PostgreSQL, SQLite, MongoDB, Redis
 - **ORM Framework**: 자동 스키마 관리를 갖춘 C++20 concept 기반 entity system
 - **Connection Pooling**: 적응형 크기 조정을 통한 엔터프라이즈급 연결 관리
 - **Query Builder**: SQL 및 NoSQL database를 위한 타입 안전 쿼리 구성
@@ -266,7 +265,6 @@ if (void_result.is_ok()) {
 | Database | 상태 | 기능 | 성능 | ORM 지원 | 보안 |
 |----------|--------|----------|-------------|-------------|----------|
 | PostgreSQL | ✅ Full | JSONB, Arrays, CTEs, Prepared Statements | Excellent | ✅ | TLS/SSL |
-| MySQL | ✅ Full | Full-text search, Transactions, Prepared Statements | Very Good | ✅ | TLS/SSL |
 | SQLite | ✅ Full | WAL mode, FTS5, In-memory databases | Good | ✅ | Encryption |
 | MongoDB | 🧪 Experimental | Documents, Aggregation, GridFS | Very Good | ✅ | TLS/SSL |
 | Redis | 🧪 Experimental | All data types, Pub/Sub, Transactions | Excellent | ✅ | TLS/SSL |
@@ -309,7 +307,6 @@ enum class database_types : uint8_t
 {
     none = 0,           // No database backend
     postgres = 1,       // PostgreSQL backend
-    mysql = 2,          // MySQL/MariaDB backend
     sqlite = 3,         // SQLite backend
     oracle = 4,         // Oracle backend (future)
     mongodb = 5,        // MongoDB backend
@@ -329,7 +326,6 @@ database_system/
 │   ├── query_builder.h                # Query builder interfaces
 │   ├── postgres_manager.h             # PostgreSQL implementation
 │   ├── backends/                      # Database backends
-│   │   ├── mysql/mysql_manager.h      # MySQL implementation
 │   │   ├── sqlite/sqlite_manager.h    # SQLite implementation
 │   │   ├── mongodb/mongodb_manager.h  # MongoDB implementation
 │   │   └── redis/redis_manager.h      # Redis implementation
@@ -386,7 +382,6 @@ database_system/
 │   │   └── connection_pool.h       # Enterprise connection pooling
 │   ├── 📁 backends/                # Database backend implementations
 │   │   ├── postgres_manager.h      # PostgreSQL implementation
-│   │   ├── mysql/mysql_manager.h   # MySQL implementation
 │   │   ├── sqlite/sqlite_manager.h # SQLite implementation
 │   │   ├── mongodb/mongodb_manager.h # MongoDB implementation
 │   │   └── redis/redis_manager.h   # Redis implementation
@@ -449,7 +444,6 @@ database_system/
 
 #### 백엔드 구현 파일
 - **`postgres_manager.h/cpp`**: 고급 기능 (JSONB, array, CTE)을 갖춘 PostgreSQL 백엔드
-- **`mysql_manager.h/cpp`**: full-text search 및 transaction을 갖춘 MySQL/MariaDB 백엔드
 - **`sqlite_manager.h/cpp`**: WAL 모드 및 FTS5 지원을 갖춘 SQLite 백엔드
 - **`mongodb_manager.h/cpp`**: document 작업 및 aggregation을 갖춘 MongoDB 백엔드
 - **`redis_manager.h/cpp`**: 모든 데이터 타입 및 pub/sub을 갖춘 Redis 백엔드
@@ -464,7 +458,7 @@ database_system/
 ```
 core (database_base, database_manager, database_types)
     │
-    ├──> backends (postgres, mysql, sqlite, mongodb, redis)
+    ├──> backends (postgres, sqlite, mongodb, redis)
     │
     ├──> query (query_builder, sql_builder, nosql_builder)
     │
@@ -757,14 +751,13 @@ cd database_system
 
 # Install database dependencies via vcpkg (optional)
 vcpkg install libpqxx           # PostgreSQL
-vcpkg install libmariadb        # MySQL (MariaDB Connector/C)
 vcpkg install sqlite3           # SQLite
 vcpkg install mongo-cxx-driver  # MongoDB
 vcpkg install hiredis           # Redis
 
 # Build with desired database support
 mkdir build && cd build
-cmake .. -DUSE_POSTGRESQL=ON -DUSE_MYSQL=ON -DUSE_SQLITE=ON -DUSE_MONGODB=ON -DUSE_REDIS=ON
+cmake .. -DUSE_POSTGRESQL=ON -DUSE_SQLITE=ON -DUSE_MONGODB=ON -DUSE_REDIS=ON
 cmake --build .
 
 # Run examples
@@ -1075,7 +1068,7 @@ processor.register_event_handler("user_changes", [](const stream_event& event) {
 ```bash
 # Build with all database support (requires libraries)
 mkdir build && cd build
-cmake .. -DUSE_POSTGRESQL=ON -DUSE_MYSQL=ON -DUSE_SQLITE=ON -DUSE_MONGODB=ON -DUSE_REDIS=ON
+cmake .. -DUSE_POSTGRESQL=ON -DUSE_SQLITE=ON -DUSE_MONGODB=ON -DUSE_REDIS=ON
 ninja  # or make
 
 # Build with specific databases only
@@ -1083,7 +1076,7 @@ cmake .. -DUSE_POSTGRESQL=ON -DUSE_SQLITE=ON
 ninja
 
 # Build without any databases (uses mock implementations)
-cmake .. -DUSE_POSTGRESQL=OFF -DUSE_MYSQL=OFF -DUSE_SQLITE=OFF
+cmake .. -DUSE_POSTGRESQL=OFF -DUSE_SQLITE=OFF
 ninja
 
 # Build with samples and tests
@@ -1103,9 +1096,6 @@ ninja
 ```bash
 # PostgreSQL support
 vcpkg install libpqxx openssl
-
-# MySQL support (via MariaDB Connector/C)
-vcpkg install libmariadb
 
 # SQLite support
 vcpkg install sqlite3
@@ -1142,7 +1132,6 @@ export REDIS_PORT=6379
 | 옵션 | 기본값 | 설명 |
 |--------|---------|-------------|
 | `USE_POSTGRESQL` | ON | PostgreSQL 지원 활성화 |
-| `USE_MYSQL` | OFF | MySQL 지원 활성화 |
 | `USE_SQLITE` | OFF | SQLite 지원 활성화 |
 | `USE_MONGODB` | OFF | MongoDB 지원 활성화 |
 | `USE_REDIS` | OFF | Redis 지원 활성화 |
@@ -1210,12 +1199,12 @@ ctest
 
 ## 성능 벤치마크
 
-| 작업 | PostgreSQL | MySQL | SQLite | MongoDB | Redis |
-|-----------|------------|-------|--------|---------|-------|
-| 단순 SELECT | 1.2ms | 1.5ms | 0.8ms | 2.1ms | 0.3ms |
-| 복잡한 JOIN | 15ms | 18ms | 12ms | N/A | N/A |
-| 대량 INSERT (1K) | 45ms | 52ms | 38ms | 35ms | 28ms |
-| Connection Pool | 0.1ms | 0.1ms | 0.1ms | 0.2ms | 0.05ms |
+| 작업 | PostgreSQL | SQLite | MongoDB | Redis |
+|-----------|------------|--------|---------|-------|
+| 단순 SELECT | 1.2ms | 0.8ms | 2.1ms | 0.3ms |
+| 복잡한 JOIN | 15ms | 12ms | N/A | N/A |
+| 대량 INSERT (1K) | 45ms | 38ms | 35ms | 28ms |
+| Connection Pool | 0.1ms | 0.1ms | 0.2ms | 0.05ms |
 
 *Intel i7-9750H, 16GB RAM, SSD 스토리지에서 벤치마크 수행*
 
@@ -1244,7 +1233,7 @@ using namespace database;
 ## 개발 로드맵
 
 ### ✅ 완료 (Phase 1-3)
-- 다중 database 백엔드 지원 (PostgreSQL, MySQL, SQLite, MongoDB, Redis)
+- 다중 database 백엔드 지원 (PostgreSQL, SQLite, MongoDB, Redis)
 - 상태 모니터링을 통한 엔터프라이즈급 connection pooling
 - SQL 및 NoSQL database를 위한 포괄적인 query builder
 - Thread 안전 작업 및 RAII 리소스 관리
@@ -1390,7 +1379,7 @@ if (!commit_result) {
 - **Connection Pool 통합**: connection pool 오류 처리와의 원활한 통합
 
 이 하이브리드 접근 방식은 다음을 제공합니다:
-- **호환성**: 모든 표준 database driver (PostgreSQL, MySQL, SQLite, MongoDB, Redis)와 작동
+- **호환성**: 현재 지원되는 표준 database driver (PostgreSQL, SQLite, MongoDB, Redis)와 작동
 - **안전성**: 애플리케이션 코드 및 생태계 통합을 위한 타입 안전 오류 처리
 - **성능**: 내부 database 작업에 대한 오버헤드 제로
 - **안정성**: 포괄적인 오류 처리를 통한 엔터프라이즈급 트랜잭션 지원
@@ -1473,7 +1462,7 @@ auto commit_result = adapter->commit();
 - **-540 ~ -549**: 보안 오류
 
 **디자인 철학**:
-- **호환성**: 모든 표준 database driver (PostgreSQL, MySQL, SQLite, MongoDB, Redis)와 작동
+- **호환성**: 현재 지원되는 표준 database driver (PostgreSQL, SQLite, MongoDB, Redis)와 작동
 - **안전성**: 애플리케이션 코드 및 생태계 통합을 위한 타입 안전 오류 처리
 - **성능**: 내부 database 작업에 대한 오버헤드 제로
 - **안정성**: 포괄적인 오류 처리를 통한 엔터프라이즈급 트랜잭션 지원

--- a/docs/ADAPTER_PATTERNS.md
+++ b/docs/ADAPTER_PATTERNS.md
@@ -51,7 +51,7 @@ database_system (Tier 3)
        ├── thread_system (OPTIONAL - adapter pattern)
        ├── container_system (OPTIONAL - protocol container)
        ├── monitoring_system (OPTIONAL - metrics adapter)
-       └── External: PostgreSQL, MySQL, SQLite, MongoDB, Redis
+       └── External: PostgreSQL, SQLite, MongoDB, Redis
 ```
 
 ---

--- a/docs/API_REFERENCE.kr.md
+++ b/docs/API_REFERENCE.kr.md
@@ -236,7 +236,7 @@ public:
     // Database type selection
     query_builder& for_database(database_types db_type);
 
-    // SQL-style interface (PostgreSQL, MySQL, SQLite)
+    // SQL-style interface (PostgreSQL, SQLite)
     query_builder& select(const std::vector<std::string>& columns);
     query_builder& from(const std::string& table);
     query_builder& where(const std::string& field, const std::string& op, const database_value& value);
@@ -467,7 +467,6 @@ enum class database_types : uint8_t
 {
     none = 0,           // No database backend
     postgres = 1,       // PostgreSQL backend
-    mysql = 2,          // MySQL/MariaDB backend
     sqlite = 3,         // SQLite backend
     oracle = 4,         // Oracle backend (future)
     mongodb = 5,        // MongoDB backend
@@ -869,14 +868,6 @@ int main() {
         .where("status", "=", database_value{std::string("active")});
 
     std::cout << "PostgreSQL: " << pg_query.build() << std::endl;
-
-    // MySQL operations (different identifier quoting)
-    auto mysql_query = db.create_query_builder(database_types::mysql)
-        .select({"id", "name"})
-        .from("users")
-        .where("status", "=", database_value{std::string("active")});
-
-    std::cout << "MySQL: " << mysql_query.build() << std::endl;
 
     // MongoDB operations
     auto mongo_query = db.create_query_builder(database_types::mongodb)

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -295,7 +295,7 @@ public:
     // Database type selection
     query_builder& for_database(database_types db_type);
 
-    // SQL-style interface (PostgreSQL, MySQL, SQLite)
+    // SQL-style interface (PostgreSQL, SQLite)
     query_builder& select(const std::vector<std::string>& columns);
     query_builder& from(const std::string& table);
     query_builder& where(const std::string& field, const std::string& op, const database_value& value);
@@ -556,7 +556,6 @@ enum class database_types : uint8_t
 {
     none = 0,           // No database backend
     postgres = 1,       // PostgreSQL backend
-    mysql = 2,          // MySQL/MariaDB backend
     sqlite = 3,         // SQLite backend
     oracle = 4,         // Oracle backend (future)
     mongodb = 5,        // MongoDB backend
@@ -959,14 +958,6 @@ int main() {
 
     std::cout << "PostgreSQL: " << pg_query.build() << std::endl;
 
-    // MySQL operations (different identifier quoting)
-    auto mysql_query = db.create_query_builder(database_types::mysql)
-        .select({"id", "name"})
-        .from("users")
-        .where("status", "=", database_value{std::string("active")});
-
-    std::cout << "MySQL: " << mysql_query.build() << std::endl;
-
     // MongoDB operations
     auto mongo_query = db.create_query_builder(database_types::mongodb)
         .collection("users")
@@ -1223,7 +1214,7 @@ coordinator.initialize();
 
 | Enum | Values |
 |------|--------|
-| `backend_type` | `postgres`, `mysql`, `sqlite`, `mongodb`, `redis` |
+| `backend_type` | `postgres`, `sqlite`, `mongodb`, `redis` |
 | `db_log_level` | `trace`, `debug`, `info`, `warning`, `error`, `critical`, `fatal` |
 | `thread_pool_type` | `standard`, `typed` |
 | `ssl_mode` | `disable`, `allow`, `prefer`, `require`, `verify_ca`, `verify_full` |

--- a/docs/ARCHITECTURE.kr.md
+++ b/docs/ARCHITECTURE.kr.md
@@ -72,7 +72,7 @@ Database System은 프로덕션 환경을 위한 고급 기능과 함께 여러 
 ├─────────────────────────────────────────────────────────────┤
 │                  Database Manager                          │
 ├─────────────────────────────────────────────────────────────┤
-│   PostgreSQL │   MySQL   │  SQLite  │ MongoDB │   Redis   │
+│  PostgreSQL │  SQLite  │ MongoDB │  Redis   │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -101,7 +101,6 @@ public:
 
 #### 백엔드 구현
 - `postgres_manager`: libpqxx를 사용하는 PostgreSQL 백엔드
-- `mysql_manager`: mysqlclient를 사용하는 MySQL 백엔드
 - `sqlite_manager`: sqlite3를 사용하는 SQLite 백엔드
 - `mongodb_manager`: mongocxx를 사용하는 MongoDB 백엔드
 - `redis_manager`: hiredis를 사용하는 Redis 백엔드
@@ -367,7 +366,6 @@ try {
 
 ### 선택적 의존성
 - **libpqxx**: PostgreSQL 지원
-- **mysqlclient**: MySQL 지원
 - **sqlite3**: SQLite 지원
 - **mongocxx**: MongoDB 지원
 - **hiredis**: Redis 지원
@@ -377,7 +375,6 @@ try {
 ### CMake 옵션
 ```cmake
 option(ENABLE_POSTGRESQL "Enable PostgreSQL support" ON)
-option(ENABLE_MYSQL "Enable MySQL support" OFF)
 option(ENABLE_SQLITE "Enable SQLite support" OFF)
 option(ENABLE_MONGODB "Enable MongoDB support" OFF)
 option(ENABLE_REDIS "Enable Redis support" OFF)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -73,7 +73,7 @@ The Database System is designed as a modular, enterprise-grade database abstract
 │                    Database Manager                        │
 ├─────────────────────────────────────────────────────────────┤
 │                   Database Backends                         │
-│       PostgreSQL │ MySQL │ SQLite │ MongoDB │ Redis         │
+│      PostgreSQL │ SQLite │ MongoDB │ Redis                │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -102,7 +102,6 @@ public:
 
 #### Backend Implementations
 - `postgres_manager`: PostgreSQL backend using libpqxx
-- `mysql_manager`: MySQL backend using mysqlclient
 - `sqlite_manager`: SQLite backend using sqlite3
 - `mongodb_manager`: MongoDB backend using mongocxx
 - `redis_manager`: Redis backend using hiredis
@@ -366,7 +365,6 @@ try {
 
 ### Optional Dependencies
 - **libpqxx**: PostgreSQL support
-- **mysqlclient**: MySQL support
 - **sqlite3**: SQLite support
 - **mongocxx**: MongoDB support
 - **hiredis**: Redis support
@@ -376,7 +374,6 @@ try {
 ### CMake Options
 ```cmake
 option(ENABLE_POSTGRESQL "Enable PostgreSQL support" ON)
-option(ENABLE_MYSQL "Enable MySQL support" OFF)
 option(ENABLE_SQLITE "Enable SQLite support" OFF)
 option(ENABLE_MONGODB "Enable MongoDB support" OFF)
 option(ENABLE_REDIS "Enable Redis support" OFF)

--- a/docs/FEATURES.kr.md
+++ b/docs/FEATURES.kr.md
@@ -85,21 +85,6 @@ auto cte_result = db.create_query_builder(database_types::postgres)
     .execute(&db);
 ```
 
-### MySQL 백엔드
-
-**상태**: ✅ 완전 지원
-**구현**: `mysql/mysql_manager.h/cpp`
-
-**기능**:
-- MATCH AGAINST를 통한 전문 검색
-- ACID 준수를 통한 InnoDB 트랜잭션
-- 플레이스홀더를 통한 준비된 문
-- 저장 프로시저 및 함수
-- 트리거 및 이벤트
-- 파티셔닝 지원
-- 복제 인식
-- JSON 컬럼 타입 (MySQL 5.7+)
-
 ### SQLite 백엔드
 
 **상태**: ✅ 완전 지원
@@ -1082,7 +1067,7 @@ C++20 모듈을 통한 빠른 컴파일 및 향상된 캡슐화:
 | `kcenon.database` | (주 모듈) | 모든 파티션 집계 |
 | `kcenon.database:core` | Core | 타입, 컨텍스트, 매니저, 백엔드 레지스트리 |
 | `kcenon.database:query` | Query | 쿼리 빌더, 조건, 방언 (SQL, MongoDB, Redis) |
-| `kcenon.database:backends` | Backends | PostgreSQL, MySQL, SQLite, MongoDB, Redis |
+| `kcenon.database:backends` | Backends | PostgreSQL, SQLite, MongoDB, Redis |
 
 ```cpp
 import kcenon.database;

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -90,53 +90,6 @@ auto cte_result = db.create_query_builder(database_types::postgres)
 - Statement timeout configuration
 - Work memory and shared buffers tuning
 
-### MySQL Backend
-
-**Status**: ✅ Full Support
-**Implementation**: `mysql/mysql_manager.h/cpp`
-
-**Features**:
-- Full-text search with MATCH AGAINST
-- InnoDB transactions with ACID compliance
-- Prepared statements with placeholders
-- Stored procedures and functions
-- Triggers and events
-- Partitioning support
-- Replication awareness
-- JSON column type (MySQL 5.7+)
-
-**Advanced Capabilities**:
-```cpp
-// Full-text search
-auto fts_result = db.create_query_builder(database_types::mysql)
-    .select({"id", "title", "content", "MATCH(title, content) AGAINST('database' IN NATURAL LANGUAGE MODE) as score"})
-    .from("articles")
-    .where("MATCH(title, content) AGAINST('database' IN NATURAL LANGUAGE MODE)")
-    .order_by("score", sort_order::desc)
-    .execute(&db);
-
-// Transaction with savepoints
-auto tx_result = db.begin_transaction();
-db.execute_command("INSERT INTO accounts (id, balance) VALUES (1, 1000)");
-db.execute_command("SAVEPOINT sp1");
-db.execute_command("UPDATE accounts SET balance = balance - 100 WHERE id = 1");
-// Can rollback to sp1 if needed
-db.commit();
-
-// Stored procedure call
-auto sp_result = db.create_query_builder(database_types::mysql)
-    .raw_sql("CALL calculate_monthly_sales(@result)")
-    .execute(&db);
-```
-
-**Configuration Options**:
-- Connection string: `host=localhost;port=3306;database=mydb;user=admin;password=secret;ssl=1`
-- SSL/TLS encryption
-- Character set (utf8mb4 recommended)
-- Connection pool size
-- Auto-reconnect settings
-- Query cache configuration
-
 ### SQLite Backend
 
 **Status**: ✅ Full Support
@@ -1619,7 +1572,7 @@ The database_system can be consumed as a C++20 module for faster compilation and
 | `kcenon.database` | (primary) | Aggregates all partitions |
 | `kcenon.database:core` | Core | Types, context, manager, backend registry, proxy config |
 | `kcenon.database:query` | Query | Query builder, conditions, dialects (SQL, MongoDB, Redis) |
-| `kcenon.database:backends` | Backends | PostgreSQL, MySQL, SQLite, MongoDB, Redis backends |
+| `kcenon.database:backends` | Backends | PostgreSQL, SQLite, MongoDB, Redis backends |
 
 ### Usage
 
@@ -1670,7 +1623,6 @@ kcenon.database
 
 **Optional** (for specific backends):
 - libpqxx (PostgreSQL)
-- MariaDB Connector/C (MySQL)
 - sqlite3 (SQLite)
 - mongo-cxx-driver (MongoDB)
 - hiredis (Redis)

--- a/docs/MIGRATION_database_base.md
+++ b/docs/MIGRATION_database_base.md
@@ -7,7 +7,7 @@ As of Issue #287, `database_base` is deprecated in favor of the new `database_ba
 ## Timeline
 
 - **v0.4.x**: `database_base` deprecated, `database_backend` recommended
-- **v0.4.4**: Legacy manager implementations removed (sqlite_manager, mysql_manager, mongodb_manager, redis_manager)
+- **v0.4.4**: Legacy manager implementations removed (sqlite_manager, legacy mysql_manager, mongodb_manager, redis_manager)
 - **v0.5.0.0**: `database_base` interface will be removed completely
 
 ## Removed Legacy Managers
@@ -17,7 +17,7 @@ As of v0.4.4 (#304), the following legacy manager implementations have been remo
 | Removed File | Replacement |
 |--------------|-------------|
 | `database/backends/sqlite/sqlite_manager.{h,cpp}` | `sqlite_backend` |
-| `database/backends/mysql/mysql_manager.{h,cpp}` | `mysql_backend` |
+| `database/backends/mysql/mysql_manager.{h,cpp}` | `legacy mysql_backend` |
 | `database/backends/mongodb/mongodb_manager.{h,cpp}` | `mongodb_backend` |
 | `database/backends/redis/redis_manager.{h,cpp}` | `redis_backend` |
 

--- a/docs/ORM_GUIDE.md
+++ b/docs/ORM_GUIDE.md
@@ -76,7 +76,6 @@ The ORM works with all `database_backend` implementations:
 | Backend | ORM Support | Notes |
 |---------|-------------|-------|
 | PostgreSQL | Full | Recommended for production |
-| MySQL | Full | |
 | SQLite | Full | Good for development/testing |
 | MongoDB | Limited | Relational features may not apply |
 | Redis | Limited | Key-value model differs from relational |
@@ -653,7 +652,7 @@ CREATE INDEX IF NOT EXISTS idx_title ON posts(title);
 | Destructive sync_schema | `sync_schema()` drops and recreates tables | Use `create_tables()` with `IF NOT EXISTS` |
 | No migration diffing | Cannot detect schema differences | Manually manage ALTER TABLE statements |
 | No connection-aware CRUD | `save()`, `load()`, `update()`, `remove()` do not take a database parameter in the base class | Use `query_builder` for database-aware operations |
-| `AUTO_INCREMENT` syntax | Uses MySQL syntax; PostgreSQL uses `SERIAL`/`BIGSERIAL` | Adjust DDL manually per backend |
+| Auto-increment syntax | Backends use different auto-increment syntax (`SERIAL`/`BIGSERIAL` in PostgreSQL, `AUTOINCREMENT` in SQLite) | Adjust DDL manually per backend |
 | Metadata init not thread-safe | `ENTITY_METADATA()` lazy init uses non-atomic `static bool` | Call `get_metadata()` from single thread or synchronize externally |
 
 ---

--- a/docs/PRODUCTION_QUALITY.kr.md
+++ b/docs/PRODUCTION_QUALITY.kr.md
@@ -72,7 +72,6 @@ credentials.store_credentials("production_db", creds);
 | 백엔드 | TLS/SSL | 인증서 검증 | 클라이언트 인증서 |
 |-------|---------|-----------|-----------------|
 | PostgreSQL | ✅ | ✅ | ✅ |
-| MySQL | ✅ | ✅ | ✅ |
 | MongoDB | ✅ | ✅ | ✅ |
 | Redis | ✅ | ✅ | ✅ |
 | SQLite | N/A (로컬) | N/A | N/A |
@@ -321,7 +320,6 @@ All heap blocks were freed -- no leaks are possible
 **핵심 메트릭**:
 - 연결 풀: 77ns 획득, 1.16M+ ops/s
 - PostgreSQL: 1.2ms 단순 SELECT, 5,000 TPS
-- MySQL: 1.5ms 단순 SELECT, 4,200 TPS
 - SQLite: 0.8ms 단순 SELECT (WAL 모드)
 - MongoDB: 2.1ms insertOne
 - Redis: 0.3ms GET/SET

--- a/docs/PRODUCTION_QUALITY.md
+++ b/docs/PRODUCTION_QUALITY.md
@@ -83,7 +83,6 @@ credentials.store_credentials("production_db", creds);
 | Backend | TLS/SSL | Certificate Verification | Client Certificates |
 |---------|---------|-------------------------|-------------------|
 | PostgreSQL | ✅ | ✅ | ✅ |
-| MySQL | ✅ | ✅ | ✅ |
 | MongoDB | ✅ | ✅ | ✅ |
 | Redis | ✅ | ✅ | ✅ |
 | SQLite | N/A (local) | N/A | N/A |
@@ -316,19 +315,18 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         compiler: [gcc, clang, msvc]
-        database: [postgres, mysql, sqlite, mongodb, redis]
+        database: [postgres, sqlite, mongodb, redis]
 
     steps:
       - uses: actions/checkout@v3
 
       - name: Install dependencies
-        run: vcpkg install libpqxx libmariadb sqlite3 mongo-cxx-driver hiredis
+        run: vcpkg install libpqxx sqlite3 mongo-cxx-driver hiredis
 
       - name: Configure CMake
         run: |
           cmake -B build \
             -DUSE_POSTGRESQL=ON \
-            -DUSE_MYSQL=ON \
             -DUSE_SQLITE=ON \
             -DUSE_MONGODB=ON \
             -DUSE_REDIS=ON \
@@ -623,7 +621,6 @@ See [BENCHMARKS.md](BENCHMARKS.md) for comprehensive performance data.
 **Key Metrics**:
 - Connection Pool: 77ns acquisition, 1.16M+ ops/s
 - PostgreSQL: 1.2ms simple SELECT, 5,000 TPS
-- MySQL: 1.5ms simple SELECT, 4,200 TPS
 - SQLite: 0.8ms simple SELECT (WAL mode)
 - MongoDB: 2.1ms insertOne
 - Redis: 0.3ms GET/SET

--- a/docs/PROJECT_STRUCTURE.kr.md
+++ b/docs/PROJECT_STRUCTURE.kr.md
@@ -76,7 +76,6 @@ database_system/
 │   │   └── adapters/              # 어댑터 테스트
 │   ├── integration/               # 통합 테스트
 │   │   ├── postgres/              # PostgreSQL 통합
-│   │   ├── mysql/                 # MySQL 통합
 │   │   ├── sqlite/                # SQLite 통합
 │   │   ├── mongodb/               # MongoDB 통합
 │   │   ├── redis/                 # Redis 통합
@@ -105,7 +104,6 @@ database_system/
 │   └── performance/               # 성능 문서
 ├── cmake/                         # CMake 모듈
 │   ├── FindPostgreSQL.cmake       # PostgreSQL finder
-│   ├── FindMySQL.cmake            # MySQL finder
 │   ├── FindSQLite3.cmake          # SQLite3 finder
 │   ├── FindMongoDB.cmake          # MongoDB finder
 │   ├── FindRedis.cmake            # Redis finder
@@ -177,19 +175,6 @@ database_system/
 **의존성**:
 - libpqxx (PostgreSQL C++ 클라이언트 라이브러리)
 - OpenSSL (TLS/SSL용)
-
-#### MySQL 백엔드
-
-**파일**:
-- `mysql/mysql_manager.h/cpp`: MySQL 구현 (780 LOC)
-- `mysql/mysql_connection.h/cpp`: 커넥션 처리 (300 LOC)
-- `mysql/mysql_prepared_statement.h/cpp`: 준비된 문 (260 LOC)
-
-**기능**:
-- 전문 검색 (MATCH AGAINST)
-- InnoDB 트랜잭션
-- 준비된 문
-- 저장 프로시저
 
 #### SQLite 백엔드
 
@@ -413,7 +398,6 @@ public:
 ```
 database_base (추상)
 ├── postgres_manager
-├── mysql_manager
 ├── sqlite_manager
 ├── mongodb_manager
 └── redis_manager
@@ -469,7 +453,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # 옵션
 option(USE_POSTGRESQL "PostgreSQL 지원 활성화" ON)
-option(USE_MYSQL "MySQL 지원 활성화" OFF)
 option(USE_SQLITE "SQLite 지원 활성화" OFF)
 option(USE_MONGODB "MongoDB 지원 활성화" OFF)
 option(USE_REDIS "Redis 지원 활성화" OFF)
@@ -511,7 +494,6 @@ endif()
 | 데이터베이스 | 라이브러리 | 버전 | vcpkg 패키지 |
 |----------|---------|---------|---------------|
 | PostgreSQL | libpqxx | 7.7+ | `libpqxx` |
-| MySQL | libmariadb | 3.x+ | `libmariadb` |
 | SQLite | sqlite3 | 3.40+ | `sqlite3` |
 | MongoDB | mongo-cxx-driver | 3.7+ | `mongo-cxx-driver` |
 | Redis | hiredis | 1.1+ | `hiredis` |
@@ -531,7 +513,7 @@ endif()
 **vcpkg 사용**:
 ```bash
 # 데이터베이스 라이브러리 설치
-vcpkg install libpqxx openssl libmariadb sqlite3 mongo-cxx-driver hiredis
+vcpkg install libpqxx openssl sqlite3 mongo-cxx-driver hiredis
 
 # 선택적 시스템 설치 (가능한 경우)
 vcpkg install kcenon-common-system kcenon-thread-system

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -72,7 +72,6 @@ database_system/
 │   │   └── adapters/              # Adapter tests
 │   ├── integration/               # Integration tests
 │   │   ├── postgres/              # PostgreSQL integration
-│   │   ├── mysql/                 # MySQL integration
 │   │   ├── sqlite/                # SQLite integration
 │   │   ├── mongodb/               # MongoDB integration
 │   │   ├── redis/                 # Redis integration
@@ -101,7 +100,6 @@ database_system/
 │   └── performance/               # Performance docs
 ├── cmake/                         # CMake modules
 │   ├── FindPostgreSQL.cmake       # PostgreSQL finder
-│   ├── FindMySQL.cmake            # MySQL finder
 │   ├── FindSQLite3.cmake          # SQLite3 finder
 │   ├── FindMongoDB.cmake          # MongoDB finder
 │   ├── FindRedis.cmake            # Redis finder
@@ -177,23 +175,6 @@ database_system/
 
 **Dependencies**:
 - libpqxx (PostgreSQL C++ client library)
-- OpenSSL (for TLS/SSL)
-
-#### MySQL Backend
-
-**Files**:
-- `mysql/mysql_manager.h/cpp`: MySQL implementation (780 LOC)
-- `mysql/mysql_connection.h/cpp`: Connection handling (300 LOC)
-- `mysql/mysql_prepared_statement.h/cpp`: Prepared statements (260 LOC)
-
-**Features**:
-- Full-text search (MATCH AGAINST)
-- InnoDB transactions
-- Prepared statements
-- Stored procedures
-
-**Dependencies**:
-- MariaDB Connector/C (MySQL-compatible C client library, LGPL-2.1)
 - OpenSSL (for TLS/SSL)
 
 #### SQLite Backend
@@ -478,7 +459,6 @@ public:
 ```
 database_base (abstract)
 ├── postgres_manager
-├── mysql_manager
 ├── sqlite_manager
 ├── mongodb_manager
 └── redis_manager
@@ -568,7 +548,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Options
 option(USE_POSTGRESQL "Enable PostgreSQL support" ON)
-option(USE_MYSQL "Enable MySQL support" OFF)
 option(USE_SQLITE "Enable SQLite support" OFF)
 option(USE_MONGODB "Enable MongoDB support" OFF)
 option(USE_REDIS "Enable Redis support" OFF)
@@ -579,10 +558,6 @@ option(BUILD_WITH_COMMON_SYSTEM "Build with common_system integration" OFF)
 # Find dependencies
 if(USE_POSTGRESQL)
     find_package(PostgreSQL REQUIRED)
-endif()
-
-if(USE_MYSQL)
-    find_package(MySQL REQUIRED)
 endif()
 
 if(USE_SQLITE)
@@ -670,7 +645,6 @@ endif()
       "inherits": "default",
       "cacheVariables": {
         "USE_POSTGRESQL": "ON",
-        "USE_MYSQL": "ON",
         "USE_SQLITE": "ON",
         "USE_MONGODB": "ON",
         "USE_REDIS": "ON"
@@ -696,7 +670,6 @@ endif()
 | Database | Library | Version | vcpkg Package |
 |----------|---------|---------|---------------|
 | PostgreSQL | libpqxx | 7.7+ | `libpqxx` |
-| MySQL | libmariadb | 3.x+ | `libmariadb` |
 | SQLite | sqlite3 | 3.40+ | `sqlite3` |
 | MongoDB | mongo-cxx-driver | 3.7+ | `mongo-cxx-driver` |
 | Redis | hiredis | 1.1+ | `hiredis` |
@@ -716,7 +689,7 @@ endif()
 **Using vcpkg**:
 ```bash
 # Install database libraries
-vcpkg install libpqxx openssl libmariadb sqlite3 mongo-cxx-driver hiredis
+vcpkg install libpqxx openssl sqlite3 mongo-cxx-driver hiredis
 
 # Install optional systems (if available)
 vcpkg install kcenon-common-system kcenon-thread-system

--- a/docs/README.kr.md
+++ b/docs/README.kr.md
@@ -71,7 +71,7 @@
 
 ### 지원 데이터베이스
 - ✅ **PostgreSQL** - 고급 기능 완전 지원
-- ✅ **MySQL/MariaDB** - 완전한 구현
+- 제거됨: **MySQL/MariaDB** 백엔드는 Issue #418에서 삭제되었으며 현재 빌드에서는 사용할 수 없습니다.
 - ✅ **SQLite** - 파일 및 인메모리 데이터베이스
 - ✅ **MongoDB** - 문서 작업 및 집계
 - ✅ **Redis** - 모든 데이터 타입 및 작업
@@ -194,11 +194,6 @@ Database System을 빌드하고 배포하는 데 필요한 모든 것:
 - API: [postgres_manager](API_REFERENCE.kr.md#database_base)
 - 예제: [PostgreSQL Advanced](SAMPLES_GUIDE.kr.md#postgresql-advanced-sample)
 - 성능: [PostgreSQL Benchmarks](PERFORMANCE_BENCHMARKS.kr.md#database-performance)
-
-**MySQL**
-- 빌드: [MySQL Dependencies](BUILD_GUIDE.kr.md#manual-installation)
-- 예제: [SQL Query Builder](SAMPLES_GUIDE.kr.md#sql-query-builder-examples)
-- 성능: [MySQL Performance](PERFORMANCE_BENCHMARKS.kr.md#database-performance)
 
 **SQLite**
 - 빌드: [SQLite Support](BUILD_GUIDE.kr.md#build-configurations)

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@
 **Last Updated:** 2025-11-11
 **Status:** Comprehensive
 
-Welcome to the database_system documentation! This unified database abstraction layer supports 5 backends (PostgreSQL, MySQL, SQLite, MongoDB, Redis) with enterprise-grade connection pooling and advanced query builders.
+Welcome to the database_system documentation! This unified database abstraction layer supports 4 backends (PostgreSQL, SQLite, MongoDB, Redis) with enterprise-grade connection pooling and advanced query builders. Legacy MySQL/MariaDB support was removed in Issue #418.
 
 ---
 
@@ -209,15 +209,6 @@ For contributors and maintainers:
 | Performance | [Benchmarks](performance/BENCHMARKS.md) - 1.2ms SELECT |
 | Tips | [Best Practices](guides/BEST_PRACTICES.md) - PostgreSQL-specific |
 
-### 🐬 MySQL
-
-| Topic | Document |
-|-------|----------|
-| Setup | [Build Guide](guides/BUILD_GUIDE.md) - MySQL dependencies |
-| Query Builder | [Samples Guide](guides/SAMPLES_GUIDE.md) - SQL query builder |
-| Performance | [Benchmarks](performance/BENCHMARKS.md) - MySQL metrics |
-| Tips | [Best Practices](guides/BEST_PRACTICES.md) - MySQL-specific |
-
 ### 🗄️ SQLite
 
 | Topic | Document |
@@ -257,13 +248,13 @@ For contributors and maintainers:
 
 ### Supported Databases
 - ✅ **PostgreSQL** - Full support with JSONB, CTEs, prepared statements
-- ✅ **MySQL/MariaDB** - Complete implementation with utf8mb4
+- Removed: **MySQL/MariaDB** backend support was deleted in Issue #418 to align dependency, SOUP, and license inventory.
 - ✅ **SQLite** - File and in-memory with WAL mode, FTS5
 - ✅ **MongoDB** - Document operations and aggregation pipeline
 - ✅ **Redis** - All data types with pipelining
 
 ### Key Features
-- 🔗 **Multi-Backend** - Unified interface for 5 database types
+- 🔗 **Multi-Backend** - Unified interface for 4 database types
 - 🏊 **Connection Pooling** - 0.1ms acquisition, 10K+ connections
 - 🔍 **Query Builders** - Type-safe SQL, MongoDB, Redis builders
 - 🗂️ **ORM Framework** - Entity mapping with type-safe CRUD

--- a/docs/advanced/TYPE_SYSTEM.md
+++ b/docs/advanced/TYPE_SYSTEM.md
@@ -8,7 +8,7 @@
 
 ## 📋 Overview
 
-The database_system uses a flexible type system to handle values across different database backends (PostgreSQL, MySQL, SQLite, MongoDB, Redis). This document explains when to use each type, how to convert between them, best practices, and performance implications.
+The database_system uses a flexible type system to handle values across different database backends (PostgreSQL, SQLite, MongoDB, Redis). This document explains when to use each type, how to convert between them, best practices, and performance implications.
 
 ---
 
@@ -143,12 +143,6 @@ PGresult* pg_result = ...;
 database_row row = convert_postgres_row(pg_result, row_index);
 ```
 
-#### MySQL
-```cpp
-// Uses MYSQL_ROW internally
-MYSQL_ROW mysql_row = ...;
-database_row row = convert_mysql_row(mysql_row, field_count);
-```
 
 #### SQLite
 ```cpp

--- a/docs/analysis/BACKEND_USAGE_ANALYSIS.md
+++ b/docs/analysis/BACKEND_USAGE_ANALYSIS.md
@@ -19,7 +19,7 @@ This document analyzes the usage patterns and maintenance considerations for Mon
 | GitHub Issues/PRs mentioning backends | Primarily maintenance/refactoring |
 | Code contribution to project | ~42% of backend code |
 
-**Recommendation**: Proceed with **Option B** (CMake Optional Modules) as the optimal balance between flexibility and maintenance.
+**Recommendation**: Proceed with **Option B** (CMake Optional Modules) as the optimal balance between flexibility and maintenance. Legacy MySQL backend support was removed in Issue #418; references below are historical unless explicitly tied to current manifests.
 
 ---
 
@@ -30,7 +30,7 @@ This document analyzes the usage patterns and maintenance considerations for Mon
 | Backend | Header (LOC) | Source (LOC) | Total (LOC) | % of Backends |
 |---------|--------------|--------------|-------------|---------------|
 | PostgreSQL | 180 | 630 | 810 | 21.3% |
-| MySQL | 171 | 520 | 691 | 18.1% |
+| Legacy MySQL | 171 | 520 | 691 | 18.1% |
 | SQLite | 178 | 537 | 715 | 18.8% |
 | **MongoDB** | 190 | 635 | 825 | **21.7%** |
 | **Redis** | 177 | 590 | 767 | **20.1%** |
@@ -57,7 +57,6 @@ This document analyzes the usage patterns and maintenance considerations for Mon
 {
   "features": {
     "postgresql": { "dependencies": ["libpq", "libpqxx", "openssl"] },
-    "mysql": { "dependencies": ["libmariadb"] },
     "sqlite": { "dependencies": ["sqlite3"] }
     // MongoDB and Redis: NOT DEFINED
   }
@@ -109,7 +108,6 @@ Files importing MongoDB/Redis backends:
 | Backend | Dedicated Test File | Integration Tests |
 |---------|--------------------|--------------------|
 | PostgreSQL | No | Yes (integration_tests.cpp) |
-| MySQL | No | Yes (integration_tests.cpp) |
 | SQLite | sqlite_backend_test.cpp | Yes |
 | **MongoDB** | **None** | **Partial** |
 | **Redis** | **None** | **Partial** |

--- a/docs/contributing/CI_CD_GUIDE.md
+++ b/docs/contributing/CI_CD_GUIDE.md
@@ -191,7 +191,6 @@ cmake -B build -G Ninja \
 
 **Backends Tested**:
 - PostgreSQL 15
-- MySQL 8.0
 - SQLite 3
 - MongoDB 6.0
 - Redis 7.0
@@ -385,12 +384,6 @@ docker run -d --name postgres-test \
   -e POSTGRES_PASSWORD=test \
   -p 5432:5432 postgres:15
 
-# MySQL
-docker run -d --name mysql-test \
-  -e MYSQL_ROOT_PASSWORD=test \
-  -e MYSQL_DATABASE=testdb \
-  -p 3306:3306 mysql:8.0
-
 # MongoDB
 docker run -d --name mongo-test \
   -p 27017:27017 mongo:6.0
@@ -405,7 +398,6 @@ docker run -d --name redis-test \
 cmake -B build -G Ninja \
   -DDATABASE_BUILD_INTEGRATION_TESTS=ON \
   -DUSE_POSTGRESQL=ON \
-  -DUSE_MYSQL=ON \
   -DUSE_SQLITE=ON \
   -DUSE_MONGODB=ON \
   -DUSE_REDIS=ON
@@ -417,8 +409,8 @@ ctest -R integration --output-on-failure
 
 **Cleanup**:
 ```bash
-docker stop postgres-test mysql-test mongo-test redis-test
-docker rm postgres-test mysql-test mongo-test redis-test
+docker stop postgres-test mongo-test redis-test
+docker rm postgres-test mongo-test redis-test
 ```
 
 ---

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -46,7 +46,6 @@ Before contributing, ensure you have:
 - Git
 - **Database-specific prerequisites**:
   - PostgreSQL development libraries (libpqxx, libpq, OpenSSL)
-  - MySQL development libraries (MariaDB Connector/C, LGPL-2.1)
   - SQLite development library (sqlite3)
   - MongoDB C++ driver (mongocxx, bsoncxx)
   - Redis client library (hiredis)
@@ -100,7 +99,7 @@ cd vcpkg
 bootstrap-vcpkg.bat   # Windows
 
 # Install all database dependencies
-vcpkg install libpqxx openssl libmariadb sqlite3 mongo-cxx-driver hiredis
+vcpkg install libpqxx openssl sqlite3 mongo-cxx-driver hiredis
 ```
 
 #### Manual Installation
@@ -110,7 +109,6 @@ vcpkg install libpqxx openssl libmariadb sqlite3 mongo-cxx-driver hiredis
 sudo apt-get update
 sudo apt-get install \
     libpqxx-dev libpq-dev libssl-dev \
-    libmariadb-dev \
     libsqlite3-dev \
     libmongocxx-dev libbsoncxx-dev \
     libhiredis-dev
@@ -118,7 +116,7 @@ sudo apt-get install \
 
 **macOS:**
 ```bash
-brew install libpqxx postgresql openssl mysql sqlite mongo-cxx-driver hiredis
+brew install libpqxx postgresql openssl sqlite mongo-cxx-driver hiredis
 ```
 
 **Windows:**
@@ -133,7 +131,6 @@ mkdir build && cd build
 # Configure with desired backends
 cmake .. \
     -DUSE_POSTGRESQL=ON \
-    -DUSE_MYSQL=ON \
     -DUSE_SQLITE=ON \
     -DUSE_MONGODB=ON \
     -DUSE_REDIS=ON \
@@ -238,7 +235,7 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/):
 
 **Scopes** (database_system specific):
 - `core`: Core database abstraction layer
-- `backend`: Database backend implementations (postgres, mysql, sqlite, mongodb, redis)
+- `backend`: Database backend implementations (postgres, sqlite, mongodb, redis)
 - `orm`: ORM framework
 - `pool`: Connection pooling
 - `query`: Query builders
@@ -324,7 +321,7 @@ public:
 
     /**
      * @brief Set the database backend type
-     * @param database_type Type of database (postgres, mysql, sqlite, etc.)
+     * @param database_type Type of database (postgres, sqlite, mongodb, redis, etc.)
      * @return true if successful, false otherwise
      */
     bool set_mode(const database_types& database_type);
@@ -413,10 +410,6 @@ cppcheck --enable=all --std=c++17 database/
 - Leverage JSONB for semi-structured data
 - Use CTEs for complex queries
 
-#### MySQL Backend
-- Use proper charset/collation (utf8mb4)
-- Implement connection pooling
-- Handle AUTO_INCREMENT properly
 
 #### SQLite Backend
 - Enable WAL mode for concurrent access
@@ -537,16 +530,6 @@ docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=test postgres
 ctest -R postgres_test
 ```
 
-#### MySQL Tests
-```bash
-# Ensure MySQL is running
-sudo systemctl start mysql
-# OR
-docker run -d -p 3306:3306 -e MYSQL_ROOT_PASSWORD=test mysql
-
-# Run MySQL-specific tests
-ctest -R mysql_test
-```
 
 #### SQLite Tests
 ```bash
@@ -727,7 +710,6 @@ Brief description of changes
 
 ## Backend Impact
 - [ ] PostgreSQL
-- [ ] MySQL
 - [ ] SQLite
 - [ ] MongoDB
 - [ ] Redis
@@ -884,11 +866,6 @@ Follows [Semantic Versioning](https://semver.org/):
 - Partition table support
 - Replication support
 
-#### MySQL
-- Full-text search enhancements
-- JSON column operations
-- Partition management
-- Replication support
 
 #### SQLite
 - Virtual table support

--- a/docs/guides/ASYNC_OPERATIONS.md
+++ b/docs/guides/ASYNC_OPERATIONS.md
@@ -560,7 +560,7 @@ auto txn_coord = context->get_transaction_coordinator();
 ```cpp
 // Participants: multiple database backends
 std::vector<std::shared_ptr<core::database_backend>> participants = {
-    postgres_backend, mysql_backend
+    postgres_backend, sqlite_backend
 };
 
 // Begin distributed transaction

--- a/docs/guides/BEST_PRACTICES.md
+++ b/docs/guides/BEST_PRACTICES.md
@@ -1071,44 +1071,6 @@ auto fts_result = db.create_query_builder(database::database_types::postgres)
     .execute(&db);
 ```
 
-### MySQL Best Practices
-
-**DO:** Use MySQL-specific optimizations and features.
-
-```cpp
-// Connection pooling for MySQL (similar to PostgreSQL)
-database::connection_pool_config mysql_config;
-mysql_config.min_connections = 5;
-mysql_config.max_connections = 50;
-mysql_config.connection_string = "host=localhost user=app dbname=mydb";
-db.create_connection_pool(database::database_types::mysql, mysql_config);
-
-// Use LOAD DATA for bulk inserts (fastest method)
-db.create_query(
-    "LOAD DATA LOCAL INFILE '/tmp/users.csv' "
-    "INTO TABLE users "
-    "FIELDS TERMINATED BY ',' "
-    "LINES TERMINATED BY '\\n' "
-    "(id, username, email)"
-);
-
-// Full-text search with MATCH/AGAINST
-db.create_query("CREATE FULLTEXT INDEX idx_content ON articles(content)");
-
-auto fts = db.create_query_builder(database::database_types::mysql)
-    .select({"id", "title", "MATCH(content) AGAINST('database' IN BOOLEAN MODE) as score"})
-    .from("articles")
-    .where_raw("MATCH(content) AGAINST('database' IN BOOLEAN MODE)")
-    .order_by("score", database::sort_order::desc)
-    .execute(&db);
-
-// JSON support
-db.create_query("CREATE TABLE configs (id INT, settings JSON)");
-db.insert_query(
-    "INSERT INTO configs VALUES (1, JSON_OBJECT('theme', 'dark', 'lang', 'en'))"
-);
-```
-
 ### SQLite Best Practices
 
 **DO:** Optimize SQLite for embedded and small-scale use cases.

--- a/docs/guides/BUILD_GUIDE.kr.md
+++ b/docs/guides/BUILD_GUIDE.kr.md
@@ -31,10 +31,11 @@
 데이터베이스 지원은 선택 사항이며 테스트를 위해 비활성화할 수 있습니다:
 
 - **PostgreSQL**: libpqxx, libpq, OpenSSL 3.0+
-- **MySQL**: MariaDB Connector/C (LGPL-2.1, MySQL 와이어 호환)
 - **SQLite**: sqlite3
 - **MongoDB**: mongo-cxx-driver (mongocxx, bsoncxx)
 - **Redis**: hiredis
+
+> Legacy MySQL/MariaDB 지원은 Issue #418에서 제거되었습니다. 현재 빌드는 `libmariadb`와 `USE_MYSQL`을 사용하지 않습니다.
 
 ## 빠른 시작
 
@@ -52,7 +53,7 @@ cd database_system
 mkdir build && cd build
 
 # 모의 구현으로 구성
-cmake .. -DUSE_POSTGRESQL=OFF -DUSE_MYSQL=OFF -DUSE_SQLITE=OFF -DUSE_MONGODB=OFF -DUSE_REDIS=OFF
+cmake .. -DUSE_POSTGRESQL=OFF -DUSE_SQLITE=OFF -DUSE_MONGODB=OFF -DUSE_REDIS=OFF
 
 # 빌드
 ninja  # 또는 make -j$(nproc)
@@ -67,7 +68,7 @@ ninja  # 또는 make -j$(nproc)
 ```bash
 # 의존성 설치 (데이터베이스 의존성 섹션 참조)
 # 그런 다음 전체 지원으로 구성
-cmake .. -DUSE_POSTGRESQL=ON -DUSE_MYSQL=ON -DUSE_SQLITE=ON -DUSE_MONGODB=ON -DUSE_REDIS=ON
+cmake .. -DUSE_POSTGRESQL=ON -DUSE_SQLITE=ON -DUSE_MONGODB=ON -DUSE_REDIS=ON
 
 # 빌드
 ninja
@@ -80,7 +81,6 @@ ninja
 | 옵션 | 기본값 | 설명 |
 |--------|---------|-------------|
 | `USE_POSTGRESQL` | ON | PostgreSQL 지원 활성화 (libpqxx 필요) |
-| `USE_MYSQL` | OFF | MySQL 지원 활성화 (MariaDB Connector/C 필요) |
 | `USE_SQLITE` | OFF | SQLite 지원 활성화 (sqlite3 필요) |
 | `USE_MONGODB` | OFF | MongoDB 지원 활성화 (mongocxx 필요) - **실험적** |
 | `USE_REDIS` | OFF | Redis 지원 활성화 (hiredis 필요) - **실험적** |
@@ -156,7 +156,6 @@ cmake .. -DCMAKE_BUILD_TYPE=MinSizeRel
 cmake .. \
   -DCMAKE_BUILD_TYPE=Debug \
   -DUSE_POSTGRESQL=ON \
-  -DUSE_MYSQL=ON \
   -DUSE_SQLITE=ON \
   -DBUILD_DATABASE_SAMPLES=ON \
   -DUSE_UNIT_TEST=ON
@@ -181,7 +180,6 @@ cmake .. \
 cmake .. \
   -DCMAKE_BUILD_TYPE=Debug \
   -DUSE_POSTGRESQL=OFF \
-  -DUSE_MYSQL=OFF \
   -DUSE_SQLITE=OFF \
   -DUSE_MONGODB=OFF \
   -DUSE_REDIS=OFF \
@@ -212,9 +210,6 @@ cd vcpkg
 # PostgreSQL 지원
 vcpkg install libpqxx openssl
 
-# MySQL 지원 (MariaDB Connector/C 사용)
-vcpkg install libmariadb
-
 # SQLite 지원
 vcpkg install sqlite3
 
@@ -225,7 +220,7 @@ vcpkg install mongo-cxx-driver
 vcpkg install hiredis
 
 # 한 번에 모두 설치
-vcpkg install libpqxx openssl libmariadb sqlite3 mongo-cxx-driver hiredis
+vcpkg install libpqxx openssl sqlite3 mongo-cxx-driver hiredis
 ```
 
 #### vcpkg로 빌드
@@ -234,7 +229,6 @@ vcpkg install libpqxx openssl libmariadb sqlite3 mongo-cxx-driver hiredis
 cmake .. \
   -DCMAKE_TOOLCHAIN_FILE=/path/to/vcpkg/scripts/buildsystems/vcpkg.cmake \
   -DUSE_POSTGRESQL=ON \
-  -DUSE_MYSQL=ON \
   -DUSE_SQLITE=ON \
   -DUSE_MONGODB=ON \
   -DUSE_REDIS=ON
@@ -247,9 +241,6 @@ cmake .. \
 ```bash
 # PostgreSQL
 sudo apt-get install libpqxx-dev libpq-dev libssl-dev
-
-# MySQL (MariaDB Connector/C 사용)
-sudo apt-get install libmariadb-dev
 
 # SQLite
 sudo apt-get install libsqlite3-dev
@@ -267,9 +258,6 @@ sudo apt-get install libhiredis-dev
 # PostgreSQL
 sudo dnf install libpqxx-devel postgresql-devel openssl-devel
 
-# MySQL (MariaDB Connector/C 사용)
-sudo dnf install mariadb-connector-c-devel
-
 # SQLite
 sudo dnf install sqlite-devel
 
@@ -285,9 +273,6 @@ sudo dnf install hiredis-devel
 ```bash
 # PostgreSQL
 brew install libpqxx postgresql openssl
-
-# MySQL (MariaDB Connector/C 사용)
-brew install mariadb-connector-c
 
 # SQLite
 brew install sqlite
@@ -485,7 +470,6 @@ otool -L bin/basic_usage  # macOS
 # 최소 빌드 - 핵심 기능만
 cmake .. \
   -DUSE_POSTGRESQL=OFF \
-  -DUSE_MYSQL=OFF \
   -DUSE_SQLITE=OFF \
   -DUSE_MONGODB=OFF \
   -DUSE_REDIS=OFF \
@@ -507,7 +491,7 @@ ninja install
 cmake .. \
   -DCMAKE_TOOLCHAIN_FILE=arm64-toolchain.cmake \
   -DUSE_POSTGRESQL=OFF \
-  -DUSE_MYSQL=OFF
+  -DUSE_SQLITE=OFF
 ```
 
 ### 환경 변수
@@ -560,7 +544,6 @@ cmake .. \
 {
     "cmake.configureSettings": {
         "USE_POSTGRESQL": "ON",
-        "USE_MYSQL": "ON",
         "USE_SQLITE": "ON",
         "CMAKE_BUILD_TYPE": "Debug"
     },
@@ -573,7 +556,7 @@ cmake .. \
 Settings → Build, Execution, Deployment → CMake에서 CMake 옵션 구성:
 
 ```
--DUSE_POSTGRESQL=ON -DUSE_MYSQL=ON -DUSE_SQLITE=ON
+-DUSE_POSTGRESQL=ON -DUSE_SQLITE=ON
 ```
 
 #### Visual Studio
@@ -591,7 +574,7 @@ vcpkg와 함께 CMake 통합 사용:
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "${projectDir}\\build\\${name}",
       "installRoot": "${projectDir}\\install\\${name}",
-      "cmakeCommandArgs": "-DUSE_POSTGRESQL=ON -DUSE_MYSQL=ON",
+      "cmakeCommandArgs": "-DUSE_POSTGRESQL=ON -DUSE_SQLITE=ON",
       "ctestCommandArgs": "",
       "variables": [
         {
@@ -662,7 +645,6 @@ RUN apt-get update && apt-get install -y \
     ninja-build \
     git \
     libpqxx-dev \
-    libmariadb-dev \
     libsqlite3-dev \
     && rm -rf /var/lib/apt/lists/*
 
@@ -671,7 +653,7 @@ COPY . .
 
 RUN mkdir build && cd build && \
     cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release \
-    -DUSE_POSTGRESQL=ON -DUSE_MYSQL=ON -DUSE_SQLITE=ON && \
+    -DUSE_POSTGRESQL=ON -DUSE_SQLITE=ON && \
     ninja
 
 CMD ["./build/bin/basic_usage"]

--- a/docs/guides/BUILD_GUIDE.md
+++ b/docs/guides/BUILD_GUIDE.md
@@ -31,10 +31,11 @@ Comprehensive guide for building the Database System with multi-backend support,
 Database support is optional and can be disabled for testing:
 
 - **PostgreSQL**: libpqxx, libpq, OpenSSL 3.0+
-- **MySQL**: MariaDB Connector/C (LGPL-2.1, wire-compatible with MySQL)
 - **SQLite**: sqlite3
 - **MongoDB**: mongo-cxx-driver (mongocxx, bsoncxx)
 - **Redis**: hiredis
+
+> Legacy MySQL/MariaDB support was removed in Issue #418. Current builds do not use `libmariadb` or `USE_MYSQL`.
 
 ## Quick Start
 
@@ -52,7 +53,7 @@ cd database_system
 mkdir build && cd build
 
 # Configure with mock implementations
-cmake .. -DUSE_POSTGRESQL=OFF -DUSE_MYSQL=OFF -DUSE_SQLITE=OFF -DUSE_MONGODB=OFF -DUSE_REDIS=OFF
+cmake .. -DUSE_POSTGRESQL=OFF -DUSE_SQLITE=OFF -DUSE_MONGODB=OFF -DUSE_REDIS=OFF
 
 # Build
 ninja  # or make -j$(nproc)
@@ -67,7 +68,7 @@ ninja  # or make -j$(nproc)
 ```bash
 # Install dependencies (see Database Dependencies section)
 # Then configure with full support
-cmake .. -DUSE_POSTGRESQL=ON -DUSE_MYSQL=ON -DUSE_SQLITE=ON -DUSE_MONGODB=ON -DUSE_REDIS=ON
+cmake .. -DUSE_POSTGRESQL=ON -DUSE_SQLITE=ON -DUSE_MONGODB=ON -DUSE_REDIS=ON
 
 # Build
 ninja
@@ -80,7 +81,6 @@ ninja
 | Option | Default | Description |
 |--------|---------|-------------|
 | `USE_POSTGRESQL` | ON | Enable PostgreSQL support (requires libpqxx) |
-| `USE_MYSQL` | OFF | Enable MySQL support (requires MariaDB Connector/C) |
 | `USE_SQLITE` | OFF | Enable SQLite support (requires sqlite3) |
 | `USE_MONGODB` | OFF | Enable MongoDB support (requires mongocxx) - **Experimental** |
 | `USE_REDIS` | OFF | Enable Redis support (requires hiredis) - **Experimental** |
@@ -156,7 +156,6 @@ cmake .. -DCMAKE_BUILD_TYPE=MinSizeRel
 cmake .. \
   -DCMAKE_BUILD_TYPE=Debug \
   -DUSE_POSTGRESQL=ON \
-  -DUSE_MYSQL=ON \
   -DUSE_SQLITE=ON \
   -DBUILD_DATABASE_SAMPLES=ON \
   -DUSE_UNIT_TEST=ON
@@ -181,7 +180,6 @@ cmake .. \
 cmake .. \
   -DCMAKE_BUILD_TYPE=Debug \
   -DUSE_POSTGRESQL=OFF \
-  -DUSE_MYSQL=OFF \
   -DUSE_SQLITE=OFF \
   -DUSE_MONGODB=OFF \
   -DUSE_REDIS=OFF \
@@ -212,9 +210,6 @@ cd vcpkg
 # PostgreSQL support
 vcpkg install libpqxx openssl
 
-# MySQL support (via MariaDB Connector/C)
-vcpkg install libmariadb
-
 # SQLite support
 vcpkg install sqlite3
 
@@ -225,7 +220,7 @@ vcpkg install mongo-cxx-driver
 vcpkg install hiredis
 
 # Install all at once
-vcpkg install libpqxx openssl libmariadb sqlite3 mongo-cxx-driver hiredis
+vcpkg install libpqxx openssl sqlite3 mongo-cxx-driver hiredis
 ```
 
 #### Build with vcpkg
@@ -234,7 +229,6 @@ vcpkg install libpqxx openssl libmariadb sqlite3 mongo-cxx-driver hiredis
 cmake .. \
   -DCMAKE_TOOLCHAIN_FILE=/path/to/vcpkg/scripts/buildsystems/vcpkg.cmake \
   -DUSE_POSTGRESQL=ON \
-  -DUSE_MYSQL=ON \
   -DUSE_SQLITE=ON \
   -DUSE_MONGODB=ON \
   -DUSE_REDIS=ON
@@ -247,9 +241,6 @@ cmake .. \
 ```bash
 # PostgreSQL
 sudo apt-get install libpqxx-dev libpq-dev libssl-dev
-
-# MySQL (via MariaDB Connector/C)
-sudo apt-get install libmariadb-dev
 
 # SQLite
 sudo apt-get install libsqlite3-dev
@@ -267,9 +258,6 @@ sudo apt-get install libhiredis-dev
 # PostgreSQL
 sudo dnf install libpqxx-devel postgresql-devel openssl-devel
 
-# MySQL (via MariaDB Connector/C)
-sudo dnf install mariadb-connector-c-devel
-
 # SQLite
 sudo dnf install sqlite-devel
 
@@ -285,9 +273,6 @@ sudo dnf install hiredis-devel
 ```bash
 # PostgreSQL
 brew install libpqxx postgresql openssl
-
-# MySQL (via MariaDB Connector/C)
-brew install mariadb-connector-c
 
 # SQLite
 brew install sqlite
@@ -485,7 +470,6 @@ otool -L bin/basic_usage  # macOS
 # Minimal build - only core functionality
 cmake .. \
   -DUSE_POSTGRESQL=OFF \
-  -DUSE_MYSQL=OFF \
   -DUSE_SQLITE=OFF \
   -DUSE_MONGODB=OFF \
   -DUSE_REDIS=OFF \
@@ -507,7 +491,7 @@ ninja install
 cmake .. \
   -DCMAKE_TOOLCHAIN_FILE=arm64-toolchain.cmake \
   -DUSE_POSTGRESQL=OFF \
-  -DUSE_MYSQL=OFF
+  -DUSE_SQLITE=OFF
 ```
 
 ### Environment Variables
@@ -560,7 +544,6 @@ cmake .. \
 {
     "cmake.configureSettings": {
         "USE_POSTGRESQL": "ON",
-        "USE_MYSQL": "ON",
         "USE_SQLITE": "ON",
         "CMAKE_BUILD_TYPE": "Debug"
     },
@@ -573,7 +556,7 @@ cmake .. \
 Configure CMake options in Settings → Build, Execution, Deployment → CMake:
 
 ```
--DUSE_POSTGRESQL=ON -DUSE_MYSQL=ON -DUSE_SQLITE=ON
+-DUSE_POSTGRESQL=ON -DUSE_SQLITE=ON
 ```
 
 #### Visual Studio
@@ -591,7 +574,7 @@ Use the CMake integration with vcpkg:
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "${projectDir}\\build\\${name}",
       "installRoot": "${projectDir}\\install\\${name}",
-      "cmakeCommandArgs": "-DUSE_POSTGRESQL=ON -DUSE_MYSQL=ON",
+      "cmakeCommandArgs": "-DUSE_POSTGRESQL=ON -DUSE_SQLITE=ON",
       "ctestCommandArgs": "",
       "variables": [
         {
@@ -662,7 +645,6 @@ RUN apt-get update && apt-get install -y \
     ninja-build \
     git \
     libpqxx-dev \
-    libmariadb-dev \
     libsqlite3-dev \
     && rm -rf /var/lib/apt/lists/*
 
@@ -671,7 +653,7 @@ COPY . .
 
 RUN mkdir build && cd build && \
     cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release \
-    -DUSE_POSTGRESQL=ON -DUSE_MYSQL=ON -DUSE_SQLITE=ON && \
+    -DUSE_POSTGRESQL=ON -DUSE_SQLITE=ON && \
     ninja
 
 CMD ["./build/bin/basic_usage"]

--- a/docs/guides/FAQ.md
+++ b/docs/guides/FAQ.md
@@ -30,7 +30,7 @@
 **A:** database_system requires:
 - C++ compiler with C++17 support or higher (C++20 for async features)
 - CMake 3.16 or higher
-- Optional: Database client libraries (PostgreSQL, MySQL, SQLite, MongoDB, Redis)
+- Optional: Database client libraries (PostgreSQL, SQLite, MongoDB, Redis)
 
 Supported platforms:
 - macOS 10.15+
@@ -54,7 +54,6 @@ cd vcpkg && ./bootstrap-vcpkg.sh
 
 # Install database dependencies (optional)
 vcpkg install libpqxx openssl  # PostgreSQL
-vcpkg install libmariadb        # MySQL (via MariaDB Connector/C)
 vcpkg install sqlite3           # SQLite
 vcpkg install mongo-cxx-driver  # MongoDB
 vcpkg install hiredis           # Redis
@@ -65,7 +64,7 @@ vcpkg install hiredis           # Redis
 git clone https://github.com/kcenon/database_system.git
 cd database_system
 mkdir build && cd build
-cmake .. -DUSE_POSTGRESQL=ON -DUSE_MYSQL=ON -DUSE_SQLITE=ON
+cmake .. -DUSE_POSTGRESQL=ON -DUSE_SQLITE=ON
 cmake --build .
 sudo cmake --install .
 ```
@@ -102,7 +101,6 @@ cmake -DCMAKE_CXX_COMPILER=g++-7 ..
 ```bash
 cmake .. \
   -DUSE_POSTGRESQL=OFF \
-  -DUSE_MYSQL=OFF \
   -DUSE_SQLITE=OFF \
   -DUSE_MONGODB=OFF \
   -DUSE_REDIS=OFF
@@ -181,7 +179,7 @@ For more details, see [Quick Start Guide](../BUILD_GUIDE.md).
 
 4. **Content management**: Large-scale content storage and retrieval
    - BLOB storage with serialization
-   - Full-text search (MySQL, PostgreSQL)
+   - Full-text search (PostgreSQL)
    - GridFS for large files (MongoDB)
 
 5. **Gaming platforms**: Player data persistence with real-time features
@@ -229,12 +227,11 @@ auto db_mgr = std::make_shared<database_manager>(context);
 
 ### Q: Which database backends are supported?
 
-**A:** database_system supports 5 backends:
+**A:** database_system supports 4 backends. Legacy MySQL/MariaDB support was removed in Issue #418:
 
 | Backend | Use Case | Performance | ORM | TLS/SSL |
 |---------|----------|-------------|-----|---------|
 | **PostgreSQL** | OLTP, Analytics | Excellent | ✅ | ✅ |
-| **MySQL** | Web apps, Full-text | Very Good | ✅ | ✅ |
 | **SQLite** | Embedded, Testing | Good | ✅ | ✅ |
 | **MongoDB** | Documents, NoSQL | Very Good | ✅ | ✅ |
 | **Redis** | Caching, Sessions | Excellent | ✅ | ✅ |
@@ -321,7 +318,7 @@ void migrate_data(database_manager& source_db, database_manager& target_db) {
     auto data = source_db.select_query("SELECT * FROM users");
 
     // Import to target
-    target_db.set_mode(database_types::mysql);
+    target_db.set_mode(database_types::sqlite);
     for (const auto& row : data) {
         // Convert and insert data
         target_db.execute_query(
@@ -625,12 +622,6 @@ db->begin_transaction();
 db->commit();
 ```
 
-**MySQL**:
-- READ UNCOMMITTED
-- READ COMMITTED
-- REPEATABLE READ (default)
-- SERIALIZABLE
-
 **SQLite**:
 - DEFERRED
 - IMMEDIATE
@@ -913,7 +904,7 @@ for (auto& t : threads) {
 3. **Dependencies**: Ensure all dependencies are installed
    ```bash
    cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON
-   # Check if libpqxx, libmariadb, sqlite3, etc. are found
+   # Check if libpqxx, sqlite3, mongo-cxx-driver, and hiredis are found
    ```
 
 4. **C++ Standard**: Verify C++17 is enabled
@@ -1202,7 +1193,6 @@ backend_registry (Singleton)
     │
     ├── backend_factory (Factory Pattern)
     │   ├── "postgresql" → postgresql_backend
-    │   ├── "mysql" → mysql_backend
     │   ├── "sqlite" → sqlite_backend
     │   ├── "mongodb" → mongodb_backend
     │   └── "redis" → redis_backend
@@ -1419,7 +1409,6 @@ cmake .. \
 cmake .. \
   -DCMAKE_BUILD_TYPE=MinSizeRel \
   -DUSE_POSTGRESQL=OFF \
-  -DUSE_MYSQL=OFF \
   -DUSE_SQLITE=ON \
   -DBUILD_DATABASE_SAMPLES=OFF
 ```
@@ -1455,18 +1444,18 @@ cmake .. \
 
 1. database_system version
 2. Compiler and platform (GCC 7, Ubuntu 20.04, etc.)
-3. Database backend (PostgreSQL 13, MySQL 8, etc.)
+3. Database backend (PostgreSQL 13, SQLite 3, MongoDB 6, etc.)
 4. Minimal reproduction case
 5. Expected vs actual behavior
 
 **Example bug report**:
 ```
-Title: Connection pool deadlock with MySQL backend
+Title: Connection pool deadlock with PostgreSQL backend
 
 Environment:
 - database_system: v1.0
 - Compiler: GCC 10.2, Ubuntu 20.04
-- Database: MySQL 8.0
+- Database: PostgreSQL 15
 
 Reproduction:
 1. Create connection pool with max_connections=5

--- a/docs/guides/INTEGRATION.md
+++ b/docs/guides/INTEGRATION.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-This comprehensive guide describes how to integrate database_system with other modules in the ecosystem. Database System provides a unified abstraction layer for multiple database backends (PostgreSQL, MySQL, SQLite, MongoDB, Redis) that seamlessly integrates with other system components.
+This comprehensive guide describes how to integrate database_system with other modules in the ecosystem. Database System provides a unified abstraction layer for multiple database backends (PostgreSQL, SQLite, MongoDB, Redis) that seamlessly integrates with other system components.
 
 **Version:** 0.1.0.0
 **Last Updated:** 2025-10-22
@@ -113,7 +113,7 @@ add_executable(your_app main.cpp)
 
 target_link_libraries(your_app PRIVATE
     kcenon::database_system
-    PostgreSQL::PostgreSQL  # Or MySQL::MySQL, SQLite::SQLite3
+    PostgreSQL::PostgreSQL  # Or SQLite::SQLite3
 )
 ```
 
@@ -145,7 +145,7 @@ Database System provides a unified interface across multiple database backends:
         ┌──────────────┼──────────────┐
         │              │              │
 ┌───────▼─────┐ ┌──────▼────┐ ┌──────▼────┐
-│ PostgreSQL  │ │   MySQL   │ │  SQLite   │
+│ PostgreSQL  │ │  SQLite   │ │ MongoDB   │
 │  Backend    │ │  Backend  │ │  Backend  │
 └─────────────┘ └───────────┘ └───────────┘
         │              │              │
@@ -709,7 +709,6 @@ target_link_libraries(your_app PRIVATE
 ```cmake
 # Database system options
 option(BUILD_WITH_POSTGRESQL "Enable PostgreSQL support" ON)
-option(BUILD_WITH_MYSQL "Enable MySQL support" OFF)
 option(BUILD_WITH_SQLITE "Enable SQLite support" OFF)
 option(BUILD_WITH_MONGODB "Enable MongoDB support" OFF)
 option(BUILD_WITH_REDIS "Enable Redis support" OFF)
@@ -791,22 +790,6 @@ auto result = db->execute_query(
 auto json_result = db->execute_query(
     "SELECT data FROM products WHERE data->>'category' = $1",
     "electronics"
-);
-```
-
-### MySQL
-
-```cpp
-#include <database/mysql_manager.h>
-
-auto db = database_system::create_mysql_manager(
-    "host=localhost;database=mydb;user=myuser;password=mypass"
-);
-
-// MySQL-specific features
-auto result = db->execute_query(
-    "SELECT * FROM users WHERE id = ?",
-    42
 );
 ```
 

--- a/docs/guides/QUICK_START.kr.md
+++ b/docs/guides/QUICK_START.kr.md
@@ -26,7 +26,6 @@ Database System을 5분 만에 시작하세요.
 ### 데이터베이스 백엔드 (최소 하나 필요)
 
 - PostgreSQL 12+
-- MySQL 8.0+
 - SQLite 3.35+
 - MongoDB 5.0+
 - Redis 6.0+
@@ -107,7 +106,7 @@ int main() {
 
 ```cpp
 auto db = unified_database_system::create_builder()
-    .set_backend_type(backend_type::postgresql)  // 또는 mysql, sqlite
+    .set_backend_type(backend_type::postgresql)  // 또는 sqlite
     .enable_logging(db_log_level::info, "./logs")
     .set_pool_size(5, 20)
     .build();

--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -9,7 +9,7 @@ Get started with database_system in 5 minutes.
 
 - C++17 or higher compiler
 - CMake 3.16+
-- PostgreSQL, MySQL, or SQLite installed (optional for demo)
+- PostgreSQL or SQLite installed (optional for demo)
 
 ## Installation
 
@@ -90,7 +90,7 @@ cmake --build .
 
 ```cpp
 auto db = unified_database_system::create_builder()
-    .set_backend_type(backend_type::postgresql)  // or mysql, sqlite
+    .set_backend_type(backend_type::postgresql)  // or sqlite
     .enable_logging(db_log_level::info, "./logs")
     .set_pool_size(5, 20)
     .build();

--- a/docs/guides/SAMPLES_GUIDE.kr.md
+++ b/docs/guides/SAMPLES_GUIDE.kr.md
@@ -593,7 +593,6 @@ void multi_database_example()
 
         switch (db_type) {
             case database::database_types::postgres:
-            case database::database_types::mysql:
             case database::database_types::sqlite:
                 query.select({"id", "name", "email"})
                      .from("users")
@@ -621,7 +620,6 @@ void multi_database_example()
 
     // 모든 데이터베이스 유형에 대해 시연
     demonstrate_select(database::database_types::postgres, "PostgreSQL");
-    demonstrate_select(database::database_types::mysql, "MySQL");
     demonstrate_select(database::database_types::sqlite, "SQLite");
     demonstrate_select(database::database_types::mongodb, "MongoDB");
     demonstrate_select(database::database_types::redis, "Redis");
@@ -633,9 +631,6 @@ void multi_database_example()
 ```
 --- PostgreSQL Example ---
 Query: SELECT "id", "name", "email" FROM "users" WHERE status = 'active' LIMIT 5
-
---- MySQL Example ---
-Query: SELECT `id`, `name`, `email` FROM `users` WHERE status = 'active' LIMIT 5
 
 --- SQLite Example ---
 Query: SELECT [id], [name], [email] FROM [users] WHERE status = 'active' LIMIT 5
@@ -734,8 +729,6 @@ void query_builder_best_practices()
     // 3. 적절한 데이터베이스별 기능 사용
     if (db.database_type() == database::database_types::postgres) {
         query.where_raw("metadata @> '{\"premium\": true}'");  // PostgreSQL JSON
-    } else if (db.database_type() == database::database_types::mysql) {
-        query.where_raw("JSON_EXTRACT(metadata, '$.premium') = true");  // MySQL JSON
     }
 
     // 4. 빌더 재설정 및 재사용

--- a/docs/guides/SAMPLES_GUIDE.md
+++ b/docs/guides/SAMPLES_GUIDE.md
@@ -593,7 +593,6 @@ void multi_database_example()
 
         switch (db_type) {
             case database::database_types::postgres:
-            case database::database_types::mysql:
             case database::database_types::sqlite:
                 query.select({"id", "name", "email"})
                      .from("users")
@@ -621,7 +620,6 @@ void multi_database_example()
 
     // Demonstrate across all database types
     demonstrate_select(database::database_types::postgres, "PostgreSQL");
-    demonstrate_select(database::database_types::mysql, "MySQL");
     demonstrate_select(database::database_types::sqlite, "SQLite");
     demonstrate_select(database::database_types::mongodb, "MongoDB");
     demonstrate_select(database::database_types::redis, "Redis");
@@ -633,9 +631,6 @@ void multi_database_example()
 ```
 --- PostgreSQL Example ---
 Query: SELECT "id", "name", "email" FROM "users" WHERE status = 'active' LIMIT 5
-
---- MySQL Example ---
-Query: SELECT `id`, `name`, `email` FROM `users` WHERE status = 'active' LIMIT 5
 
 --- SQLite Example ---
 Query: SELECT [id], [name], [email] FROM [users] WHERE status = 'active' LIMIT 5
@@ -734,8 +729,6 @@ void query_builder_best_practices()
     // 3. Use appropriate database-specific features
     if (db.database_type() == database::database_types::postgres) {
         query.where_raw("metadata @> '{\"premium\": true}'");  // PostgreSQL JSON
-    } else if (db.database_type() == database::database_types::mysql) {
-        query.where_raw("JSON_EXTRACT(metadata, '$.premium') = true");  // MySQL JSON
     }
 
     // 4. Reset and reuse builders

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -111,7 +111,6 @@ cmake .. -DCMAKE_TOOLCHAIN_FILE=/path/to/vcpkg/scripts/buildsystems/vcpkg.cmake
 | Backend | Package | Ubuntu | macOS |
 |---------|---------|--------|-------|
 | PostgreSQL | libpqxx | libpqxx-dev | libpqxx |
-| MySQL | libmariadb | libmariadb-dev | mariadb-connector-c |
 | SQLite | sqlite3 | libsqlite3-dev | sqlite |
 | MongoDB | mongocxx | libmongocxx-dev | mongo-cxx-driver |
 | Redis | hiredis | libhiredis-dev | hiredis |
@@ -198,7 +197,6 @@ bool success = db.connect("host=localhost port=5432 dbname=testdb");
 ```bash
 # Check if server is running
 psql -U postgres -h localhost -p 5432 -c "SELECT 1"  # PostgreSQL
-mysql -u root -h localhost                            # MySQL
 sqlite3 /path/to/database.db "SELECT 1;"            # SQLite
 
 # Check network connectivity
@@ -210,7 +208,6 @@ sudo netstat -tulpn | grep LISTEN | grep 5432
 
 # View system logs
 journalctl -u postgresql -n 50  # PostgreSQL service logs
-tail -f /var/log/mysql/error.log # MySQL error log
 ```
 
 **Solution**:
@@ -257,20 +254,6 @@ sudo -u postgres psql
 postgres=# ALTER USER postgres WITH PASSWORD 'new_password';
 ```
 
-2. **MySQL**:
-```bash
-# Test connection
-mysql -u root -p -h localhost
-
-# Reset root password
-sudo mysql_secure_installation
-
-# Create new user
-mysql -u root -p
-mysql> CREATE USER 'dbuser'@'localhost' IDENTIFIED BY 'password';
-mysql> GRANT ALL PRIVILEGES ON testdb.* TO 'dbuser'@'localhost';
-mysql> FLUSH PRIVILEGES;
-```
 
 3. **Code Configuration**:
 ```cpp
@@ -520,8 +503,6 @@ std::cout << "Average latency: " << query_latency << "ms" << std::endl;
 CREATE INDEX idx_users_id ON users(id);
 CREATE INDEX idx_orders_user_id ON orders(user_id);
 
--- MySQL
-ALTER TABLE users ADD INDEX idx_id (id);
 
 -- SQLite
 CREATE INDEX idx_users_id ON users(id);
@@ -642,40 +623,6 @@ cat /etc/postgresql/*/main/pg_hba.conf
 std::string grant_sql =
     "GRANT TEMPORARY ON DATABASE testdb TO postgres";
 db.create_query(grant_sql);
-```
-
----
-
-### MySQL Issues
-
-**Lost connection during query**:
-```cpp
-// Implement reconnection logic
-bool execute_with_retry(const std::string& query, int max_retries = 3) {
-    for (int i = 0; i < max_retries; ++i) {
-        try {
-            db.insert_query(query);
-            return true;
-        } catch (const std::exception& e) {
-            if (i < max_retries - 1) {
-                db.disconnect();
-                std::this_thread::sleep_for(std::chrono::milliseconds(500 * i));
-                db.connect(connection_string);
-            }
-        }
-    }
-    return false;
-}
-```
-
-**Incorrect datetime conversion**:
-```cpp
-// Use ISO 8601 format for compatibility
-auto query = "INSERT INTO events(event_time) VALUES('2025-11-11T10:30:00')";
-db.insert_query(query);
-
-// Better: Use prepared statements
-auto formatted_time = std::format("{:%FT%T}", current_time);
 ```
 
 ---
@@ -905,7 +852,6 @@ cmake --version
 
 # Test database connectivity
 psql --version
-mysql --version
 sqlite3 --version
 
 # Check library availability
@@ -927,7 +873,6 @@ make 2>&1 | tee build.log
 
 # Database version
 psql --version
-mysql --version
 ```
 
 3. **Try minimal reproduction**:

--- a/docs/guides/UNIFIED_SYSTEM.md
+++ b/docs/guides/UNIFIED_SYSTEM.md
@@ -103,7 +103,7 @@ The **unified database system** (`database/integrated/`) is the top-level integr
 ├──────────────────┴──────────────────┴───────────────────────────┤
 │           connection_string_builder  │  connection_pool         │
 ├─────────────────────────────────────────────────────────────────┤
-│           Database Backends (postgres, mysql, sqlite, ...)      │
+│           Database Backends (postgres, sqlite, mongodb, redis)  │
 ├─────────────────────────────────────────────────────────────────┤
 │           Protocol Layer (binary message serialization)         │
 └─────────────────────────────────────────────────────────────────┘
@@ -194,7 +194,6 @@ auto config = unified_db_config{}
 | Value | Description |
 |-------|-------------|
 | `postgres` | PostgreSQL database |
-| `mysql` | MySQL/MariaDB database |
 | `sqlite` | SQLite embedded database |
 | `mongodb` | MongoDB NoSQL database |
 | `redis` | Redis key-value store |
@@ -300,7 +299,6 @@ The `connection_string_builder` provides a type-safe, fluent API for constructin
 | Backend | Required Fields | Output Format |
 |---------|-----------------|---------------|
 | PostgreSQL | host (recommended) | `host=... port=... dbname=... user=... password=...` |
-| MySQL | host (recommended) | `host=...;port=...;database=...;user=...;password=...` |
 | SQLite | database (or `in_memory()`) | `path/to/db.sqlite` or `:memory:` |
 | MongoDB | host | MongoDB URI format |
 | Redis | host | Redis connection format |
@@ -1073,16 +1071,6 @@ void demonstrate_builders() {
     //    password=secret sslmode=verify-full connect_timeout=10
     //    application_name=my-service"
 
-    // MySQL
-    auto mysql = connection_string_builder()
-        .host("mysql.example.com")
-        .port(3306)
-        .database("appdb")
-        .user("root")
-        .password("secret")
-        .build(backend_type::mysql);
-    // → "host=mysql.example.com;port=3306;database=appdb;user=root;
-    //    password=secret"
 
     // SQLite file-based
     auto sqlite_file = connection_string_builder()

--- a/docs/performance/BASELINE.kr.md
+++ b/docs/performance/BASELINE.kr.md
@@ -62,7 +62,7 @@
 - ✅ **5,000 TPS** (PostgreSQL)
 - ✅ **10,000+ 동시 연결**
 - ✅ **0.1 ms connection pooling**
-- ✅ **Multi-backend 지원** (PostgreSQL, MySQL, SQLite, MongoDB, Redis)
+- ✅ **Multi-backend 지원** (PostgreSQL, SQLite, MongoDB, Redis)
 - ✅ **Enterprise 보안** (TLS/SSL, RBAC)
 
 ---

--- a/docs/performance/BASELINE.md
+++ b/docs/performance/BASELINE.md
@@ -31,7 +31,7 @@ This document serves as both the baseline performance metrics and the benchmark 
 - **Build Type**: Release (-O3)
 - **C++ Standard**: C++20
 - **CMake Version**: 3.16+
-- **Database Backends**: PostgreSQL, MySQL, SQLite, MongoDB, Redis
+- **Database Backends**: PostgreSQL, SQLite, MongoDB, Redis
 
 ### Test Database Setup
 - **Database**: In-memory SQLite (for consistent benchmarks)
@@ -247,7 +247,6 @@ This document serves as both the baseline performance metrics and the benchmark 
 |---------|-------------|-------------|-------------|-------|
 | SQLite | 800 | TBD | TBD | In-memory |
 | PostgreSQL | 1200 | TBD | TBD | Local server |
-| MySQL | TBD | TBD | TBD | Local server |
 | MongoDB | TBD | TBD | TBD | Document store |
 | Redis | 300 | TBD | TBD | Key-value store |
 
@@ -292,7 +291,7 @@ This document serves as both the baseline performance metrics and the benchmark 
 - ✅ **5,000 TPS** (PostgreSQL)
 - ✅ **10,000+ concurrent connections**
 - ✅ **0.1 ms connection pooling**
-- ✅ **Multi-backend support** (PostgreSQL, MySQL, SQLite, MongoDB, Redis)
+- ✅ **Multi-backend support** (PostgreSQL, SQLite, MongoDB, Redis)
 - ✅ **Enterprise security** (TLS/SSL, RBAC)
 
 ---

--- a/docs/performance/TUNING_GUIDE.md
+++ b/docs/performance/TUNING_GUIDE.md
@@ -12,7 +12,7 @@ for the Database System across different backends and use cases.
 | Workload Type | Recommended Backend | Rationale |
 |---------------|---------------------|-----------|
 | Read-heavy OLTP | PostgreSQL | Superior indexing, parallel queries |
-| Write-heavy OLTP | MySQL (InnoDB) | Efficient transaction batching |
+| Write-heavy OLTP | PostgreSQL | Strong WAL-based throughput and mature operational tooling |
 | Embedded/Local | SQLite | Zero configuration, in-process |
 | Complex Analytics | PostgreSQL | Advanced query planner |
 | Simple Key-Value | SQLite | Minimal overhead |
@@ -23,7 +23,6 @@ for the Database System across different backends and use cases.
 Benchmark: 10,000 mixed operations (70% read, 30% write)
 
 PostgreSQL:  850 ops/sec  (best for complex queries)
-MySQL:       920 ops/sec  (best for simple writes)
 SQLite:     1200 ops/sec  (best for embedded use)
 ```
 
@@ -117,141 +116,8 @@ checkpoint_completion_target = 0.9
 - Use GIN for full-text search
 - Use BRIN for large, naturally ordered tables
 
-### MySQL
-
-**Key Settings:**
-```ini
-# InnoDB settings
-innodb_buffer_pool_size = 1G  # 70-80% of RAM
-innodb_log_file_size = 256M
-innodb_flush_log_at_trx_commit = 2  # Performance vs durability
-
-# Query cache (MySQL 5.7)
-query_cache_type = 1
-query_cache_size = 64M
-```
-
-**Index Strategy:**
-- Use covering indexes for read-heavy queries
-- Consider composite indexes for multi-column WHERE
-- Use EXPLAIN to verify index usage
-
-### SQLite
-
-**Key Settings:**
-```cpp
-db->execute_query("PRAGMA journal_mode = WAL");
-db->execute_query("PRAGMA synchronous = NORMAL");
-db->execute_query("PRAGMA cache_size = -64000");  // 64MB
-db->execute_query("PRAGMA temp_store = MEMORY");
-```
-
-**Best Practices:**
-- Use WAL mode for concurrent read/write
-- Batch writes in transactions
-- Vacuum periodically for large databases
-
-## Caching Strategy
-
-### Query Result Caching
-
-```cpp
-cache_config cache;
-cache.enabled = true;
-cache.max_entries = 10000;
-cache.default_ttl = std::chrono::seconds(300);
-
-// Cache invalidation patterns
-cache.invalidate_on_write = true;
-cache.table_tracking = true;
-
-gateway.configure_caching(cache);
-```
-
-### Cache Size Guidelines
-
-| Dataset Size | Recommended Cache Size |
-|--------------|------------------------|
-| < 100MB | Cache entire result set |
-| 100MB - 1GB | 10-20% of dataset |
-| > 1GB | Monitor hit rate, adjust |
-
-## Monitoring and Diagnostics
-
-### Key Metrics to Monitor
-
-1. **Connection Pool**
-   - Active connections
-   - Wait time for connections
-   - Connection creation rate
-
-2. **Query Performance**
-   - Average query latency
-   - Slow query count
-   - Query cache hit rate
-
-3. **Resource Utilization**
-   - Memory usage
-   - CPU utilization
-   - Disk I/O
-
-### Example Monitoring Code
-
-```cpp
-auto stats = gateway.get_stats();
-
-std::cout << "Total queries: " << stats.total_queries << std::endl;
-std::cout << "Avg latency: " << stats.avg_latency_ms << "ms" << std::endl;
-std::cout << "Cache hit rate: "
-          << (stats.cache_hits * 100.0 / (stats.cache_hits + stats.cache_misses))
-          << "%" << std::endl;
-```
-
-## Common Performance Issues
-
-### Issue: High Latency
-
-**Symptoms:** Slow query response times
-
-**Solutions:**
-1. Check indexes with EXPLAIN
-2. Increase connection pool size
-3. Enable query caching
-4. Optimize query structure
-
-### Issue: Connection Exhaustion
-
-**Symptoms:** "Too many connections" errors
-
-**Solutions:**
-1. Increase max_connections
-2. Implement connection pooling
-3. Set proper connection timeouts
-4. Close idle connections
-
-### Issue: Memory Pressure
-
-**Symptoms:** OOM errors, swapping
-
-**Solutions:**
-1. Reduce cache size
-2. Limit result set sizes
-3. Use streaming for large results
-4. Optimize queries to reduce memory
-
-## Performance Checklist
-
-- [ ] Connection pool properly sized
-- [ ] Prepared statements used for repeated queries
-- [ ] Appropriate indexes created
-- [ ] Query cache configured
-- [ ] Slow query logging enabled
-- [ ] Monitoring in place
-- [ ] Backend-specific tuning applied
-
 ## See Also
 
 - [POSTGRESQL_TUNING.md](POSTGRESQL_TUNING.md) - PostgreSQL specific tuning
-- [MYSQL_TUNING.md](MYSQL_TUNING.md) - MySQL specific tuning
 - [SQLITE_TUNING.md](SQLITE_TUNING.md) - SQLite specific tuning
 - [BENCHMARKS.md](BENCHMARKS.md) - Performance benchmark results

--- a/samples/README.md
+++ b/samples/README.md
@@ -10,7 +10,7 @@ This directory contains comprehensive demonstration programs showcasing the capa
 **Purpose**: Demonstrates fundamental database operations and multi-backend support
 **Features Covered**:
 - Basic CRUD operations (Create, Read, Update, Delete)
-- Multi-database backend support (PostgreSQL, MySQL, SQLite, MongoDB, Redis)
+- Multi-database backend support (PostgreSQL, SQLite, MongoDB, Redis)
 - Connection management and error handling
 - Query result processing
 

--- a/src/modules/backends.cppm
+++ b/src/modules/backends.cppm
@@ -8,14 +8,12 @@
  *
  * This module partition exports database backend implementations:
  * - postgresql_backend: PostgreSQL database backend
- * - mysql_backend: MySQL/MariaDB database backend
  * - sqlite_backend: SQLite database backend
  * - mongodb_backend: MongoDB database backend
  * - redis_backend: Redis database backend
  *
  * Backend availability depends on compile-time configuration:
  * - USE_POSTGRESQL: Enables PostgreSQL backend
- * - USE_MYSQL: Enables MySQL backend
  * - USE_SQLITE: Enables SQLite backend
  * - USE_MONGODB: Enables MongoDB backend
  * - USE_REDIS: Enables Redis backend
@@ -39,10 +37,6 @@ module;
 // Conditionally include backend headers based on configuration
 #ifdef USE_POSTGRESQL
 #include "database/backends/postgresql_backend.h"
-#endif
-
-#ifdef USE_MYSQL
-#include "database/backends/mysql_backend.h"
 #endif
 
 #ifdef USE_SQLITE
@@ -70,19 +64,6 @@ export namespace database::backends {
 
 // Re-export PostgreSQL backend
 using ::database::backends::postgresql_backend;
-
-} // namespace database::backends
-#endif
-
-// ============================================================================
-// MySQL Backend
-// ============================================================================
-
-#ifdef USE_MYSQL
-export namespace database::backends {
-
-// Re-export MySQL backend
-using ::database::backends::mysql_backend;
 
 } // namespace database::backends
 #endif


### PR DESCRIPTION
## Background

Issue #418 removed the MySQL/libmariadb backend from the actual dependency model, but the repository still had stale references in the C++20 module surface and multiple current-state documents. That left the codebase in an inconsistent state where the manifest, SOUP register, and license inventory said one thing while user-facing documentation still advertised MySQL support.

## Problem

The remaining MySQL references created three concrete risks:
- The module partition still suggested a hidden backend export even though the backend implementation no longer exists.
- Build, architecture, API, sample, and contributor docs still described MySQL as a supported option.
- Readers could incorrectly assume `libmariadb` or `USE_MYSQL` remained part of the supported build surface.

## Approach

- Removed the obsolete MySQL include/re-export from `src/modules/backends.cppm`.
- Updated current-state documentation to reflect the supported backend set: PostgreSQL, SQLite, MongoDB, and Redis.
- Deleted invalid MySQL build flags, dependency installation instructions, examples, architecture snippets, and troubleshooting guidance.
- Kept explicit legacy notes only where historical context is useful, so the docs explain that MySQL support was removed rather than silently erasing all trace of it.

## Key Changes

- Reconciled top-level and docs entry points so they no longer present MySQL as an active backend.
- Updated build/contributor guidance to remove `libmariadb` and `USE_MYSQL` from current workflows.
- Removed invalid MySQL code examples from API, samples, best-practices, integration, and troubleshooting guides.
- Clarified legacy/historical references in migration and analysis documents.

## Verification

- `rg -n -i "mysql|mariadb|libmariadb|USE_MYSQL|ENABLE_MYSQL|BUILD_WITH_MYSQL" src database include CMakeLists.txt cmake vcpkg.json vcpkg-configuration.json docs/SOUP.md LICENSE-THIRD-PARTY .github`
- `cmake --build build --target database`

## Remaining Risks

- Historical documents such as changelogs and archived benchmark material still mention legacy MySQL support intentionally. They were left untouched because they describe past states rather than the current support model.

Closes #426
