### PR TITLE
fix(vcpkg): upgrade libpqxx to 7.9.2 and add default-features

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -14,11 +14,14 @@
       "version>=": "1.30.2"
     }
   ],
+  "default-features": [
+    "postgresql"
+  ],
   "overrides": [
     { "name": "asio", "version": "1.30.2" },
     { "name": "openssl", "version": "3.4.1" },
     { "name": "libpq", "version": "16.2" },
-    { "name": "libpqxx", "version": "7.9.0" },
+    { "name": "libpqxx", "version": "7.9.2" },
     { "name": "sqlite3", "version": "3.45.3" },
     { "name": "mongo-cxx-driver", "version": "3.10.1" },
     { "name": "hiredis", "version": "1.2.0" },


### PR DESCRIPTION
## What

### Summary
Upgrade libpqxx override from 7.9.0 to 7.9.2 to fix CMake build failure, and add
`default-features: ["postgresql"]` to align root manifest with port manifest.

### Change Type
- [x] Bugfix (dependency version fix)
- [x] Chore (dependency metadata alignment)

## Why

### Related Issues
- Closes #507

### Motivation
**Previous attempt** (#508) failed because adding `default-features: ["postgresql"]`
causes vcpkg to install libpqxx, which fails with:

```
CMake Error at cmake/config.cmake:42 (cmake_determine_compile_features):
  Unknown CMake command "cmake_determine_compile_features".
```

**Root cause**: `libpqxx 7.9.0` has a broken CMake configuration calling a non-existent
command. This was hidden because CI explicitly sets `-DUSE_POSTGRESQL=OFF`, and without
`default-features`, vcpkg never installed libpqxx.

**Fix**: Upgrade to `libpqxx 7.9.2` (patch release fixing the CMake config bug), then
add the `default-features` field.

### Alternatives Considered
1. ~~Remove postgresql from default-features~~ — Doesn't fix the underlying bug, leaves
   root/port inconsistent
2. ~~Upgrade to 7.10.x~~ — Larger version jump, higher risk of API changes; try
   patch release first

## Where

### Files Changed
| File | Change |
|------|--------|
| `vcpkg.json` | Upgrade libpqxx 7.9.0 → 7.9.2, add `default-features: ["postgresql"]` |

## How

### Implementation
1. Changed libpqxx override version from `"7.9.0"` to `"7.9.2"` in `overrides` array
2. Added `"default-features": ["postgresql"]` between `dependencies` and `overrides`

### Testing Done
- [x] JSON validation (syntax check)
- [x] CI passes on all platforms

### Breaking Changes
None. PostgreSQL was already the CMake default (`USE_POSTGRESQL=ON`). CI explicitly
disables it (`-DUSE_POSTGRESQL=OFF`) so build behavior is unchanged.

### Rollback Plan
Revert this PR — no data or schema changes involved.