### PR TITLE
feat(cmake): add vcpkg CMake preset to CMakePresets.json

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -104,6 +104,23 @@
                 "DATABASE_BUILD_BENCHMARKS": "ON",
                 "DATABASE_BUILD_INTEGRATION_TESTS": "ON"
             }
+        },
+        {
+            "name": "vcpkg",
+            "displayName": "vcpkg Release",
+            "description": "Release build using vcpkg for dependency management",
+            "binaryDir": "${sourceDir}/build/vcpkg",
+            "cacheVariables": {
+                "CMAKE_TOOLCHAIN_FILE": {
+                    "type": "FILEPATH",
+                    "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+                },
+                "CMAKE_BUILD_TYPE": "Release",
+                "USE_UNIT_TEST": "OFF",
+                "BUILD_DATABASE_SAMPLES": "OFF",
+                "DATABASE_BUILD_BENCHMARKS": "OFF",
+                "DATABASE_BUILD_INTEGRATION_TESTS": "OFF"
+            }
         }
     ],
     "buildPresets": [
@@ -138,6 +155,10 @@
         {
             "name": "ci",
             "configurePreset": "ci"
+        },
+        {
+            "name": "vcpkg",
+            "configurePreset": "vcpkg"
         }
     ],
     "testPresets": [


### PR DESCRIPTION
Closes #491

## Summary

- Add `vcpkg` configure preset with `CMAKE_TOOLCHAIN_FILE` pointing to `$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake`
- Add matching build preset
- Disables tests, samples, benchmarks, and integration tests (matching portfile behavior)

## Usage

```bash
export VCPKG_ROOT=/path/to/vcpkg
cmake --preset vcpkg
cmake --build --preset vcpkg
```

## Test Plan

- [ ] `cmake --preset vcpkg` configures successfully when `VCPKG_ROOT` is set
- [ ] All vcpkg.json dependencies are resolved through the toolchain
- [ ] Preset disables test/sample/benchmark builds (matching portfile behavior)
- [ ] JSON is syntactically valid