### PR TITLE
docs: add C++20 module support and improve comment coverage

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1,6 +1,6 @@
 PROJECT_NAME           = "Database System"
 PROJECT_BRIEF          = "Advanced C++20 Database System with Multi-Backend Support"
-PROJECT_VERSION        = 1.0.0
+PROJECT_NUMBER         = 1.0.0
 OUTPUT_DIRECTORY       = documents
 CREATE_SUBDIRS         = YES
 ALLOW_UNICODE_NAMES    = NO
@@ -87,7 +87,7 @@ QUIET                  = NO
 WARNINGS               = YES
 WARN_IF_UNDOCUMENTED   = YES
 WARN_IF_DOC_ERROR      = YES
-WARN_NO_PARAMDOC       = NO
+WARN_NO_PARAMDOC       = YES
 WARN_AS_ERROR          = NO
 WARN_FORMAT            = "$file:$line: $text"
 WARN_LOGFILE           =
@@ -105,6 +105,7 @@ FILE_PATTERNS          = *.c \
                          *.hh \
                          *.hpp \
                          *.tpp \
+                         *.cppm \
                          *.md
 RECURSIVE              = YES
 EXCLUDE                = ./build \

--- a/include/kcenon/database/forward.h
+++ b/include/kcenon/database/forward.h
@@ -10,73 +10,124 @@
 
 namespace kcenon::database {
 
-// Core classes
+/// @name Core classes
+/// @{
 namespace core {
+    /// @brief Top-level database abstraction
     class database;
+    /// @brief Dependency injection context for database components
     class database_context;
+    /// @brief Database connection handle
     class connection;
+    /// @brief ACID transaction scope
     class transaction;
+    /// @brief Prepared or ad-hoc SQL statement
     class statement;
+    /// @brief Result wrapper for database operations
     template<typename T> class result;
 }
+/// @}
 
-// Connection management
+/// @name Connection management
+/// @{
 namespace connection {
+    /// @brief Factory for creating database connections
     class connection_factory;
+    /// @brief Connection configuration parameters
     struct connection_config;
+    /// @brief Connection pool usage statistics
     struct connection_stats;
 }
+/// @}
 
-// Query handling
+/// @name Query handling
+/// @{
 namespace query {
+    /// @brief Fluent SQL query builder
     class query_builder;
+    /// @brief Query execution engine
     class query_executor;
+    /// @brief Pre-compiled parameterized statement
     class prepared_statement;
+    /// @brief Batch query executor for bulk operations
     class batch_query;
 }
+/// @}
 
-// Schema management
+/// @name Schema management
+/// @{
 namespace schema {
+    /// @brief Database table representation
     class table;
+    /// @brief Table column definition
     class column;
+    /// @brief Database index definition
     class index;
+    /// @brief Foreign key constraint
     class foreign_key;
+    /// @brief Schema migration step
     class migration;
 }
+/// @}
 
-// ORM support
+/// @name ORM support
+/// @{
 namespace orm {
+    /// @brief Object-relational model mapping for type T
     template<typename T> class model;
+    /// @brief Object-to-row mapping strategy
     class mapper;
+    /// @brief Inter-model relationship definition
     class relation;
+    /// @brief Model field validation rules
     class validator;
 }
+/// @}
 
-// Cache
+/// @name Cache
+/// @{
 namespace cache {
+    /// @brief Cache for compiled query plans
     class query_cache;
+    /// @brief Cache for query result sets
     class result_cache;
+    /// @brief Cache for idle database connections
     class connection_cache;
 }
+/// @}
 
-// Async operations
+/// @name Async operations
+/// @{
 namespace async {
+    /// @brief Asynchronous result future for type T
     template<typename T> class async_result;
+    /// @brief Asynchronous query execution engine
     class async_executor;
+    /// @brief Non-blocking database connection
     class async_connection;
 }
+/// @}
 
-// Utilities
+/// @name Utilities
+/// @{
 namespace utils {
+    /// @brief SQL statement parser and validator
     class sql_parser;
+    /// @brief Data type conversion between C++ and SQL types
     class data_converter;
+    /// @brief Database backup and restore manager
     class backup_manager;
 }
+/// @}
 
-// Error handling
+/// @name Error handling
+/// @{
 namespace error {
+    /// @brief Database operation error with context
     class database_error;
+    /// @brief Database-specific error code enumeration
     enum class error_code;
 }
+/// @}
 
 } // namespace kcenon::database

--- a/src/modules/core.cppm
+++ b/src/modules/core.cppm
@@ -52,9 +52,11 @@ import kcenon.common;
 
 export namespace database {
 
-// Re-export core type aliases from core namespace
+/// @brief Variant type for individual database cell values
 using core::database_value;
+/// @brief A single row of database values (ordered by column)
 using core::database_row;
+/// @brief Collection of rows returned from a database query
 using core::database_result;
 
 } // namespace database


### PR DESCRIPTION
## Summary
- Add `*.cppm` to `FILE_PATTERNS` for C++20 module documentation
- Enable `WARN_NO_PARAMDOC` for stricter documentation checks
- Fix non-standard `PROJECT_VERSION` to `PROJECT_NUMBER`
- Add `@brief` annotations to all forward-declared types in `forward.h`
- Add `@brief` to re-exported type aliases in `core.cppm`

## Test plan
- [ ] Run `doxygen Doxyfile` and verify no new warnings
- [ ] Verify forward-declared types appear with descriptions in documentation index
- [ ] Verify `.cppm` files are included in documentation

Closes #436