### PR TITLE
chore: add local vcpkg portfile for registry synchronization

### DIFF
--- a/vcpkg-ports/kcenon-database-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-database-system/portfile.cmake
@@ -1,0 +1,62 @@
+# kcenon-database-system portfile
+# Pure, lightweight C++20 Core DAL library with multi-backend support
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO kcenon/database_system
+    REF "v${VERSION}"
+    SHA512 7207570689fad1ae2afc96b4b7c79be3690a174e6f7e9c704ec470fa71f74e18ab872becbbd4a15bb3ace5a7d5eb9d5d7a5125ccca49062abab7f61b2d06185f
+    HEAD_REF main
+)
+
+# Feature-based backend selection
+set(DB_USE_POSTGRESQL OFF)
+if("postgresql" IN_LIST FEATURES)
+    set(DB_USE_POSTGRESQL ON)
+endif()
+
+set(DB_USE_SQLITE OFF)
+if("sqlite" IN_LIST FEATURES)
+    set(DB_USE_SQLITE ON)
+endif()
+
+set(DB_USE_MONGODB OFF)
+if("mongodb" IN_LIST FEATURES)
+    set(DB_USE_MONGODB ON)
+endif()
+
+set(DB_USE_REDIS OFF)
+if("redis" IN_LIST FEATURES)
+    set(DB_USE_REDIS ON)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DUSE_POSTGRESQL=${DB_USE_POSTGRESQL}
+        -DUSE_SQLITE=${DB_USE_SQLITE}
+        -DUSE_MONGODB=${DB_USE_MONGODB}
+        -DUSE_REDIS=${DB_USE_REDIS}
+        -DUSE_UNIT_TEST=OFF
+        -DBUILD_DATABASE_SAMPLES=OFF
+        -DDATABASE_BUILD_BENCHMARKS=OFF
+        -DDATABASE_BUILD_INTEGRATION_TESTS=OFF
+        -DBUILD_SHARED_LIBS=OFF
+        -DUSE_THREAD_SYSTEM=OFF
+        -DUSE_MONITORING_SYSTEM=OFF
+        -DUSE_CONTAINER_SYSTEM=OFF
+        -DBUILD_INTEGRATED_DATABASE=OFF
+        -DFETCHCONTENT_FULLY_DISCONNECTED=ON
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME database_system
+    CONFIG_PATH lib/cmake/database_system
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/vcpkg-ports/kcenon-database-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-database-system/vcpkg.json
@@ -1,0 +1,70 @@
+{
+  "name": "kcenon-database-system",
+  "version": "0.1.0",
+  "port-version": 4,
+  "description": "Pure, lightweight C++20 Core DAL library with unified access to PostgreSQL, SQLite, MongoDB, and Redis",
+  "homepage": "https://github.com/kcenon/database_system",
+  "license": "BSD-3-Clause",
+  "supports": "!(uwp | xbox)",
+  "dependencies": [
+    "kcenon-common-system",
+    {
+      "name": "asio",
+      "version>=": "1.30.2"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "postgresql"
+  ],
+  "features": {
+    "postgresql": {
+      "description": "Enable PostgreSQL database support",
+      "dependencies": [
+        "libpq",
+        {
+          "name": "libpqxx",
+          "default-features": false
+        },
+        {
+          "name": "openssl",
+          "version>=": "3.3.0"
+        }
+      ]
+    },
+    "sqlite": {
+      "description": "Enable SQLite database support",
+      "dependencies": [
+        {
+          "name": "sqlite3",
+          "version>=": "3.45.0"
+        }
+      ]
+    },
+    "mongodb": {
+      "description": "Enable MongoDB backend (experimental)",
+      "dependencies": [
+        {
+          "name": "mongo-cxx-driver",
+          "version>=": "3.8.0"
+        }
+      ]
+    },
+    "redis": {
+      "description": "Enable Redis backend (experimental)",
+      "dependencies": [
+        {
+          "name": "hiredis",
+          "version>=": "1.2.0"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `vcpkg-ports/kcenon-database-system/` with `portfile.cmake` and `vcpkg.json` mirroring the canonical vcpkg-registry

## Rationale

Standardize portfile management (Strategy B: local + registry sync) across the ecosystem, following the pattern already established by `monitoring_system`. Local portfiles enable atomic source+port changes and CI validation.

## Test plan

- [ ] Verify portfile matches the canonical registry version
- [ ] CI builds pass without regression

Ref: kcenon/vcpkg-registry#36