### PR TITLE
fix(vcpkg): sync port-version with registry baseline

### DIFF
--- a/vcpkg-ports/kcenon-database-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-database-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-database-system",
   "version-semver": "0.1.0",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Pure, lightweight C++20 Core DAL library with unified access to PostgreSQL, SQLite, MongoDB, and Redis",
   "homepage": "https://github.com/kcenon/database_system",
   "license": "BSD-3-Clause",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "kcenon-database-system",
   "version-semver": "0.1.0",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Advanced C++20 Database System with Multi-Backend Support",
   "homepage": "https://github.com/kcenon/database_system",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
## What
Sync port-version from 5 to 6 to match vcpkg-registry baseline.

## Why
Registry PR (kcenon/vcpkg-registry#49) bumped port-version to 6 when reverting PACKAGE_NAME to PascalCase, but source repo was not updated.

## How
- Updated `vcpkg.json` port-version: 5 → 6
- Updated `vcpkg-ports/kcenon-database-system/vcpkg.json` port-version: 5 → 6

Closes #519