### PR TITLE
refactor(api): expand public header install surface

### DIFF
--- a/include/kcenon/database/core/backend_registry.h
+++ b/include/kcenon/database/core/backend_registry.h
@@ -1,0 +1,21 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file backend_registry.h
+ * @brief Public forwarding header for database backend registry.
+ *
+ * Exposes database::core::backend_registry for runtime backend
+ * registration and creation.
+ *
+ * @code
+ * #include <kcenon/database/core/backend_registry.h>
+ *
+ * auto backend = database::core::create_backend("postgresql");
+ * @endcode
+ */
+
+#pragma once
+
+#include "database/core/backend_registry.h"

--- a/include/kcenon/database/core/database_backend.h
+++ b/include/kcenon/database/core/database_backend.h
@@ -1,0 +1,24 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file database_backend.h
+ * @brief Public forwarding header for database backend interface.
+ *
+ * Exposes database::core::database_backend abstract base class and
+ * associated types (database_value, database_row, database_result,
+ * connection_config, backend_factory_fn).
+ *
+ * @code
+ * #include <kcenon/database/core/database_backend.h>
+ *
+ * class my_backend : public database::core::database_backend {
+ *     // ...
+ * };
+ * @endcode
+ */
+
+#pragma once
+
+#include "database/core/database_backend.h"

--- a/include/kcenon/database/core/database_context.h
+++ b/include/kcenon/database/core/database_context.h
@@ -1,0 +1,21 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file database_context.h
+ * @brief Public forwarding header for database dependency injection context.
+ *
+ * Exposes database::database_context for creating database_manager
+ * instances with dependency injection.
+ *
+ * @code
+ * #include <kcenon/database/core/database_context.h>
+ *
+ * auto context = std::make_shared<database::database_context>();
+ * @endcode
+ */
+
+#pragma once
+
+#include "database/core/database_context.h"

--- a/include/kcenon/database/database_manager.h
+++ b/include/kcenon/database/database_manager.h
@@ -1,0 +1,23 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file database_manager.h
+ * @brief Public forwarding header for the database manager.
+ *
+ * Exposes database::database_manager, the primary high-level interface
+ * for database connections and query execution.
+ *
+ * @code
+ * #include <kcenon/database/database_manager.h>
+ *
+ * auto context = std::make_shared<database::database_context>();
+ * database::database_manager mgr(context);
+ * mgr.set_mode(database::database_types::postgres);
+ * @endcode
+ */
+
+#pragma once
+
+#include "database/database_manager.h"

--- a/include/kcenon/database/database_types.h
+++ b/include/kcenon/database/database_types.h
@@ -1,0 +1,20 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file database_types.h
+ * @brief Public forwarding header for database type enumeration.
+ *
+ * Exposes database::database_types enum for downstream consumers.
+ *
+ * @code
+ * #include <kcenon/database/database_types.h>
+ *
+ * auto type = database::database_types::postgres;
+ * @endcode
+ */
+
+#pragma once
+
+#include "database/database_types.h"

--- a/include/kcenon/database/integrated/unified_database_system.h
+++ b/include/kcenon/database/integrated/unified_database_system.h
@@ -1,0 +1,23 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file unified_database_system.h
+ * @brief Public forwarding header for the unified database system.
+ *
+ * Exposes database::integrated::unified_database_system and related
+ * types (query_result, database_metrics, health_check, transaction, etc.)
+ * for zero-configuration database access.
+ *
+ * @code
+ * #include <kcenon/database/integrated/unified_database_system.h>
+ *
+ * database::integrated::unified_database_system db;
+ * auto result = db.connect("postgresql://localhost/mydb");
+ * @endcode
+ */
+
+#pragma once
+
+#include "database/integrated/unified_database_system.h"

--- a/include/kcenon/database/query_builder.h
+++ b/include/kcenon/database/query_builder.h
@@ -1,0 +1,26 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file query_builder.h
+ * @brief Public forwarding header for the universal query builder.
+ *
+ * Exposes database::query_builder, database::query_condition, and
+ * related enums (join_type, sort_order) for constructing database
+ * queries across different backends.
+ *
+ * @code
+ * #include <kcenon/database/query_builder.h>
+ *
+ * database::query_builder builder(database::database_types::postgres);
+ * auto query = builder.select({"id", "name"})
+ *     .from("users")
+ *     .where("active", "=", true)
+ *     .build();
+ * @endcode
+ */
+
+#pragma once
+
+#include "database/query_builder.h"


### PR DESCRIPTION
## Summary
- Add 7 forwarding headers under `include/kcenon/database/` for types that downstream consumers actively depend on
- Covers `database_types`, `database_backend`, `backend_registry`, `database_context`, `database_manager`, `query_builder`, and `unified_database_system`
- No CMakeLists.txt changes needed — existing `install(DIRECTORY include/ ...)` rule covers all headers

## What
Previously only 4 headers were exposed via the public `kcenon/database/` path. Downstream projects like `pacs_system` were including internal `database/` headers directly. This PR adds proper public forwarding headers for all 7 types that downstream consumers actively use.

## Why
Downstream consumers should include types through the stable `kcenon/database/` public API path rather than reaching into internal `database/` paths. This enables future refactoring of internal header layout without breaking downstream builds.

Closes #478

## Test plan
- [x] Verified `cmake --preset default` configures successfully
- [x] Confirmed build error on `main` is pre-existing (`container_system` API mismatch in `database_protocol_container.cpp`) and unrelated to this change
- [x] Verified no existing headers were modified — all 7 files are new additions
- [ ] CI build verification