### PR TITLE
fix(security): mask password in PostgreSQL connection error messages

### DIFF
--- a/database/backends/postgresql_backend.cpp
+++ b/database/backends/postgresql_backend.cpp
@@ -74,7 +74,7 @@ kcenon::common::VoidResult postgresql_backend::do_initialize(const core::connect
 			return kcenon::common::ok();
 		}
 	} catch (const std::exception& e) {
-		last_error_ = std::string("Connection error: ") + e.what();
+		last_error_ = std::string("Connection error: ") + sanitize_error(e.what());
 		logger_.error("do_initialize", last_error_);
 	}
 #elif defined(HAVE_LIBPQ)
@@ -84,15 +84,15 @@ kcenon::common::VoidResult postgresql_backend::do_initialize(const core::connect
 			last_error_.clear();
 			return kcenon::common::ok();
 		}
-		last_error_ = PQerrorMessage(static_cast<PGconn*>(connection_));
+		last_error_ = sanitize_error(PQerrorMessage(static_cast<PGconn*>(connection_)));
 		PQfinish(static_cast<PGconn*>(connection_));
 		connection_ = nullptr;
 	} catch (const std::exception& e) {
-		last_error_ = std::string("Connection error: ") + e.what();
+		last_error_ = std::string("Connection error: ") + sanitize_error(e.what());
 		logger_.error("do_initialize", last_error_);
 	}
 #else
-	logger_.warning("PostgreSQL support not compiled. Connection: " + conn_str.substr(0, 20) + "...");
+	logger_.warning("PostgreSQL support not compiled. Connection: " + build_safe_connection_string(config));
 	// Mock mode for testing without PostgreSQL
 	last_error_.clear();
 	return kcenon::common::ok();
@@ -617,6 +617,53 @@ std::string postgresql_backend::build_connection_string(const core::connection_c
 	}
 
 	return oss.str();
+}
+
+std::string postgresql_backend::build_safe_connection_string(const core::connection_config& config) const
+{
+	std::ostringstream oss;
+
+	if (!config.host.empty()) {
+		oss << "host=" << config.host << " ";
+	}
+
+	if (config.port > 0) {
+		oss << "port=" << config.port << " ";
+	}
+
+	if (!config.database.empty()) {
+		oss << "dbname=" << config.database << " ";
+	}
+
+	if (!config.username.empty()) {
+		oss << "user=" << config.username << " ";
+	}
+
+	if (!config.password.empty()) {
+		oss << "password=*** ";
+	}
+
+	for (const auto& [key, value] : config.options) {
+		oss << key << "=" << value << " ";
+	}
+
+	return oss.str();
+}
+
+std::string postgresql_backend::sanitize_error(const std::string& error_message) const
+{
+	if (connection_config_.password.empty()) {
+		return error_message;
+	}
+
+	std::string sanitized = error_message;
+	std::string::size_type pos = 0;
+	while ((pos = sanitized.find(connection_config_.password, pos)) != std::string::npos) {
+		sanitized.replace(pos, connection_config_.password.length(), "***");
+		pos += 3;
+	}
+
+	return sanitized;
 }
 
 } // namespace backends

--- a/database/backends/postgresql_backend.h
+++ b/database/backends/postgresql_backend.h
@@ -164,6 +164,20 @@ private:
 	std::string build_connection_string(const core::connection_config& config) const;
 
 	/**
+	 * @brief Build a connection string with password masked for safe logging
+	 * @param config Structured connection configuration
+	 * @return Connection string with password replaced by "***"
+	 */
+	std::string build_safe_connection_string(const core::connection_config& config) const;
+
+	/**
+	 * @brief Remove password from an error message that may contain the connection string
+	 * @param error_message The error message to sanitize
+	 * @return Error message with password masked
+	 */
+	std::string sanitize_error(const std::string& error_message) const;
+
+	/**
 	 * @brief Execute a modification query (INSERT, UPDATE, DELETE)
 	 * @param query_string SQL query to execute
 	 * @return Number of affected rows


### PR DESCRIPTION
## What

### Summary
Masks plaintext PostgreSQL passwords in error messages and log output to prevent credential exposure through connection error diagnostics.

### Change Type
- [x] Bugfix (fixes an issue)

### Affected Components
- `database/backends/postgresql_backend.cpp` - Password sanitization in error paths
- `database/backends/postgresql_backend.h` - New sanitization method declarations

## Why

### Problem Solved
When a PostgreSQL connection fails, the exception message from pqxx/libpq can contain the full connection string including the plaintext password. This connection string is stored in `last_error_` and logged via `logger_.error()`, creating a security risk where credentials could appear in application logs. Additionally, the mock-mode warning logged a truncated connection string that could still expose password fragments.

### Related Issues
- Closes #477

## Where

### Files Changed
| Directory | Files | Type of Change |
|-----------|-------|----------------|
| `database/backends/` | 2 | Security fix |

## How

### Implementation Details
1. **`sanitize_error()`** - Strips the stored password from any error message string by performing a find-and-replace with `***`. Uses the cached `connection_config_.password` to know what to mask.
2. **`build_safe_connection_string()`** - Builds a connection string identical to `build_connection_string()` but replaces the password value with `***`. Used for the mock-mode warning log.
3. All error paths in `do_initialize()` now pass through `sanitize_error()` before storing in `last_error_` or logging.
4. `connection_info()` already excludes password - no changes needed there.

### Testing Done
- [x] Code review of all error paths in postgresql_backend.cpp
- [x] Verified `connection_info()` continues to exclude password
- [ ] CI build and test verification

### Breaking Changes
None - error messages will contain `***` instead of actual passwords, which is the desired behavior.