### PR TITLE
fix(deps): align asio override version to 1.30.2 in vcpkg-configuration.json

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -10,7 +10,7 @@
   "overrides": [
     {
       "name": "asio",
-      "version": "1.29.0"
+      "version": "1.30.2"
     }
   ]
 }


### PR DESCRIPTION
## What

### Summary
Fixes the version conflict where `vcpkg-configuration.json` had asio pinned to `1.29.0` while `vcpkg.json` requires `>= 1.30.2`. The configuration-level override now matches the manifest minimum version.

### Change Type
- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Documentation

### Affected Components
- `vcpkg-configuration.json` — Updated asio override from `1.29.0` to `1.30.2`

## Why

### Problem Solved
vcpkg resolves `vcpkg-configuration.json` overrides with higher precedence than `vcpkg.json` overrides and `version>=` constraints. The stale `1.29.0` pin in the configuration file caused vcpkg to select asio `1.29.0` regardless of the `1.30.2` minimum requirement, risking build failures or silent ABI incompatibilities.

### Related Issues
- Closes #446

## How

### Implementation Details
Single-line change: updated `overrides[].version` for `asio` in `vcpkg-configuration.json` from `1.29.0` to `1.30.2`, aligning it with the `version>=` constraint and the corresponding override in `vcpkg.json`.

### Breaking Changes
None — this is a dependency version alignment fix.