### PR TITLE
fix(vcpkg): add kcenon-common-system as core dependency

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,6 +8,7 @@
   "license": "BSD-3-Clause",
   "supports": "!(uwp | xbox)",
   "dependencies": [
+    "kcenon-common-system",
     {
       "name": "asio",
       "version>=": "1.30.2"
@@ -29,7 +30,6 @@
     "ecosystem": {
       "description": "Enable kcenon ecosystem integration (requires ecosystem packages in vcpkg registry)",
       "dependencies": [
-        "kcenon-common-system",
         "kcenon-thread-system",
         "kcenon-logger-system",
         "kcenon-container-system",


### PR DESCRIPTION
## Summary
- Add kcenon-common-system to core dependencies in vcpkg.json
- Remove redundant entry from ecosystem feature
- Aligns source manifest with registry port and CMakeLists.txt requirements

## Test plan
- [ ] Verify kcenon-common-system is in top-level dependencies
- [ ] Verify ecosystem feature no longer has redundant kcenon-common-system
- [ ] Verify CMakeLists.txt still builds correctly

Closes #456