### PR TITLE
fix(cmake): change find_dependency from QUIET to REQUIRED for mandatory deps

### DIFF
--- a/cmake/database_system-config.cmake.in
+++ b/cmake/database_system-config.cmake.in
@@ -32,11 +32,11 @@ if(@USE_REDIS@)
     find_dependency(hiredis CONFIG)
 endif()
 
-# Ecosystem dependencies (optional)
-find_dependency(common_system CONFIG QUIET)
+# Ecosystem dependencies
+find_dependency(common_system CONFIG REQUIRED)
 
 if(@USE_CONTAINER_SYSTEM@)
-    find_dependency(container_system CONFIG QUIET)
+    find_dependency(container_system CONFIG REQUIRED)
 endif()
 
 # Include targets


### PR DESCRIPTION
## What

### Summary
Changes `find_dependency(common_system CONFIG QUIET)` to `REQUIRED` in the installed config template, and similarly for `container_system` within its `USE_CONTAINER_SYSTEM` guard. This aligns the installed config's dependency requirements with the build-time `FATAL_ERROR` enforcement.

### Change Type
- [x] Bugfix

## Why

### Related Issues
- Closes #462
- Part of kcenon/common_system#454

### Motivation
`common_system` is mandatory at build time (`FATAL_ERROR` if missing), but the installed config template used `QUIET`, silently proceeding when the dependency was absent. Consumers would then get cryptic linker errors instead of a clear configure-time "common_system not found" message.

## Where

### Files Changed
| File | Change |
|------|--------|
| `cmake/database_system-config.cmake.in` | `QUIET` → `REQUIRED` for `common_system` and `container_system` |

## How

### Implementation
- Line 36: `find_dependency(common_system CONFIG QUIET)` → `find_dependency(common_system CONFIG REQUIRED)`
- Line 39: `find_dependency(container_system CONFIG QUIET)` → `find_dependency(container_system CONFIG REQUIRED)` (within `USE_CONTAINER_SYSTEM` guard)
- Comment updated: "Ecosystem dependencies (optional)" → "Ecosystem dependencies"

### Test Plan
- `find_package(database_system CONFIG)` should fail immediately with a clear error when `common_system` is not installed
- No regression when all dependencies are correctly installed