### PR TITLE
chore(ci): add automated vcpkg registry sync on release

### DIFF
--- a/.github/workflows/on-release-sync-registry.yml
+++ b/.github/workflows/on-release-sync-registry.yml
@@ -1,0 +1,14 @@
+name: Sync Registry on Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  sync:
+    uses: kcenon/common_system/.github/workflows/sync-vcpkg-registry.yml@main
+    with:
+      port-name: kcenon-database-system
+      version: ${{ github.event.release.tag_name }}
+    secrets:
+      REGISTRY_PAT: ${{ secrets.VCPKG_REGISTRY_PAT }}


### PR DESCRIPTION
## Summary

- Add `on-release-sync-registry.yml` trigger workflow
- References centralized `sync-vcpkg-registry.yml` in common_system
- On release publish, automatically syncs port to vcpkg-registry

## Prerequisites

`VCPKG_REGISTRY_PAT` secret must be configured in repo settings.

## Related

- Part of kcenon/common_system#544
- Part of kcenon/common_system#541 (Ecosystem vcpkg Registry Sync Automation)

## Test Plan

- Verify workflow YAML is valid (CI validates)
- Full verification on next release