### PR TITLE
chore(deps): remove duplicate asio override from vcpkg-configuration.json

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -13,11 +13,5 @@
         "kcenon-*"
       ]
     }
-  ],
-  "overrides": [
-    {
-      "name": "asio",
-      "version": "1.30.2"
-    }
   ]
 }


### PR DESCRIPTION
## What

Remove the redundant `overrides` block from `vcpkg-configuration.json` that pinned `asio` to version `1.30.2`.

### Change Type
- [x] Chore (dependency configuration cleanup)

## Why

### Related Issues
- Closes #496

### Motivation
The asio version override is already managed through the custom vcpkg registry (`kcenon-*` packages). The explicit override in `vcpkg-configuration.json` is redundant and can cause version conflicts during dependency resolution. Removing it aligns this file with the standard ecosystem pattern of only having `default-registry` and `registries` blocks.

## Where

### Files Changed
| File | Change |
|------|--------|
| `vcpkg-configuration.json` | Removed `overrides` block (lines 17-22), removed trailing comma on `registries` array |

## How

### Implementation Details
Removed the entire `overrides` array containing the pinned asio version. No other changes to the file.

### Test Plan
- [ ] Verify `vcpkg-configuration.json` is valid JSON after the change
- [ ] Verify CI builds pass without the explicit asio override
- [ ] Confirm dependency resolution works correctly with only the registry-based configuration