### PR TITLE
chore(vcpkg): add default-features to root manifest

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -14,6 +14,9 @@
       "version>=": "1.30.2"
     }
   ],
+  "default-features": [
+    "postgresql"
+  ],
   "overrides": [
     { "name": "asio", "version": "1.30.2" },
     { "name": "openssl", "version": "3.4.1" },


### PR DESCRIPTION
## What

### Summary
Add `default-features: ["postgresql"]` to root `vcpkg.json` to match port manifest.

### Change Type
- [x] Chore (dependency metadata alignment)

## Why

### Related Issues
- Closes #507

### Motivation
Port vcpkg.json declares `"default-features": ["postgresql"]` matching the CMake default `USE_POSTGRESQL=ON`. Root manifest was missing this, causing inconsistent behavior between local development and registry consumption.

## Where

### Files Changed
| File | Change |
|------|--------|
| `vcpkg.json` | Add `default-features` field with `["postgresql"]` |

## How

### Implementation
Added `"default-features": ["postgresql"]` between the `dependencies` and `overrides` arrays.

### Testing Done
- [x] JSON validation (syntax check)
- [x] CI passes on all platforms

### Breaking Changes
None