### PR TITLE
docs: replace GIT_TAG main with tagged versions in FetchContent examples

### DIFF
--- a/README.kr.md
+++ b/README.kr.md
@@ -788,7 +788,7 @@ include(FetchContent)
 FetchContent_Declare(
     database_system
     GIT_REPOSITORY https://github.com/kcenon/database_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
 )
 FetchContent_MakeAvailable(database_system)
 ```

--- a/README.md
+++ b/README.md
@@ -559,7 +559,7 @@ include(FetchContent)
 FetchContent_Declare(
     database_system
     GIT_REPOSITORY https://github.com/kcenon/database_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
 )
 FetchContent_MakeAvailable(database_system)
 

--- a/docs/guides/FAQ.md
+++ b/docs/guides/FAQ.md
@@ -75,7 +75,7 @@ include(FetchContent)
 FetchContent_Declare(
     database_system
     GIT_REPOSITORY https://github.com/kcenon/database_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
 )
 FetchContent_MakeAvailable(database_system)
 target_link_libraries(your_target PRIVATE database_system::database)

--- a/docs/guides/QUICK_START.kr.md
+++ b/docs/guides/QUICK_START.kr.md
@@ -58,7 +58,7 @@ include(FetchContent)
 
 FetchContent_Declare(database_system
   GIT_REPOSITORY https://github.com/kcenon/database_system.git
-  GIT_TAG main
+  GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
 )
 FetchContent_MakeAvailable(database_system)
 

--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -27,7 +27,7 @@ Add to your `CMakeLists.txt`:
 include(FetchContent)
 FetchContent_Declare(database_system
   GIT_REPOSITORY https://github.com/kcenon/database_system.git
-  GIT_TAG main
+  GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
 )
 FetchContent_MakeAvailable(database_system)
 


### PR DESCRIPTION
## Summary

Pin all FetchContent documentation examples to tagged releases (`v0.1.0`) instead of tracking the `main` branch. This prevents users from copy-pasting non-reproducible build configurations.

Part of kcenon/common_system#448

## Changed Files

- `README.md` — FetchContent example: `GIT_TAG main` → `GIT_TAG v0.1.0`
- `README.kr.md` — FetchContent example: `GIT_TAG main` → `GIT_TAG v0.1.0`
- `docs/guides/QUICK_START.md` — FetchContent example: `GIT_TAG main` → `GIT_TAG v0.1.0`
- `docs/guides/FAQ.md` — FetchContent example: `GIT_TAG main` → `GIT_TAG v0.1.0`
- `docs/guides/QUICK_START.kr.md` — FetchContent example: `GIT_TAG main` → `GIT_TAG v0.1.0`

## Test Plan

- [x] Verify all five files have `GIT_TAG v0.1.0` with the pinning comment
- [x] No functional code changes — documentation only