### PR TITLE
chore(vcpkg): update local port REF to v0.1.0 with valid SHA512

### DIFF
--- a/vcpkg-ports/kcenon-database-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-database-system/portfile.cmake
@@ -10,8 +10,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kcenon/database_system
-    REF 23c999eb68bab535d436251d5e1bfcaad84f2868
-    SHA512 0  # TODO: Update with actual SHA512 hash after release tag
+    REF v0.1.0
+    SHA512 7207570689fad1ae2afc96b4b7c79be3690a174e6f7e9c704ec470fa71f74e18ab872becbbd4a15bb3ace5a7d5eb9d5d7a5125ccca49062abab7f61b2d06185f
     HEAD_REF main
 )
 

--- a/vcpkg-ports/kcenon-database-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-database-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-database-system",
   "version": "0.1.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Pure, lightweight C++20 Core DAL library with multi-backend support",
   "homepage": "https://github.com/kcenon/database_system",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
## What

Updates the local overlay portfile to use the stable `v0.1.0` release tag and its verified SHA512 hash, replacing the stale commit hash REF and `0` placeholder.

### Change Type
- [x] Chore (maintenance, no functional change)

### Affected Components
- `vcpkg-ports/kcenon-database-system/portfile.cmake` — REF and SHA512 updated
- `vcpkg-ports/kcenon-database-system/vcpkg.json` — port-version bumped to 2

## Why

### Related Issues
- Closes #447

### Motivation
- `SHA512 0` placeholder blocked actual vcpkg installation
- Raw commit hash REF has no semantic meaning and breaks version tracking
- `port-version: 2` aligns with the central registry in `monitoring_system/vcpkg-ports/`

## How

### Changes Made
| Field | Before | After |
|-------|--------|-------|
| `REF` | `23c999eb68bab535d436251d5e1bfcaad84f2868` | `v0.1.0` |
| `SHA512` | `0` (placeholder) | verified 512-bit hash |
| `port-version` | `1` | `2` |

### SHA512 Verification
Hash computed from `https://github.com/kcenon/database_system/archive/refs/tags/v0.1.0.tar.gz`.

### Testing Done
- [x] SHA512 independently computed from the v0.1.0 GitHub archive
- [x] Tag `v0.1.0` confirmed present on `main`
- [x] GitHub Release `v0.1.0` confirmed present

### Breaking Changes
None — overlay port is now installable where it was previously blocked by the placeholder hash.