### PR TITLE
fix(security): deprecate raw SQL string query API

### DIFF
--- a/database/async/async_operations.h
+++ b/database/async/async_operations.h
@@ -781,6 +781,15 @@ namespace database::async
 		return async_result<bool>(std::move(future));
 	}
 
+// Suppress deprecation: async wrappers delegate to raw query API until parameterized support is added
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4996)
+#endif
+
 	inline async_result<core::database_result> async_database::select_async(const std::string& query)
 	{
 		auto db = db_;
@@ -831,6 +840,12 @@ namespace database::async
 		});
 		return async_result<std::vector<core::database_result>>(std::move(future));
 	}
+
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 	inline async_result<bool> async_database::begin_transaction_async()
 	{

--- a/database/core/database_backend.h
+++ b/database/core/database_backend.h
@@ -167,28 +167,36 @@ public:
 	 * @brief Execute an INSERT query
 	 * @param query_string SQL INSERT statement
 	 * @return Number of rows inserted, or error
+	 * @deprecated Use parameterized query API instead to prevent SQL injection
 	 */
+	[[deprecated("Use parameterized query API instead")]]
 	virtual kcenon::common::Result<uint64_t> insert_query(const std::string& query_string) = 0;
 
 	/**
 	 * @brief Execute an UPDATE query
 	 * @param query_string SQL UPDATE statement
 	 * @return Number of rows updated, or error
+	 * @deprecated Use parameterized query API instead to prevent SQL injection
 	 */
+	[[deprecated("Use parameterized query API instead")]]
 	virtual kcenon::common::Result<uint64_t> update_query(const std::string& query_string) = 0;
 
 	/**
 	 * @brief Execute a DELETE query
 	 * @param query_string SQL DELETE statement
 	 * @return Number of rows deleted, or error
+	 * @deprecated Use parameterized query API instead to prevent SQL injection
 	 */
+	[[deprecated("Use parameterized query API instead")]]
 	virtual kcenon::common::Result<uint64_t> delete_query(const std::string& query_string) = 0;
 
 	/**
 	 * @brief Execute a SELECT query
 	 * @param query_string SQL SELECT statement
 	 * @return Query results as rows, or error
+	 * @deprecated Use parameterized query API instead to prevent SQL injection
 	 */
+	[[deprecated("Use parameterized query API instead")]]
 	virtual kcenon::common::Result<database_result> select_query(const std::string& query_string) = 0;
 
 	/**

--- a/database/database_manager.cpp
+++ b/database/database_manager.cpp
@@ -161,6 +161,15 @@ namespace database
 		return database_->execute_query(query_string);
 	}
 
+// Suppress deprecation warnings for internal delegation to deprecated raw query API
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4996)
+#endif
+
 	kcenon::common::Result<uint64_t> database_manager::insert_query_result(const std::string& query_string)
 	{
 		if (!database_)
@@ -200,6 +209,12 @@ namespace database
 		}
 		return database_->select_query(query_string);
 	}
+
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 	kcenon::common::VoidResult database_manager::execute_query_result(const std::string& query_string)
 	{

--- a/database/database_manager.h
+++ b/database/database_manager.h
@@ -148,28 +148,36 @@ namespace database
 		 * @brief Result-based wrapper for insert_query().
 		 * @param query_string The SQL INSERT statement.
 		 * @return Number of rows inserted, or error.
+		 * @deprecated Use parameterized query API instead to prevent SQL injection
 		 */
+		[[deprecated("Use parameterized query API instead")]]
 		kcenon::common::Result<uint64_t> insert_query_result(const std::string& query_string);
 
 		/**
 		 * @brief Result-based wrapper for update_query().
 		 * @param query_string The SQL UPDATE statement.
 		 * @return Number of rows updated, or error.
+		 * @deprecated Use parameterized query API instead to prevent SQL injection
 		 */
+		[[deprecated("Use parameterized query API instead")]]
 		kcenon::common::Result<uint64_t> update_query_result(const std::string& query_string);
 
 		/**
 		 * @brief Result-based wrapper for delete_query().
 		 * @param query_string The SQL DELETE statement.
 		 * @return Number of rows deleted, or error.
+		 * @deprecated Use parameterized query API instead to prevent SQL injection
 		 */
+		[[deprecated("Use parameterized query API instead")]]
 		kcenon::common::Result<uint64_t> delete_query_result(const std::string& query_string);
 
 		/**
 		 * @brief Result-based wrapper for select_query().
 		 * @param query_string The SQL SELECT statement.
 		 * @return Query results, or error.
+		 * @deprecated Use parameterized query API instead to prevent SQL injection
 		 */
+		[[deprecated("Use parameterized query API instead")]]
 		kcenon::common::Result<core::database_result> select_query_result(const std::string& query_string);
 
 		/**

--- a/database/integrated/unified_database_system.cpp
+++ b/database/integrated/unified_database_system.cpp
@@ -49,6 +49,16 @@
 #include <stdexcept>
 #include <sstream>
 
+// Suppress deprecation warnings: this file intentionally uses raw query API
+// until parameterized query support is implemented
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4996)
+#endif
+
 namespace database::integrated {
 
 // ============================================================================
@@ -832,3 +842,9 @@ unified_database_system::builder unified_database_system::create_builder() {
 }
 
 } // namespace database::integrated
+
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif

--- a/database/query_builder.cpp
+++ b/database/query_builder.cpp
@@ -170,6 +170,15 @@ namespace database
 		return raw_condition_;
 	}
 
+// Suppress deprecation: logical operators use raw constructor internally for composite conditions
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4996)
+#endif
+
 	query_condition query_condition::operator&&(const query_condition& other) const
 	{
 		query_condition result("");
@@ -187,6 +196,12 @@ namespace database
 		result.logical_operator_ = "OR";
 		return result;
 	}
+
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 	// query_builder implementation using Strategy pattern
 	query_builder::query_builder(database_types db_type)
@@ -391,6 +406,15 @@ namespace database
 		return "";
 	}
 
+// Suppress deprecation: execute() is itself a transitional API that delegates to raw select_query
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4996)
+#endif
+
 	core::database_result query_builder::execute(core::database_backend* db) const
 	{
 		if (!db) {
@@ -408,6 +432,12 @@ namespace database
 		}
 		return result.value();
 	}
+
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 	void query_builder::reset()
 	{

--- a/database/query_builder.h
+++ b/database/query_builder.h
@@ -75,6 +75,7 @@ namespace database
 	{
 	public:
 		query_condition(const std::string& field, const std::string& op, const core::database_value& value);
+		[[deprecated("Use parameterized query_condition(field, op, value) instead")]]
 		query_condition(const std::string& raw_condition);
 
 		std::string to_sql() const;

--- a/include/kcenon/database/adapters/common_system_database_adapter.h
+++ b/include/kcenon/database/adapters/common_system_database_adapter.h
@@ -156,6 +156,13 @@ public:
      * @param query SQL query string
      * @return Result containing query results or error
      */
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4996)
+#endif
     common::Result<common::database_result> execute_query(const std::string& query) override {
         if (!manager_) {
             return common::make_error<common::database_result>(
@@ -188,6 +195,11 @@ public:
 
         return common::Result<common::database_result>::ok(std::move(common_result));
     }
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
     /**
      * @brief Execute a command without returning results


### PR DESCRIPTION
## What

### Summary
Marks raw SQL string methods (`insert_query`, `update_query`, `delete_query`, `select_query`) with `[[deprecated]]` in the `database_backend` base class, `database_manager` wrappers, and the `query_condition` raw string constructor. Internal delegation sites use pragma-based suppression to keep the build clean.

### Change Type
- [x] Security
- [x] Refactor (deprecation annotations only, no behavioral changes)

### Affected Components
- `database/core/database_backend.h` — base class virtual declarations
- `database/database_manager.h` — wrapper method declarations
- `database/query_builder.h` — `query_condition` raw string constructor
- `database/query_builder.cpp` — internal suppression for `operator&&`/`operator||` and `execute()`
- `database/database_manager.cpp` — internal suppression for delegation
- `database/async/async_operations.h` — internal suppression for async wrappers
- `database/integrated/unified_database_system.cpp` — internal suppression
- `include/kcenon/database/adapters/common_system_database_adapter.h` — internal suppression

## Why

### Related Issues
Closes #476

### Motivation
All backends expose `insert_query(string)`, `update_query(string)`, etc. that accept raw SQL strings, creating a SQL injection surface. The `query_condition` raw string constructor bypasses escaping entirely. Deprecating these methods is the first step toward migrating all callers to a parameterized query API.

## How

### Implementation Highlights
1. Added `[[deprecated("Use parameterized query API instead")]]` to 4 virtual methods in `database_backend.h`
2. Added `[[deprecated]]` to 4 `_result` wrapper methods in `database_manager.h`
3. Added `[[deprecated]]` to `query_condition(const std::string& raw_condition)` constructor
4. Internal callers that must continue using the deprecated API use cross-platform pragma suppression (`GCC diagnostic`/`MSVC warning`) until they are migrated

### Testing Done
- [x] Full CMake build passes with no deprecation warnings from internal code
- [x] External callers (tests, samples) will see deprecation warnings as intended

### Breaking Changes
None — existing code continues to compile with deprecation warnings only.