### PR TITLE
fix(vcpkg): sync local portfile CONFIG_PATH with v0.1.0 release tag

### DIFF
--- a/vcpkg-ports/kcenon-database-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-database-system/portfile.cmake
@@ -36,8 +36,8 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(
-    PACKAGE_NAME database_system
-    CONFIG_PATH lib/cmake/database_system
+    PACKAGE_NAME DatabaseSystem
+    CONFIG_PATH lib/cmake/DatabaseSystem
 )
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/vcpkg-ports/kcenon-database-system/usage
+++ b/vcpkg-ports/kcenon-database-system/usage
@@ -1,0 +1,6 @@
+The package kcenon-database-system provides CMake targets:
+
+    find_package(database_system CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE database_system::database)
+
+Available features: postgresql (default), sqlite, mongodb, redis

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "kcenon-database-system",
   "version-semver": "0.1.0",
-  "port-version": 0,
+  "port-version": 5,
   "description": "Advanced C++20 Database System with Multi-Backend Support",
   "homepage": "https://github.com/kcenon/database_system",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
## Summary
- Fix `vcpkg_cmake_config_fixup` PACKAGE_NAME and CONFIG_PATH to match v0.1.0 release tag (PascalCase)
- Sync root `vcpkg.json` port-version from 0 to 5
- Add missing `usage` file to local port directory

## Related
- Closes #517
- Related: kcenon/vcpkg-registry#48

## Test plan
- [ ] Verify portfile PACKAGE_NAME matches release tag install path
- [ ] Verify root vcpkg.json port-version matches port definition