### PR TITLE
fix(deps): Add grpc and protobuf version overrides to vcpkg.json

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -24,7 +24,9 @@
     { "name": "hiredis", "version": "1.2.0" },
     { "name": "spdlog", "version": "1.13.0" },
     { "name": "gtest", "version": "1.14.0" },
-    { "name": "benchmark", "version": "1.8.3" }
+    { "name": "benchmark", "version": "1.8.3" },
+    { "name": "grpc", "version": "1.51.1" },
+    { "name": "protobuf", "version": "3.21.12" }
   ],
   "features": {
     "ecosystem": {


### PR DESCRIPTION
## Summary
- Add grpc 1.51.1 and protobuf 3.21.12 version overrides to vcpkg.json
- Aligns database_system with peer systems (logger, container, monitoring, network) that pin these versions

## Related Issues
- Closes #458
- Part of kcenon/common_system#454

## Test plan
- [ ] Verify vcpkg.json is valid JSON
- [ ] Verify grpc override version matches ecosystem standard (1.51.1)
- [ ] Verify protobuf override version matches ecosystem standard (3.21.12)