### PR TITLE
fix(coverage): fix codecov reporting showing 5% instead of actual coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -64,28 +64,51 @@ jobs:
 
     - name: Generate coverage report
       run: |
-        cd build
-        # Capture coverage data
-        # Ubuntu 22.04 lcov 1.14 only supports --ignore-errors source
-        lcov --directory . --capture --output-file coverage.info --ignore-errors source --rc lcov_branch_coverage=0 2>/dev/null || \
-          lcov --directory . --capture --output-file coverage.info 2>/dev/null || true
+        WORKSPACE="${GITHUB_WORKSPACE}"
 
-        # Filter out system headers and test files
-        if [ -f coverage.info ]; then
-          lcov --remove coverage.info '/usr/*' '*/test/*' '*/tests/*' '*/examples/*' '*/samples/*' '*/googletest/*' \
-            --output-file coverage_filtered.info --ignore-errors source 2>/dev/null || true
+        # Capture coverage data with base directory set to workspace root
+        lcov --directory build --capture \
+          --output-file build/coverage_raw.info \
+          --base-directory "${WORKSPACE}" \
+          --ignore-errors source \
+          --rc lcov_branch_coverage=0 2>/dev/null || \
+        lcov --directory build --capture \
+          --output-file build/coverage_raw.info \
+          --base-directory "${WORKSPACE}" 2>/dev/null || true
+
+        if [ -f build/coverage_raw.info ]; then
+          # Extract only project source files (database/ directory)
+          lcov --extract build/coverage_raw.info \
+            "${WORKSPACE}/database/*" \
+            --output-file build/coverage.info \
+            --ignore-errors source 2>/dev/null || true
+
+          if [ -f build/coverage.info ]; then
+            # Remove test helpers that may be under database/
+            lcov --remove build/coverage.info \
+              '*/test/*' '*/tests/*' '*/mock/*' '*/mocks/*' \
+              --output-file build/coverage_filtered.info \
+              --ignore-errors source 2>/dev/null || \
+            cp build/coverage.info build/coverage_filtered.info
+          fi
 
           # Generate HTML report
-          if [ -f coverage_filtered.info ]; then
-            genhtml coverage_filtered.info --output-directory coverage_html --ignore-errors source 2>/dev/null || \
-              echo "⚠️  HTML coverage report generation skipped"
+          if [ -f build/coverage_filtered.info ]; then
+            genhtml build/coverage_filtered.info \
+              --output-directory build/coverage_html \
+              --ignore-errors source 2>/dev/null || \
+              echo "HTML coverage report generation skipped"
 
             # Print summary
-            lcov --list coverage_filtered.info --ignore-errors source 2>/dev/null || \
-              echo "⚠️  Coverage summary generation skipped"
+            echo "=== Coverage Summary ==="
+            lcov --summary build/coverage_filtered.info \
+              --ignore-errors source 2>/dev/null || true
+            echo ""
+            lcov --list build/coverage_filtered.info \
+              --ignore-errors source 2>/dev/null || true
           fi
         else
-          echo "⚠️  Coverage data file not created"
+          echo "Coverage data file not created"
         fi
 
     - name: Upload coverage to Codecov
@@ -96,6 +119,7 @@ jobs:
         name: database_system-coverage
         fail_ci_if_error: false
         verbose: true
+        root_dir: ${{ github.workspace }}
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -105,6 +129,7 @@ jobs:
       with:
         name: coverage-report
         path: |
+          build/coverage_raw.info
           build/coverage.info
           build/coverage_filtered.info
           build/coverage_html/

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,8 @@
 # Codecov Configuration for database_system
-# See: https://docs.codecov.io/docs/codecov-yaml
+# https://docs.codecov.com/docs/codecovyml-reference
+
+codecov:
+  require_ci_to_pass: yes
 
 coverage:
   precision: 2
@@ -12,11 +15,13 @@ coverage:
         target: 55%  # Phase 1: Establish realistic baseline
         threshold: 2%
         if_ci_failed: error
+        informational: true  # Don't block PRs on coverage status
 
     patch:
       default:
         target: 60%
         threshold: 5%
+        informational: true
 
 # Gradual improvement plan:
 # - Phase 1 (Current): 55% project, 60% patch - Establish baseline
@@ -34,29 +39,28 @@ parsers:
 comment:
   layout: "reach, diff, flags, files"
   behavior: default
-  require_changes: true
+  require_changes: no
   require_base: false
   require_head: true
 
 flags:
-  database:
+  unittests:
     paths:
       - database/
     carryforward: true
 
-  integration:
-    paths:
-      - integration_tests/
-    carryforward: true
-
 ignore:
-  - "tests/**/*"
-  - "third_party/**/*"
-  - "samples/**/*"
-  - "benchmarks/**/*"
-  - "build/**/*"
+  - "tests/**"
+  - "integration_tests/**"
+  - "third_party/**"
+  - "samples/**"
+  - "benchmarks/**"
+  - "build/**"
+  - "build_*/**"
+  - "build-*/**"
+  - "docs/**"
+  - "cmake/**"
+  - "scripts/**"
+  - "common_system/**"
   - "**/*.md"
   - "**/CMakeLists.txt"
-
-fixes:
-  - "::database_system/database/::database/"


### PR DESCRIPTION
Closes #521

## Summary
- Remove malformed `fixes` section in `codecov.yml` that broke codecov path resolution (the `::` delimiters were incorrectly formatted, causing source file paths to not map to repository files)
- Switch lcov from blacklist (`--remove`) to whitelist (`--extract database/*`) approach for precise source-only coverage capture
- Add `--base-directory` and `root_dir` for explicit workspace path mapping
- Align `codecov.yml` with working `common_system`/`thread_system` configurations (add `codecov.require_ci_to_pass`, `informational: true`, comprehensive `ignore` list)
- Add `common_system/**` to ignore list to exclude external dependency coverage data

## Root Cause
The `fixes` section contained `"::database_system/database/::database/"` which is malformed — the double `::` delimiter caused codecov to misinterpret the path mapping rule, resulting in most source files not being matched to repository paths. Other ecosystem modules (common_system, thread_system) work correctly without a `fixes` section by relying on codecov's automatic GitHub Actions workspace detection.

## Test Plan
- [ ] Verify coverage workflow runs successfully on this PR
- [ ] Check codecov report shows accurate coverage percentage (expected: significantly higher than 5%)
- [ ] Verify coverage artifacts include raw, extracted, and filtered info files for debugging
- [ ] Confirm codecov comment appears on PR with per-file coverage breakdown