### PR TITLE
chore(cmake): Standardize namespace to snake_case (DatabaseSystem:: → database_system::)

### DIFF
--- a/.github/workflows/vcpkg-overlay.yml
+++ b/.github/workflows/vcpkg-overlay.yml
@@ -160,7 +160,7 @@ jobs:
         set(CMAKE_CXX_STANDARD 20)
         find_package(database_system CONFIG REQUIRED)
         add_executable(test_import test_import.cpp)
-        target_link_libraries(test_import PRIVATE DatabaseSystem::database)
+        target_link_libraries(test_import PRIVATE database_system::database)
         EOF
 
         cat > test_import.cpp << 'EOF'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,10 +369,10 @@ if(BUILD_DATABASE)
         INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/database_system
     )
 
-    # Install export set with DatabaseSystem:: namespace
+    # Install export set with database_system:: namespace
     install(EXPORT database_system-targets
         FILE database_system-targets.cmake
-        NAMESPACE DatabaseSystem::
+        NAMESPACE database_system::
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/database_system
     )
 
@@ -401,7 +401,7 @@ if(BUILD_DATABASE)
     # Build-tree export for FetchContent/add_subdirectory users
     export(EXPORT database_system-targets
         FILE "${CMAKE_CURRENT_BINARY_DIR}/database_system-targets.cmake"
-        NAMESPACE DatabaseSystem::
+        NAMESPACE database_system::
     )
 endif()
 

--- a/README.kr.md
+++ b/README.kr.md
@@ -774,12 +774,12 @@ ctest
 ```cmake
 # Using as a subdirectory
 add_subdirectory(database_system)
-target_link_libraries(your_target PRIVATE DatabaseSystem::database)
+target_link_libraries(your_target PRIVATE database_system::database)
 
 # Optional: Add container system integration
 add_subdirectory(container_system)
 target_link_libraries(your_target PRIVATE
-    DatabaseSystem::database
+    database_system::database
     ContainerSystem::container
 )
 

--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@ cmake --build build --target docs
 
 ```cmake
 add_subdirectory(database_system)
-target_link_libraries(your_target PRIVATE DatabaseSystem::database)
+target_link_libraries(your_target PRIVATE database_system::database)
 ```
 
 ### With FetchContent
@@ -563,7 +563,7 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(database_system)
 
-target_link_libraries(your_target PRIVATE DatabaseSystem::database)
+target_link_libraries(your_target PRIVATE database_system::database)
 ```
 
 ### Build Options

--- a/cmake/database_system-config.cmake.in
+++ b/cmake/database_system-config.cmake.in
@@ -4,8 +4,12 @@
 # database_system Package Configuration
 #
 # Provides imported targets:
-#   DatabaseSystem::database             - Core DAL library
-#   DatabaseSystem::integrated_database  - Integrated adapter layer (if built)
+#   database_system::database             - Core DAL library
+#   database_system::integrated_database  - Integrated adapter layer (if built)
+#
+# Legacy aliases (backward compatibility):
+#   DatabaseSystem::database             → database_system::database
+#   DatabaseSystem::integrated_database  → database_system::integrated_database
 ##################################################
 
 include(CMakeFindDependencyMacro)
@@ -51,7 +55,15 @@ set(database_system_FOUND TRUE)
 # Provide information about the package
 set(database_system_VERSION @PROJECT_VERSION@)
 set(database_system_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@/database_system")
-set(database_system_LIBRARIES DatabaseSystem::database)
+set(database_system_LIBRARIES database_system::database)
+
+# Backward compatibility aliases: DatabaseSystem:: → database_system::
+if(TARGET database_system::database AND NOT TARGET DatabaseSystem::database)
+    add_library(DatabaseSystem::database ALIAS database_system::database)
+endif()
+if(TARGET database_system::integrated_database AND NOT TARGET DatabaseSystem::integrated_database)
+    add_library(DatabaseSystem::integrated_database ALIAS database_system::integrated_database)
+endif()
 
 # Legacy variables for backward compatibility
 set(DatabaseSystem_FOUND TRUE)


### PR DESCRIPTION
## Summary

- Change CMake export namespace from `DatabaseSystem::` to `database_system::` to adopt the ecosystem convention of `<name>::` snake_case namespacing
- Add backward compatibility aliases (`DatabaseSystem::database`, `DatabaseSystem::integrated_database`) so existing consumers continue to work without changes
- Update CI workflow, README.md, and README.kr.md to reference the new namespace

## What

| Area | Change |
|------|--------|
| `CMakeLists.txt` | `NAMESPACE DatabaseSystem::` → `NAMESPACE database_system::` (install + build-tree export) |
| `cmake/database_system-config.cmake.in` | Update target references; add `add_library(ALIAS)` for backward compat |
| `.github/workflows/vcpkg-overlay.yml` | Update `target_link_libraries` in find_package verification test |
| `README.md` / `README.kr.md` | Update CMake integration examples |

## Why

Standardize on snake_case namespace (`database_system::`) to match the ecosystem convention used across sibling projects.

Part of kcenon/common_system#456

Closes #464

## Test plan

- [ ] CI builds pass (namespace change is validated by vcpkg-overlay workflow's find_package test)
- [ ] Existing consumers using `DatabaseSystem::database` continue to work via backward compatibility aliases