### PR TITLE
chore(build): add CMakePresets.json and fix missing triplets reference

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,160 @@
+{
+    "version": 3,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 16,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "default",
+            "displayName": "Default Config",
+            "description": "Default build with PostgreSQL backend",
+            "binaryDir": "${sourceDir}/build",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "USE_UNIT_TEST": "OFF",
+                "BUILD_DATABASE_SAMPLES": "OFF",
+                "DATABASE_BUILD_INTEGRATION_TESTS": "OFF",
+                "USE_POSTGRESQL": "ON",
+                "USE_SQLITE": "OFF",
+                "USE_MONGODB": "OFF",
+                "USE_REDIS": "OFF"
+            }
+        },
+        {
+            "name": "debug",
+            "displayName": "Debug",
+            "description": "Debug build with tests enabled",
+            "inherits": "default",
+            "binaryDir": "${sourceDir}/build-debug",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "USE_UNIT_TEST": "ON",
+                "BUILD_DATABASE_SAMPLES": "ON",
+                "DATABASE_BUILD_INTEGRATION_TESTS": "ON",
+                "ENABLE_COVERAGE": "ON"
+            }
+        },
+        {
+            "name": "release",
+            "displayName": "Release",
+            "description": "Optimized release build",
+            "inherits": "default",
+            "binaryDir": "${sourceDir}/build-release",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "full",
+            "displayName": "Full Backends",
+            "description": "Debug build with all database backends enabled",
+            "inherits": "debug",
+            "binaryDir": "${sourceDir}/build-full",
+            "cacheVariables": {
+                "USE_POSTGRESQL": "ON",
+                "USE_SQLITE": "ON",
+                "USE_MONGODB": "ON",
+                "USE_REDIS": "ON"
+            }
+        },
+        {
+            "name": "asan",
+            "displayName": "AddressSanitizer",
+            "description": "Build with AddressSanitizer",
+            "inherits": "debug",
+            "binaryDir": "${sourceDir}/build-asan",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "-fsanitize=address -fno-omit-frame-pointer",
+                "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address"
+            }
+        },
+        {
+            "name": "tsan",
+            "displayName": "ThreadSanitizer",
+            "description": "Build with ThreadSanitizer",
+            "inherits": "debug",
+            "binaryDir": "${sourceDir}/build-tsan",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "-fsanitize=thread",
+                "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=thread"
+            }
+        },
+        {
+            "name": "ubsan",
+            "displayName": "UndefinedBehaviorSanitizer",
+            "description": "Build with UndefinedBehaviorSanitizer",
+            "inherits": "debug",
+            "binaryDir": "${sourceDir}/build-ubsan",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "-fsanitize=undefined",
+                "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=undefined"
+            }
+        },
+        {
+            "name": "ci",
+            "displayName": "CI Build",
+            "description": "Configuration for continuous integration",
+            "inherits": "default",
+            "binaryDir": "${sourceDir}/build-ci",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "USE_UNIT_TEST": "ON",
+                "DATABASE_BUILD_BENCHMARKS": "ON",
+                "DATABASE_BUILD_INTEGRATION_TESTS": "ON"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "default",
+            "configurePreset": "default"
+        },
+        {
+            "name": "debug",
+            "configurePreset": "debug"
+        },
+        {
+            "name": "release",
+            "configurePreset": "release"
+        },
+        {
+            "name": "full",
+            "configurePreset": "full"
+        },
+        {
+            "name": "asan",
+            "configurePreset": "asan"
+        },
+        {
+            "name": "tsan",
+            "configurePreset": "tsan"
+        },
+        {
+            "name": "ubsan",
+            "configurePreset": "ubsan"
+        },
+        {
+            "name": "ci",
+            "configurePreset": "ci"
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "default",
+            "configurePreset": "default",
+            "output": {
+                "outputOnFailure": true
+            }
+        },
+        {
+            "name": "ci",
+            "configurePreset": "ci",
+            "output": {
+                "outputOnFailure": true,
+                "verbosity": "verbose"
+            }
+        }
+    ]
+}

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -14,9 +14,6 @@
       ]
     }
   ],
-  "overlay-triplets": [
-    "triplets"
-  ],
   "overrides": [
     {
       "name": "asio",


### PR DESCRIPTION
## What

### Summary
Add standardized `CMakePresets.json` and remove invalid `overlay-triplets` reference from `vcpkg-configuration.json`.

### Change Type
- [x] Chore (build configuration)

## Why

### Related Issues
- Closes #474

### Motivation
1. database_system is one of 4 ecosystem repos missing CMakePresets.json
2. `vcpkg-configuration.json` referenced `"overlay-triplets": ["triplets"]` but the `triplets/` directory never existed, causing vcpkg warnings

## Where

### Files Changed
| File | Type of Change |
|------|----------------|
| `CMakePresets.json` | New file |
| `vcpkg-configuration.json` | Remove invalid `overlay-triplets` reference |

## How

### Presets Included

| Preset | Build Type | Tests | Notes |
|--------|-----------|-------|-------|
| `default` | Release | OFF | PostgreSQL backend only |
| `debug` | Debug | ON | Development build with coverage |
| `release` | Release | OFF | Optimized build |
| `full` | Debug | ON | All backends (PostgreSQL, SQLite, MongoDB, Redis) |
| `asan` | Debug | ON | AddressSanitizer |
| `tsan` | Debug | ON | ThreadSanitizer |
| `ubsan` | Debug | ON | UBSanitizer |
| `ci` | RelWithDebInfo | ON | CI pipeline build |

### vcpkg-configuration.json Fix

Removed:
```json
"overlay-triplets": ["triplets"]
```
The `triplets/` directory did not exist. Custom triplets are not currently needed since default vcpkg triplets are sufficient.

### Testing Done
- [x] Preset structure follows ecosystem pattern (version 3, CMake 3.16+)
- [x] All cache variables match existing CMakeLists.txt options
- [x] vcpkg-configuration.json is valid after removing overlay-triplets