### PR TITLE
fix(cmake): guard install/export rules and define KCENON_HAS_COMMON_SYSTEM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,11 +341,16 @@ endif()
 
 ##################################################
 # Installation Rules
+#
+# Only generate install/export rules when database_system is the top-level
+# project. In subdirectory builds (e.g., via pacs_system), transitive
+# dependencies (thread_base, simdutf, etc.) may not be in any export set,
+# which causes CMake generation errors.
 ##################################################
 
 include(GNUInstallDirs)
 
-if(BUILD_DATABASE)
+if(BUILD_DATABASE AND CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
     # Install header files
     install(DIRECTORY database/
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/database_system/database

--- a/database/CMakeLists.txt
+++ b/database/CMakeLists.txt
@@ -166,7 +166,7 @@ if(BUILD_WITH_COMMON_SYSTEM)
 
     if(_DATABASE_COMMON_TARGET)
         target_link_libraries(${PROJECT_NAME} PUBLIC ${_DATABASE_COMMON_TARGET})
-        target_compile_definitions(${PROJECT_NAME} PUBLIC BUILD_WITH_COMMON_SYSTEM)
+        target_compile_definitions(${PROJECT_NAME} PUBLIC BUILD_WITH_COMMON_SYSTEM KCENON_HAS_COMMON_SYSTEM=1)
         message(STATUS "Database: common_system integration enabled via target ${_DATABASE_COMMON_TARGET}")
     else()
         find_system_dependency_include(common_system)
@@ -176,7 +176,7 @@ if(BUILD_WITH_COMMON_SYSTEM)
             target_include_directories(${PROJECT_NAME} PUBLIC
                 $<BUILD_INTERFACE:${common_system_INCLUDE_DIR}>
             )
-            target_compile_definitions(${PROJECT_NAME} PUBLIC BUILD_WITH_COMMON_SYSTEM)
+            target_compile_definitions(${PROJECT_NAME} PUBLIC BUILD_WITH_COMMON_SYSTEM KCENON_HAS_COMMON_SYSTEM=1)
             message(STATUS "Database: common_system integration enabled")
         else()
             message(WARNING "common_system not found - integration disabled. Install common_system or set BUILD_WITH_COMMON_SYSTEM=OFF to suppress this warning.")

--- a/database/integrated/CMakeLists.txt
+++ b/database/integrated/CMakeLists.txt
@@ -271,17 +271,23 @@ endif()
 # Installation
 ##################################################
 
-install(TARGETS ${INTEGRATED_DB_TARGET}
-    EXPORT database_system-targets
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION bin
-)
+# Only add to export set when database_system is the top-level project.
+# In subdirectory builds (e.g., via pacs_system), the parent project handles
+# installation and the transitive dependencies (thread_base, etc.) may not
+# be in any export set.
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+    install(TARGETS ${INTEGRATED_DB_TARGET}
+        EXPORT database_system-targets
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin
+    )
 
-# Install headers
-install(DIRECTORY core/ adapters/
-    DESTINATION include/database_system/database/integrated
-    FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
-)
+    # Install headers
+    install(DIRECTORY core/ adapters/
+        DESTINATION include/database_system/database/integrated
+        FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
+    )
+endif()
 
 message(STATUS "Integrated database system configured")


### PR DESCRIPTION
## Summary
- Fix CMake generation failure when database_system is built as a subdirectory (e.g. via pacs_system)
- Fix container_system serialize()/serialize_string() being excluded at compile time

## Changes
1. **Export guard**: Wrap all `install(EXPORT)` and `export(EXPORT)` rules with `CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR` so they only apply in standalone builds. In subdirectory builds, transitive dependencies (thread_base, simdutf, etc.) may not be in any export set, which causes CMake generation errors.

2. **KCENON_HAS_COMMON_SYSTEM macro**: Add `KCENON_HAS_COMMON_SYSTEM=1` compile definition alongside `BUILD_WITH_COMMON_SYSTEM`. container_system headers gate `serialize()`/`serialize_string()` behind `CONTAINER_HAS_COMMON_RESULT` which requires this macro.

## Test plan
- [x] `bash scripts/build.sh --clean` compiles successfully (standalone)
- [x] pacs_system `./build.sh --clean` completes with database_system as subdirectory
- [x] container_system serialization API available in database protocol code