### PR TITLE
chore(deps): add vcpkg overlay port for kcenon-database-system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ compile_commands.json
 !cmake/*.cmake
 !cmake/*.cmake.in
 !triplets/*.cmake
+!vcpkg-ports/**/*.cmake
 
 # Test results
 Testing/

--- a/vcpkg-ports/kcenon-database-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-database-system/portfile.cmake
@@ -1,0 +1,60 @@
+# kcenon-database-system portfile
+# Pure, lightweight C++20 Core DAL library with multi-backend support
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO kcenon/database_system
+    REF 26ad04ca3ebe28a64e23aa95d4f0104aac019c3e
+    SHA512 0  # TODO: Update with actual SHA512 hash after release
+    HEAD_REF main
+)
+
+# Feature-based backend selection
+set(DB_USE_POSTGRESQL OFF)
+if("postgresql" IN_LIST FEATURES)
+    set(DB_USE_POSTGRESQL ON)
+endif()
+
+set(DB_USE_SQLITE OFF)
+if("sqlite" IN_LIST FEATURES)
+    set(DB_USE_SQLITE ON)
+endif()
+
+set(DB_USE_MONGODB OFF)
+if("mongodb" IN_LIST FEATURES)
+    set(DB_USE_MONGODB ON)
+endif()
+
+set(DB_USE_REDIS OFF)
+if("redis" IN_LIST FEATURES)
+    set(DB_USE_REDIS ON)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DUSE_POSTGRESQL=${DB_USE_POSTGRESQL}
+        -DUSE_SQLITE=${DB_USE_SQLITE}
+        -DUSE_MONGODB=${DB_USE_MONGODB}
+        -DUSE_REDIS=${DB_USE_REDIS}
+        -DUSE_UNIT_TEST=OFF
+        -DBUILD_DATABASE_SAMPLES=OFF
+        -DDATABASE_BUILD_BENCHMARKS=OFF
+        -DDATABASE_BUILD_INTEGRATION_TESTS=OFF
+        -DBUILD_SHARED_LIBS=OFF
+        -DUSE_THREAD_SYSTEM=OFF
+        -DUSE_MONITORING_SYSTEM=OFF
+        -DUSE_CONTAINER_SYSTEM=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME DatabaseSystem
+    CONFIG_PATH lib/cmake/DatabaseSystem
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/vcpkg-ports/kcenon-database-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-database-system/vcpkg.json
@@ -1,0 +1,70 @@
+{
+  "name": "kcenon-database-system",
+  "version": "0.1.0",
+  "port-version": 0,
+  "description": "Pure, lightweight C++20 Core DAL library with multi-backend support",
+  "homepage": "https://github.com/kcenon/database_system",
+  "license": "BSD-3-Clause",
+  "supports": "!(uwp | xbox)",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "kcenon-common-system",
+    {
+      "name": "asio",
+      "version>=": "1.30.2"
+    }
+  ],
+  "default-features": [
+    "postgresql"
+  ],
+  "features": {
+    "postgresql": {
+      "description": "Enable PostgreSQL database support",
+      "dependencies": [
+        "libpq",
+        {
+          "name": "libpqxx",
+          "default-features": false
+        },
+        {
+          "name": "openssl",
+          "version>=": "3.3.0"
+        }
+      ]
+    },
+    "sqlite": {
+      "description": "Enable SQLite database support",
+      "dependencies": [
+        {
+          "name": "sqlite3",
+          "version>=": "3.45.0"
+        }
+      ]
+    },
+    "mongodb": {
+      "description": "Enable MongoDB backend (experimental)",
+      "dependencies": [
+        {
+          "name": "mongo-cxx-driver",
+          "version>=": "3.8.0"
+        }
+      ]
+    },
+    "redis": {
+      "description": "Enable Redis backend (experimental)",
+      "dependencies": [
+        {
+          "name": "hiredis",
+          "version>=": "1.2.0"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Closes #428

## Summary

- Add vcpkg overlay port definition (`vcpkg-ports/kcenon-database-system/`)
- Feature-based backend selection: `postgresql` (default), `sqlite`, `mongodb`, `redis`
- Follows established ecosystem port patterns (common_system, thread_system, etc.)
- Add `.gitignore` exception for `vcpkg-ports/**/*.cmake`

## Port Details

| File | Purpose |
|------|---------|
| `vcpkg-ports/kcenon-database-system/vcpkg.json` | Package manifest with features and dependencies |
| `vcpkg-ports/kcenon-database-system/portfile.cmake` | Build recipe with feature-conditional CMake options |

### Features

| Feature | Default | Dependencies | Status |
|---------|---------|-------------|--------|
| `postgresql` | Yes | libpq, libpqxx, openssl | Stable |
| `sqlite` | No | sqlite3 | Stable |
| `mongodb` | No | mongo-cxx-driver | Experimental |
| `redis` | No | hiredis | Experimental |

### Usage

```bash
# Install with default backend (PostgreSQL)
vcpkg install kcenon-database-system --overlay-ports=./vcpkg-ports

# Install with SQLite backend
vcpkg install kcenon-database-system[sqlite] --overlay-ports=./vcpkg-ports

# Install with multiple backends
vcpkg install kcenon-database-system[postgresql,sqlite] --overlay-ports=./vcpkg-ports
```

## Test Plan

- [ ] `vcpkg install kcenon-database-system[postgresql]` succeeds
- [ ] `vcpkg install kcenon-database-system[sqlite]` succeeds
- [ ] `find_package(DatabaseSystem CONFIG)` works in test consumer
- [ ] SHA512 hash validation (currently set to 0 for development)