### PR TITLE
feat(examples): add examples directory with usage examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ endif()
 option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
 option(USE_UNIT_TEST "Use unit test" ON)
 option(BUILD_DATABASE_SAMPLES "Build database system samples" ON)
+option(BUILD_DATABASE_EXAMPLES "Build database system usage examples" OFF)
 option(USE_POSTGRESQL "Enable PostgreSQL support" ON)
 option(USE_SQLITE "Enable SQLite support" OFF)
 option(USE_MONGODB "Enable MongoDB backend (EXPERIMENTAL - see docs/BACKENDS.md)" OFF)
@@ -112,6 +113,7 @@ if(ENABLE_COVERAGE)
                     --exclude '.*tests/.*'
                     --exclude '.*third_party/.*'
                     --exclude '.*samples/.*'
+                    --exclude '.*examples/.*'
                     --exclude '.*benchmarks/.*'
                     --html --html-details
                     --output ${CMAKE_BINARY_DIR}/coverage/index.html
@@ -128,6 +130,7 @@ if(ENABLE_COVERAGE)
                     --exclude '.*tests/.*'
                     --exclude '.*third_party/.*'
                     --exclude '.*samples/.*'
+                    --exclude '.*examples/.*'
                     --exclude '.*benchmarks/.*'
                     --fail-under-line 80
                     --print-summary
@@ -311,6 +314,15 @@ if(BUILD_DATABASE_SAMPLES AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/samples)
 endif()
 
 ##################################################
+# Examples
+##################################################
+
+if(BUILD_DATABASE_EXAMPLES AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/examples)
+    add_subdirectory(examples)
+    message(STATUS "Database examples will be built")
+endif()
+
+##################################################
 # Testing
 ##################################################
 
@@ -478,6 +490,7 @@ message(STATUS "  Integrated database: ${BUILD_INTEGRATED_DATABASE}")
 message(STATUS "")
 message(STATUS "Build Options:")
 message(STATUS "  Build samples: ${BUILD_DATABASE_SAMPLES}")
+message(STATUS "  Build examples: ${BUILD_DATABASE_EXAMPLES}")
 message(STATUS "  Build tests: ${USE_UNIT_TEST}")
 message(STATUS "  Build integration tests: ${DATABASE_BUILD_INTEGRATION_TESTS}")
 message(STATUS "  Build benchmarks: ${DATABASE_BUILD_BENCHMARKS}")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,126 @@
+cmake_minimum_required(VERSION 3.20)
+
+##################################################
+# Database System Examples CMakeLists.txt
+#
+# Introductory examples demonstrating database_system usage.
+# Each example focuses on a single feature area.
+##################################################
+
+project(database_system_examples
+    VERSION 0.1.0
+    DESCRIPTION "Database System Usage Examples"
+    LANGUAGES CXX
+)
+
+# C++ Standard
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Find required packages
+find_package(Threads REQUIRED)
+
+##################################################
+# Example Programs
+##################################################
+
+set(EXAMPLE_PROGRAMS
+    basic_connection
+    query_builder_usage
+    transaction_management
+    error_handling
+    orm_entity_demo
+    connection_pool_demo
+)
+
+# Output directory
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+##################################################
+# Build Each Example
+##################################################
+
+foreach(EXAMPLE ${EXAMPLE_PROGRAMS})
+    add_executable(example_${EXAMPLE} ${EXAMPLE}.cpp)
+
+    set_target_properties(example_${EXAMPLE} PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+    )
+
+    target_include_directories(example_${EXAMPLE} PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/..
+        ${CMAKE_CURRENT_SOURCE_DIR}/../..
+    )
+
+    target_link_libraries(example_${EXAMPLE} PRIVATE
+        database
+        Threads::Threads
+    )
+
+    # Compiler-specific options
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(example_${EXAMPLE} PRIVATE
+            -Wall
+            -Wextra
+            -Wpedantic
+            -Wno-unused-parameter
+        )
+    elseif(MSVC)
+        target_compile_options(example_${EXAMPLE} PRIVATE
+            /W4
+            /wd4100  # unreferenced formal parameter
+        )
+    endif()
+
+    # Platform-specific definitions
+    if(WIN32)
+        target_compile_definitions(example_${EXAMPLE} PRIVATE
+            _WIN32_WINNT=0x0A00
+            WIN32_LEAN_AND_MEAN
+            NOMINMAX
+        )
+    endif()
+
+    message(STATUS "Database example configured: ${EXAMPLE}")
+endforeach()
+
+##################################################
+# Installation (Optional)
+##################################################
+
+set(EXAMPLE_TARGETS)
+foreach(EXAMPLE ${EXAMPLE_PROGRAMS})
+    list(APPEND EXAMPLE_TARGETS example_${EXAMPLE})
+endforeach()
+
+install(TARGETS ${EXAMPLE_TARGETS}
+    RUNTIME DESTINATION bin/examples
+    COMPONENT examples
+)
+
+# Install example source files for reference
+set(EXAMPLE_SOURCES)
+foreach(EXAMPLE ${EXAMPLE_PROGRAMS})
+    list(APPEND EXAMPLE_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/${EXAMPLE}.cpp)
+endforeach()
+list(APPEND EXAMPLE_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt
+    ${CMAKE_CURRENT_SOURCE_DIR}/README.md
+)
+
+install(FILES ${EXAMPLE_SOURCES}
+    DESTINATION share/database_system/examples
+    COMPONENT examples
+)
+
+##################################################
+# Summary
+##################################################
+
+message(STATUS "Database System Examples configured:")
+message(STATUS "  Example programs: ${EXAMPLE_PROGRAMS}")
+message(STATUS "  Output directory: ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+message(STATUS "  Dependencies: database, Threads")

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,59 @@
+# database_system Examples
+
+Introductory C++20 examples demonstrating the core features of database_system.
+Each example focuses on a single feature area and is designed to be read top-to-bottom.
+
+## Examples
+
+| Example | File | Database Required | Description |
+|---------|------|:-----------------:|-------------|
+| **Basic Connection** | `basic_connection.cpp` | Yes | Connect to PostgreSQL, create a table, insert and query data, disconnect. |
+| **Query Builder** | `query_builder_usage.cpp` | No | Build SELECT, INSERT, UPDATE, DELETE queries using the fluent API. Demonstrates joins, grouping, conditions, and dialect switching. |
+| **Transaction Management** | `transaction_management.cpp` | Yes | Begin, commit, and rollback transactions. Includes a RAII transaction guard pattern. |
+| **Error Handling** | `error_handling.cpp` | Partial | Use `Result<T>` and `VoidResult` to handle connection failures, invalid SQL, constraint violations, and chained operations. |
+| **ORM Entity** | `orm_entity_demo.cpp` | No | Define entity classes with field metadata and constraints. Generate CREATE TABLE SQL and inspect metadata programmatically. |
+| **Connection Pool** | `connection_pool_demo.cpp` | Yes | Multi-threaded database usage with independent `database_manager` instances per thread. |
+
+## Building
+
+Examples are built when the `BUILD_DATABASE_EXAMPLES` CMake option is enabled (default: `OFF`):
+
+```bash
+cmake -B build -DBUILD_DATABASE_EXAMPLES=ON
+cmake --build build
+```
+
+The example binaries are placed in `build/bin/`:
+
+```
+build/bin/example_basic_connection
+build/bin/example_query_builder_usage
+build/bin/example_transaction_management
+build/bin/example_error_handling
+build/bin/example_orm_entity_demo
+build/bin/example_connection_pool_demo
+```
+
+## Running Without a Database
+
+Two examples (`query_builder_usage` and `orm_entity_demo`) do not require a running database server. They demonstrate API usage by generating SQL strings and inspecting metadata in-memory.
+
+## Running With PostgreSQL
+
+For examples that require a database:
+
+1. Start a PostgreSQL server (local or Docker).
+2. Create a database:
+   ```sql
+   CREATE DATABASE example_db;
+   CREATE USER "user" WITH PASSWORD 'password';
+   GRANT ALL PRIVILEGES ON DATABASE example_db TO "user";
+   ```
+3. Update the connection string in the example source file if needed.
+4. Run the example binary.
+
+## Relationship to samples/
+
+The `samples/` directory contains more comprehensive integration-level programs.
+These `examples/` are intentionally simpler and focused on introducing individual
+API features to new users.

--- a/examples/basic_connection.cpp
+++ b/examples/basic_connection.cpp
@@ -1,0 +1,128 @@
+/**
+ * BSD 3-Clause License
+ * Copyright (c) 2025, kcenon
+ *
+ * @file basic_connection.cpp
+ * @brief Demonstrates basic database connection and simple query execution.
+ *
+ * This example shows how to:
+ * - Create a database_context and database_manager
+ * - Configure the database backend (PostgreSQL)
+ * - Connect to a database using a connection string
+ * - Execute a simple SQL query
+ * - Retrieve and display results
+ * - Disconnect cleanly
+ *
+ * Prerequisites:
+ * - A running PostgreSQL server (or adjust for your backend)
+ * - Update the connection string below with valid credentials
+ */
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <variant>
+
+#include "database/database_manager.h"
+#include "database/core/database_context.h"
+
+using namespace database;
+
+int main()
+{
+	std::cout << "=== basic_connection example ===" << std::endl;
+
+	// Step 1: Create a dependency injection context.
+	// database_context manages shared components such as the performance
+	// monitor and entity manager.
+	auto context = std::make_shared<database_context>();
+
+	// Step 2: Create the database manager using the context.
+	auto db_manager = std::make_shared<database_manager>(context);
+
+	// Step 3: Select the database backend.
+	// Available types: database_types::postgres, database_types::sqlite, etc.
+	if (!db_manager->set_mode(database_types::postgres))
+	{
+		std::cerr << "Failed to set database mode to PostgreSQL" << std::endl;
+		return 1;
+	}
+	std::cout << "Database mode set to PostgreSQL" << std::endl;
+
+	// Step 4: Connect to the database.
+	// Adjust the connection string to match your environment.
+	std::string connection_string
+		= "host=localhost port=5432 dbname=example_db user=user password=password";
+
+	std::cout << "Connecting to database..." << std::endl;
+	auto connect_result = db_manager->connect_result(connection_string);
+
+	if (!connect_result.is_ok())
+	{
+		std::cerr << "Connection failed. Make sure PostgreSQL is running and\n"
+				  << "the connection string is correct.\n"
+				  << "Connection string format:\n"
+				  << "  host=<host> port=<port> dbname=<db> user=<user> password=<pass>"
+				  << std::endl;
+		return 1;
+	}
+	std::cout << "Connected successfully" << std::endl;
+
+	// Step 5: Create a table (DDL query).
+	std::string create_sql = R"(
+		CREATE TABLE IF NOT EXISTS greetings (
+			id    SERIAL PRIMARY KEY,
+			message VARCHAR(200) NOT NULL
+		)
+	)";
+
+	auto create_result = db_manager->create_query_result(create_sql);
+	if (create_result.is_ok())
+	{
+		std::cout << "Table 'greetings' is ready" << std::endl;
+	}
+	else
+	{
+		std::cerr << "Failed to create table" << std::endl;
+	}
+
+	// Step 6: Insert a row (DML query).
+	auto insert_result = db_manager->execute_query_result(
+		"INSERT INTO greetings (message) VALUES ('Hello from database_system!')");
+
+	if (insert_result.is_ok())
+	{
+		std::cout << "Row inserted" << std::endl;
+	}
+
+	// Step 7: Select rows and display results.
+	auto select_result
+		= db_manager->select_query_result("SELECT id, message FROM greetings ORDER BY id");
+
+	if (select_result.is_ok())
+	{
+		const auto& rows = select_result.value();
+		std::cout << "Query returned " << rows.size() << " row(s):" << std::endl;
+
+		for (const auto& row : rows)
+		{
+			for (const auto& [column, value] : row)
+			{
+				std::cout << "  " << column << " = ";
+				std::visit([](const auto& v) { std::cout << v; }, value);
+				std::cout << std::endl;
+			}
+		}
+	}
+	else
+	{
+		std::cerr << "Select query failed: " << select_result.error().message << std::endl;
+	}
+
+	// Step 8: Disconnect.
+	db_manager->disconnect_result();
+	std::cout << "Disconnected" << std::endl;
+
+	std::cout << "=== basic_connection example completed ===" << std::endl;
+	return 0;
+}

--- a/examples/connection_pool_demo.cpp
+++ b/examples/connection_pool_demo.cpp
@@ -1,0 +1,181 @@
+/**
+ * BSD 3-Clause License
+ * Copyright (c) 2025, kcenon
+ *
+ * @file connection_pool_demo.cpp
+ * @brief Demonstrates multi-threaded database usage with independent
+ *        database_manager instances.
+ *
+ * This example shows how to:
+ * - Create multiple database_manager instances for concurrent use
+ * - Use separate database_context instances per thread
+ * - Execute queries safely from multiple threads
+ * - Aggregate results from parallel database operations
+ *
+ * Design note: database_manager instances are not thread-safe for
+ * concurrent operations on the same instance. Each thread should use
+ * its own database_manager. The underlying connection pooling is handled
+ * server-side (ProxyMode) or by creating separate connections.
+ *
+ * Prerequisites:
+ * - A running PostgreSQL server
+ * - Update the connection string below with valid credentials
+ */
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+#include <mutex>
+#include <variant>
+
+#include "database/database_manager.h"
+#include "database/core/database_context.h"
+
+using namespace database;
+
+static std::mutex cout_mutex;
+
+/**
+ * @brief Thread-safe print helper.
+ */
+static void thread_print(int thread_id, const std::string& msg)
+{
+	std::lock_guard<std::mutex> lock(cout_mutex);
+	std::cout << "  [thread " << thread_id << "] " << msg << std::endl;
+}
+
+/**
+ * @brief Worker function: creates its own connection, inserts data, reads it
+ *        back, and disconnects.
+ */
+static void worker(int thread_id, const std::string& connection_string)
+{
+	// Each thread creates its own context and manager
+	auto context = std::make_shared<database_context>();
+	auto db = std::make_shared<database_manager>(context);
+	db->set_mode(database_types::postgres);
+
+	auto connect_result = db->connect_result(connection_string);
+	if (!connect_result.is_ok())
+	{
+		thread_print(thread_id, "Connection failed");
+		return;
+	}
+	thread_print(thread_id, "Connected");
+
+	// Insert a row identifying this thread
+	std::string insert_sql
+		= "INSERT INTO pool_demo (thread_id, message) VALUES ("
+		  + std::to_string(thread_id) + ", 'Hello from thread "
+		  + std::to_string(thread_id) + "')";
+
+	auto insert_result = db->execute_query_result(insert_sql);
+	if (insert_result.is_ok())
+	{
+		thread_print(thread_id, "Row inserted");
+	}
+	else
+	{
+		thread_print(thread_id, "Insert failed");
+	}
+
+	// Read back all rows (each thread sees the current state)
+	auto select_result = db->select_query_result(
+		"SELECT thread_id, message FROM pool_demo ORDER BY thread_id");
+	if (select_result.is_ok())
+	{
+		thread_print(thread_id,
+					 "Read " + std::to_string(select_result.value().size()) + " row(s)");
+	}
+
+	db->disconnect_result();
+	thread_print(thread_id, "Disconnected");
+}
+
+int main()
+{
+	std::cout << "=== connection_pool_demo example ===" << std::endl;
+
+	std::string connection_string
+		= "host=localhost port=5432 dbname=example_db user=user password=password";
+
+	// Setup: create the demo table using a single connection
+	{
+		auto context = std::make_shared<database_context>();
+		auto db = std::make_shared<database_manager>(context);
+		db->set_mode(database_types::postgres);
+
+		auto connect_result = db->connect_result(connection_string);
+		if (!connect_result.is_ok())
+		{
+			std::cerr << "Setup connection failed. Ensure PostgreSQL is running."
+					  << std::endl;
+			return 1;
+		}
+
+		db->create_query_result(R"(
+			CREATE TABLE IF NOT EXISTS pool_demo (
+				id        SERIAL PRIMARY KEY,
+				thread_id INTEGER NOT NULL,
+				message   VARCHAR(200)
+			)
+		)");
+		db->execute_query_result("DELETE FROM pool_demo");
+		db->disconnect_result();
+		std::cout << "Setup complete" << std::endl;
+	}
+
+	// Launch multiple threads, each with its own connection
+	const int num_threads = 4;
+	std::vector<std::thread> threads;
+	threads.reserve(num_threads);
+
+	std::cout << "\nLaunching " << num_threads << " worker threads..." << std::endl;
+
+	for (int i = 0; i < num_threads; ++i)
+	{
+		threads.emplace_back(worker, i, connection_string);
+	}
+
+	// Wait for all threads to complete
+	for (auto& t : threads)
+	{
+		t.join();
+	}
+	std::cout << "\nAll threads completed" << std::endl;
+
+	// Final verification: read all inserted rows
+	{
+		auto context = std::make_shared<database_context>();
+		auto db = std::make_shared<database_manager>(context);
+		db->set_mode(database_types::postgres);
+
+		auto connect_result = db->connect_result(connection_string);
+		if (connect_result.is_ok())
+		{
+			auto result = db->select_query_result(
+				"SELECT thread_id, message FROM pool_demo ORDER BY thread_id");
+			if (result.is_ok())
+			{
+				std::cout << "\nFinal table contents (" << result.value().size()
+						  << " rows):" << std::endl;
+				for (const auto& row : result.value())
+				{
+					for (const auto& [col, val] : row)
+					{
+						std::cout << "  " << col << " = ";
+						std::visit([](const auto& v) { std::cout << v; }, val);
+						std::cout << "  ";
+					}
+					std::cout << std::endl;
+				}
+			}
+			db->disconnect_result();
+		}
+	}
+
+	std::cout << "\n=== connection_pool_demo example completed ===" << std::endl;
+	return 0;
+}

--- a/examples/error_handling.cpp
+++ b/examples/error_handling.cpp
@@ -1,0 +1,223 @@
+/**
+ * BSD 3-Clause License
+ * Copyright (c) 2025, kcenon
+ *
+ * @file error_handling.cpp
+ * @brief Demonstrates the Result<T> error handling pattern used throughout
+ *        the database_system API.
+ *
+ * This example shows how to:
+ * - Use VoidResult for operations that either succeed or fail
+ * - Use Result<T> for operations that return data on success
+ * - Inspect error messages from failed operations
+ * - Chain operations with early-return on failure
+ * - Handle connection failures, query failures, and data validation
+ *
+ * Note: Parts of this example intentionally trigger errors to demonstrate
+ * the error handling paths. A running PostgreSQL server is required for
+ * full execution, but the patterns are useful even without one.
+ */
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <variant>
+
+#include "database/database_manager.h"
+#include "database/core/database_context.h"
+
+using namespace database;
+
+/**
+ * @brief Helper to print a Result error.
+ *
+ * The error type returned by Result<T>::error() is kcenon::common::error_info,
+ * which contains code, message, and module fields.
+ */
+static void print_error(const std::string& operation, const kcenon::common::error_info& err)
+{
+	std::cerr << "  [ERROR] " << operation << ": " << err.message << std::endl;
+}
+
+/**
+ * @brief Demonstrates handling a connection failure gracefully.
+ */
+static void demonstrate_connection_failure()
+{
+	std::cout << "\n--- Connection failure handling ---" << std::endl;
+
+	auto context = std::make_shared<database_context>();
+	auto db = std::make_shared<database_manager>(context);
+	db->set_mode(database_types::postgres);
+
+	// Intentionally use wrong credentials
+	auto result = db->connect_result(
+		"host=localhost port=9999 dbname=nonexistent user=nobody password=wrong");
+
+	if (result.is_ok())
+	{
+		std::cout << "  Connected (unexpected)" << std::endl;
+		db->disconnect_result();
+	}
+	else
+	{
+		print_error("connect", result.error());
+		std::cout << "  Connection failure handled gracefully" << std::endl;
+	}
+}
+
+/**
+ * @brief Demonstrates handling query errors with Result<T>.
+ */
+static void demonstrate_query_errors(std::shared_ptr<database_manager> db)
+{
+	std::cout << "\n--- Query error handling ---" << std::endl;
+
+	// 1. Execute invalid SQL
+	auto bad_sql = db->execute_query_result("THIS IS NOT VALID SQL");
+	if (!bad_sql.is_ok())
+	{
+		print_error("bad SQL", bad_sql.error());
+	}
+
+	// 2. Reference a non-existent table
+	auto missing_table = db->select_query_result("SELECT * FROM nonexistent_table_xyz");
+	if (!missing_table.is_ok())
+	{
+		print_error("missing table", missing_table.error());
+	}
+
+	// 3. Insert with constraint violation (duplicate primary key)
+	db->create_query_result(R"(
+		CREATE TABLE IF NOT EXISTS error_demo (
+			id   INTEGER PRIMARY KEY,
+			name VARCHAR(50) NOT NULL
+		)
+	)");
+	db->execute_query_result("DELETE FROM error_demo");
+	db->execute_query_result("INSERT INTO error_demo (id, name) VALUES (1, 'first')");
+
+	auto duplicate = db->execute_query_result(
+		"INSERT INTO error_demo (id, name) VALUES (1, 'duplicate')");
+	if (!duplicate.is_ok())
+	{
+		print_error("duplicate key", duplicate.error());
+		std::cout << "  Constraint violation handled" << std::endl;
+	}
+}
+
+/**
+ * @brief Demonstrates chaining operations with early return on failure.
+ */
+static bool demonstrate_chained_operations(std::shared_ptr<database_manager> db)
+{
+	std::cout << "\n--- Chained operations with early return ---" << std::endl;
+
+	// Step 1: Create table
+	auto step1 = db->create_query_result(R"(
+		CREATE TABLE IF NOT EXISTS chain_demo (
+			id    SERIAL PRIMARY KEY,
+			value INTEGER NOT NULL
+		)
+	)");
+	if (!step1.is_ok())
+	{
+		print_error("step 1 (create table)", step1.error());
+		return false;
+	}
+	std::cout << "  Step 1: Table created" << std::endl;
+
+	// Step 2: Insert data
+	auto step2 = db->execute_query_result(
+		"INSERT INTO chain_demo (value) VALUES (42)");
+	if (!step2.is_ok())
+	{
+		print_error("step 2 (insert)", step2.error());
+		return false;
+	}
+	std::cout << "  Step 2: Data inserted" << std::endl;
+
+	// Step 3: Read back
+	auto step3 = db->select_query_result("SELECT id, value FROM chain_demo");
+	if (!step3.is_ok())
+	{
+		print_error("step 3 (select)", step3.error());
+		return false;
+	}
+	std::cout << "  Step 3: Read " << step3.value().size() << " row(s)" << std::endl;
+
+	// Step 4: Verify data
+	if (step3.value().empty())
+	{
+		std::cerr << "  [ERROR] No rows returned" << std::endl;
+		return false;
+	}
+	std::cout << "  Step 4: Data verified" << std::endl;
+
+	return true;
+}
+
+/**
+ * @brief Demonstrates using last_error() for additional diagnostics.
+ */
+static void demonstrate_last_error(std::shared_ptr<database_manager> db)
+{
+	std::cout << "\n--- last_error() diagnostics ---" << std::endl;
+
+	// Trigger an error
+	db->execute_query_result("SELECT * FROM __does_not_exist__");
+
+	auto err = db->last_error();
+	if (!err.empty())
+	{
+		std::cout << "  last_error(): " << err << std::endl;
+	}
+	else
+	{
+		std::cout << "  last_error() returned empty (backend may not populate it)"
+				  << std::endl;
+	}
+}
+
+int main()
+{
+	std::cout << "=== error_handling example ===" << std::endl;
+
+	// Demonstrate connection failure (does not need a running DB)
+	demonstrate_connection_failure();
+
+	// For the remaining demos, attempt a real connection
+	auto context = std::make_shared<database_context>();
+	auto db = std::make_shared<database_manager>(context);
+	db->set_mode(database_types::postgres);
+
+	std::string connection_string
+		= "host=localhost port=5432 dbname=example_db user=user password=password";
+
+	auto connect = db->connect_result(connection_string);
+	if (!connect.is_ok())
+	{
+		std::cout << "\nSkipping remaining demos (no database connection available)"
+				  << std::endl;
+		std::cout << "=== error_handling example completed ===" << std::endl;
+		return 0;
+	}
+
+	demonstrate_query_errors(db);
+	demonstrate_chained_operations(db);
+	demonstrate_last_error(db);
+
+	// Connection info for diagnostics
+	std::cout << "\n--- Connection info ---" << std::endl;
+	auto info = db->connection_info();
+	for (const auto& [key, value] : info)
+	{
+		std::cout << "  " << key << " = " << value << std::endl;
+	}
+
+	db->disconnect_result();
+	std::cout << "\nDisconnected" << std::endl;
+
+	std::cout << "=== error_handling example completed ===" << std::endl;
+	return 0;
+}

--- a/examples/orm_entity_demo.cpp
+++ b/examples/orm_entity_demo.cpp
@@ -1,0 +1,245 @@
+/**
+ * BSD 3-Clause License
+ * Copyright (c) 2025, kcenon
+ *
+ * @file orm_entity_demo.cpp
+ * @brief Demonstrates the ORM entity system with field metadata and SQL
+ *        generation.
+ *
+ * This example shows how to:
+ * - Define an entity class deriving from entity_base
+ * - Configure field constraints (primary key, not null, unique, index)
+ * - Generate CREATE TABLE SQL from entity metadata
+ * - Inspect entity field metadata programmatically
+ * - Use type-safe field accessors
+ * - Check type traits for entity and field types
+ *
+ * Note: This example focuses on the ORM metadata and schema generation
+ * capabilities. It does not require a running database.
+ */
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "database/orm/entity.h"
+#include "database/database_types.h"
+
+using namespace database;
+using namespace database::orm;
+
+// -------------------------------------------------------
+// Define a User entity
+//
+// We manually implement table_name() and define fields
+// using the ENTITY_FIELD macro for type-safe accessors.
+// -------------------------------------------------------
+class user_entity : public entity_base
+{
+public:
+	using primary_key_type = int64_t;
+
+	std::string table_name() const override { return "users"; }
+
+	// Declare fields with constraints
+	ENTITY_FIELD(int64_t, id,
+				 field_constraint::primary_key | field_constraint::auto_increment)
+	ENTITY_FIELD(std::string, username,
+				 field_constraint::not_null | field_constraint::unique)
+	ENTITY_FIELD(std::string, email,
+				 field_constraint::not_null | field_constraint::unique)
+	ENTITY_FIELD(int32_t, age, field_constraint::not_null)
+	ENTITY_FIELD(bool, is_active, field_constraint::not_null)
+
+	ENTITY_METADATA()
+
+	// CRUD operations (stubs for this demo)
+	bool save() override { return false; }
+	bool load() override { return false; }
+	bool update() override { return false; }
+	bool remove() override { return false; }
+
+private:
+	static inline entity_metadata metadata_{"users"};
+};
+
+// Initialize entity metadata by registering each field
+void user_entity::initialize_metadata()
+{
+	metadata_.add_field(id_metadata_);
+	metadata_.add_field(username_metadata_);
+	metadata_.add_field(email_metadata_);
+	metadata_.add_field(age_metadata_);
+	metadata_.add_field(is_active_metadata_);
+}
+
+// -------------------------------------------------------
+// Define a Post entity with indexed field
+// -------------------------------------------------------
+class post_entity : public entity_base
+{
+public:
+	using primary_key_type = int64_t;
+
+	std::string table_name() const override { return "posts"; }
+
+	ENTITY_FIELD(int64_t, id,
+				 field_constraint::primary_key | field_constraint::auto_increment)
+	ENTITY_FIELD(std::string, title, field_constraint::not_null)
+	ENTITY_FIELD(std::string, body, field_constraint::none)
+	ENTITY_FIELD(int64_t, author_id,
+				 field_constraint::not_null | field_constraint::index)
+
+	ENTITY_METADATA()
+
+	bool save() override { return false; }
+	bool load() override { return false; }
+	bool update() override { return false; }
+	bool remove() override { return false; }
+
+private:
+	static inline entity_metadata metadata_{"posts"};
+};
+
+void post_entity::initialize_metadata()
+{
+	metadata_.add_field(id_metadata_);
+	metadata_.add_field(title_metadata_);
+	metadata_.add_field(body_metadata_);
+	metadata_.add_field(author_id_metadata_);
+}
+
+// -------------------------------------------------------
+// Main
+// -------------------------------------------------------
+int main()
+{
+	std::cout << "=== orm_entity_demo example ===" << std::endl;
+
+	// -------------------------------------------------------
+	// 1. Inspect User entity metadata
+	// -------------------------------------------------------
+	std::cout << "\n--- User entity metadata ---" << std::endl;
+	{
+		user_entity user;
+		const auto& meta = user.get_metadata();
+
+		std::cout << "Table: " << meta.table_name() << std::endl;
+		std::cout << "Fields:" << std::endl;
+
+		for (const auto& field : meta.fields())
+		{
+			std::cout << "  " << field.name()
+					  << " (" << field.type_name() << ")";
+
+			if (field.is_primary_key())
+			{
+				std::cout << " [PK]";
+			}
+			if (field.is_auto_increment())
+			{
+				std::cout << " [AUTO]";
+			}
+			if (field.is_not_null())
+			{
+				std::cout << " [NOT NULL]";
+			}
+			if (field.is_unique())
+			{
+				std::cout << " [UNIQUE]";
+			}
+			if (field.has_index())
+			{
+				std::cout << " [INDEX]";
+			}
+			std::cout << std::endl;
+		}
+
+		// Primary key info
+		const auto* pk = meta.get_primary_key();
+		if (pk != nullptr)
+		{
+			std::cout << "Primary key: " << pk->name() << std::endl;
+		}
+	}
+
+	// -------------------------------------------------------
+	// 2. Generate CREATE TABLE SQL
+	// -------------------------------------------------------
+	std::cout << "\n--- Generated SQL ---" << std::endl;
+	{
+		user_entity user;
+		std::cout << "User table SQL:" << std::endl;
+		std::cout << user.get_metadata().create_table_sql() << std::endl;
+
+		post_entity post;
+		std::cout << "\nPost table SQL:" << std::endl;
+		std::cout << post.get_metadata().create_table_sql() << std::endl;
+	}
+
+	// -------------------------------------------------------
+	// 3. Generate index SQL
+	// -------------------------------------------------------
+	std::cout << "\n--- Generated index SQL ---" << std::endl;
+	{
+		post_entity post;
+		auto index_sql = post.get_metadata().create_indexes_sql();
+		if (!index_sql.empty())
+		{
+			std::cout << "Post indexes:" << std::endl;
+			std::cout << index_sql << std::endl;
+		}
+		else
+		{
+			std::cout << "No additional indexes defined" << std::endl;
+		}
+	}
+
+	// -------------------------------------------------------
+	// 4. Using field accessors
+	// -------------------------------------------------------
+	std::cout << "\n--- Field accessors ---" << std::endl;
+	{
+		user_entity user;
+
+		// Set field values through accessors
+		user.id = int64_t{1};
+		user.username = std::string("john_doe");
+		user.email = std::string("john@example.com");
+		user.age = int32_t{30};
+		user.is_active = true;
+
+		// Read field values
+		std::cout << "User: "
+				  << "id=" << user.id.get()
+				  << " username=" << user.username.get()
+				  << " email=" << user.email.get()
+				  << " age=" << user.age.get()
+				  << " active=" << std::boolalpha << user.is_active.get()
+				  << std::endl;
+	}
+
+	// -------------------------------------------------------
+	// 5. Type trait checks
+	// -------------------------------------------------------
+	std::cout << "\n--- Type trait checks ---" << std::endl;
+	{
+		std::cout << "is_entity<user_entity>: "
+				  << std::boolalpha << is_entity_v<user_entity> << std::endl;
+		std::cout << "is_entity<post_entity>: "
+				  << std::boolalpha << is_entity_v<post_entity> << std::endl;
+		std::cout << "is_entity<int>: "
+				  << std::boolalpha << is_entity_v<int> << std::endl;
+
+		std::cout << "is_field_type<int32_t>: "
+				  << std::boolalpha << is_field_type_v<int32_t> << std::endl;
+		std::cout << "is_field_type<std::string>: "
+				  << std::boolalpha << is_field_type_v<std::string> << std::endl;
+		std::cout << "is_field_type<std::vector<int>>: "
+				  << std::boolalpha << is_field_type_v<std::vector<int>> << std::endl;
+	}
+
+	std::cout << "\n=== orm_entity_demo example completed ===" << std::endl;
+	return 0;
+}

--- a/examples/query_builder_usage.cpp
+++ b/examples/query_builder_usage.cpp
@@ -1,0 +1,207 @@
+/**
+ * BSD 3-Clause License
+ * Copyright (c) 2025, kcenon
+ *
+ * @file query_builder_usage.cpp
+ * @brief Demonstrates the fluent query builder API for constructing SQL queries.
+ *
+ * This example shows how to:
+ * - Build SELECT queries with WHERE, ORDER BY, LIMIT, and OFFSET
+ * - Build INSERT queries with column-value maps
+ * - Build UPDATE queries with SET and WHERE clauses
+ * - Build DELETE queries with conditions
+ * - Use JOIN, GROUP BY, and HAVING clauses
+ * - Use query_condition objects with logical operators
+ *
+ * Note: This example generates SQL strings without executing them. It does
+ * not require a running database and is useful for understanding the query
+ * builder API.
+ */
+
+#include <iostream>
+#include <string>
+#include <vector>
+#include <map>
+
+#include "database/query_builder.h"
+#include "database/database_types.h"
+
+using namespace database;
+
+int main()
+{
+	std::cout << "=== query_builder_usage example ===" << std::endl;
+
+	// -------------------------------------------------------
+	// 1. SELECT query
+	// -------------------------------------------------------
+	std::cout << "\n--- SELECT ---" << std::endl;
+	{
+		query_builder builder(database_types::postgres);
+
+		auto query = builder.select({"id", "name", "email"})
+						 .from("users")
+						 .where("age", ">=", int64_t{18})
+						 .where("is_active", "=", true)
+						 .order_by("name", sort_order::asc)
+						 .limit(20)
+						 .offset(0)
+						 .build();
+
+		std::cout << "SELECT query:\n  " << query << std::endl;
+	}
+
+	// -------------------------------------------------------
+	// 2. INSERT query
+	// -------------------------------------------------------
+	std::cout << "\n--- INSERT ---" << std::endl;
+	{
+		query_builder builder(database_types::postgres);
+
+		std::map<std::string, core::database_value> row;
+		row["name"] = std::string("Alice");
+		row["email"] = std::string("alice@example.com");
+		row["age"] = int64_t{30};
+		row["is_active"] = true;
+
+		auto query = builder.insert_into("users").values(row).build();
+
+		std::cout << "INSERT query:\n  " << query << std::endl;
+	}
+
+	// -------------------------------------------------------
+	// 3. Batch INSERT query
+	// -------------------------------------------------------
+	std::cout << "\n--- Batch INSERT ---" << std::endl;
+	{
+		query_builder builder(database_types::postgres);
+
+		std::vector<std::map<std::string, core::database_value>> rows;
+
+		std::map<std::string, core::database_value> row1;
+		row1["name"] = std::string("Bob");
+		row1["email"] = std::string("bob@example.com");
+		row1["age"] = int64_t{25};
+		rows.push_back(row1);
+
+		std::map<std::string, core::database_value> row2;
+		row2["name"] = std::string("Carol");
+		row2["email"] = std::string("carol@example.com");
+		row2["age"] = int64_t{28};
+		rows.push_back(row2);
+
+		auto query = builder.insert_into("users").values(rows).build();
+
+		std::cout << "Batch INSERT query:\n  " << query << std::endl;
+	}
+
+	// -------------------------------------------------------
+	// 4. UPDATE query
+	// -------------------------------------------------------
+	std::cout << "\n--- UPDATE ---" << std::endl;
+	{
+		query_builder builder(database_types::postgres);
+
+		auto query = builder.update("users")
+						 .set("email", std::string("newalice@example.com"))
+						 .set("age", int64_t{31})
+						 .where("name", "=", std::string("Alice"))
+						 .build();
+
+		std::cout << "UPDATE query:\n  " << query << std::endl;
+	}
+
+	// -------------------------------------------------------
+	// 5. DELETE query
+	// -------------------------------------------------------
+	std::cout << "\n--- DELETE ---" << std::endl;
+	{
+		query_builder builder(database_types::postgres);
+
+		auto query = builder.delete_from("users")
+						 .where("is_active", "=", false)
+						 .build();
+
+		std::cout << "DELETE query:\n  " << query << std::endl;
+	}
+
+	// -------------------------------------------------------
+	// 6. JOIN query
+	// -------------------------------------------------------
+	std::cout << "\n--- JOIN ---" << std::endl;
+	{
+		query_builder builder(database_types::postgres);
+
+		auto query = builder.select({"u.name", "o.total"})
+						 .from("users u")
+						 .join("orders o", "u.id = o.user_id", join_type::inner)
+						 .where("o.total", ">", 100.0)
+						 .order_by("o.total", sort_order::desc)
+						 .build();
+
+		std::cout << "JOIN query:\n  " << query << std::endl;
+	}
+
+	// -------------------------------------------------------
+	// 7. GROUP BY with HAVING
+	// -------------------------------------------------------
+	std::cout << "\n--- GROUP BY ---" << std::endl;
+	{
+		query_builder builder(database_types::postgres);
+
+		auto query = builder.select({"department", "COUNT(*) AS cnt"})
+						 .from("employees")
+						 .group_by("department")
+						 .having("COUNT(*) > 5")
+						 .order_by("cnt", sort_order::desc)
+						 .build();
+
+		std::cout << "GROUP BY query:\n  " << query << std::endl;
+	}
+
+	// -------------------------------------------------------
+	// 8. Compound conditions with query_condition
+	// -------------------------------------------------------
+	std::cout << "\n--- Compound conditions ---" << std::endl;
+	{
+		query_builder builder(database_types::postgres);
+
+		// Build individual conditions
+		query_condition age_check("age", ">=", int64_t{21});
+		query_condition active_check("is_active", "=", true);
+
+		// Combine with logical AND
+		auto combined = age_check && active_check;
+
+		auto query = builder.select({"*"}).from("users").where(combined).build();
+
+		std::cout << "Compound condition query:\n  " << query << std::endl;
+	}
+
+	// -------------------------------------------------------
+	// 9. Switching database dialect
+	// -------------------------------------------------------
+	std::cout << "\n--- Dialect switch ---" << std::endl;
+	{
+		query_builder builder(database_types::postgres);
+
+		auto pg_query = builder.select({"id", "name"})
+							.from("users")
+							.where("id", "=", int64_t{1})
+							.build();
+		std::cout << "PostgreSQL: " << pg_query << std::endl;
+
+		// Reset and switch dialect to SQLite
+		builder.reset();
+		builder.for_database(database_types::sqlite);
+
+		auto sqlite_query = builder.select({"id", "name"})
+							   .from("users")
+							   .where("id", "=", int64_t{1})
+							   .build();
+		std::cout << "SQLite:     " << sqlite_query << std::endl;
+	}
+
+	std::cout << "\n=== query_builder_usage example completed ===" << std::endl;
+	return 0;
+}

--- a/examples/transaction_management.cpp
+++ b/examples/transaction_management.cpp
@@ -1,0 +1,278 @@
+/**
+ * BSD 3-Clause License
+ * Copyright (c) 2025, kcenon
+ *
+ * @file transaction_management.cpp
+ * @brief Demonstrates transaction management with commit and rollback.
+ *
+ * This example shows how to:
+ * - Begin, commit, and rollback transactions
+ * - Use the in_transaction() check
+ * - Handle errors within a transaction scope
+ * - Implement a simple RAII-style transaction guard pattern
+ *
+ * Prerequisites:
+ * - A running PostgreSQL server
+ * - Update the connection string below with valid credentials
+ */
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <variant>
+
+#include "database/database_manager.h"
+#include "database/core/database_context.h"
+
+using namespace database;
+
+/**
+ * @brief RAII transaction guard that rolls back on destruction unless committed.
+ *
+ * This pattern ensures that transactions are never left dangling even when
+ * an exception or early return occurs.
+ */
+class transaction_guard
+{
+public:
+	explicit transaction_guard(std::shared_ptr<database_manager> mgr)
+		: mgr_(std::move(mgr)), committed_(false)
+	{
+		auto result = mgr_->begin_transaction();
+		if (!result.is_ok())
+		{
+			throw std::runtime_error("Failed to begin transaction");
+		}
+	}
+
+	~transaction_guard()
+	{
+		if (!committed_ && mgr_->in_transaction())
+		{
+			std::cout << "  [guard] Rolling back uncommitted transaction" << std::endl;
+			mgr_->rollback_transaction();
+		}
+	}
+
+	void commit()
+	{
+		auto result = mgr_->commit_transaction();
+		if (result.is_ok())
+		{
+			committed_ = true;
+		}
+		else
+		{
+			throw std::runtime_error("Failed to commit transaction");
+		}
+	}
+
+	// Non-copyable, non-movable
+	transaction_guard(const transaction_guard&) = delete;
+	transaction_guard& operator=(const transaction_guard&) = delete;
+
+private:
+	std::shared_ptr<database_manager> mgr_;
+	bool committed_;
+};
+
+int main()
+{
+	std::cout << "=== transaction_management example ===" << std::endl;
+
+	// Setup
+	auto context = std::make_shared<database_context>();
+	auto db_manager = std::make_shared<database_manager>(context);
+	db_manager->set_mode(database_types::postgres);
+
+	std::string connection_string
+		= "host=localhost port=5432 dbname=example_db user=user password=password";
+
+	auto connect_result = db_manager->connect_result(connection_string);
+	if (!connect_result.is_ok())
+	{
+		std::cerr << "Connection failed. Ensure PostgreSQL is running." << std::endl;
+		return 1;
+	}
+	std::cout << "Connected" << std::endl;
+
+	// Prepare a test table
+	db_manager->create_query_result(R"(
+		CREATE TABLE IF NOT EXISTS accounts (
+			id      SERIAL PRIMARY KEY,
+			name    VARCHAR(100) NOT NULL,
+			balance DECIMAL(12,2) NOT NULL DEFAULT 0.00
+		)
+	)");
+	db_manager->execute_query_result("DELETE FROM accounts");
+	db_manager->execute_query_result(
+		"INSERT INTO accounts (name, balance) VALUES ('Alice', 1000.00)");
+	db_manager->execute_query_result(
+		"INSERT INTO accounts (name, balance) VALUES ('Bob',   500.00)");
+
+	// -------------------------------------------------------
+	// Scenario 1: Successful transaction (transfer funds)
+	// -------------------------------------------------------
+	std::cout << "\n--- Scenario 1: Successful transfer ---" << std::endl;
+	{
+		auto begin_result = db_manager->begin_transaction();
+		if (!begin_result.is_ok())
+		{
+			std::cerr << "Failed to begin transaction" << std::endl;
+			return 1;
+		}
+		std::cout << "Transaction started, in_transaction = "
+				  << std::boolalpha << db_manager->in_transaction() << std::endl;
+
+		// Transfer 200 from Alice to Bob
+		db_manager->execute_query_result(
+			"UPDATE accounts SET balance = balance - 200 WHERE name = 'Alice'");
+		db_manager->execute_query_result(
+			"UPDATE accounts SET balance = balance + 200 WHERE name = 'Bob'");
+
+		auto commit_result = db_manager->commit_transaction();
+		if (commit_result.is_ok())
+		{
+			std::cout << "Transaction committed" << std::endl;
+		}
+
+		// Verify balances
+		auto result = db_manager->select_query_result(
+			"SELECT name, balance FROM accounts ORDER BY name");
+		if (result.is_ok())
+		{
+			for (const auto& row : result.value())
+			{
+				for (const auto& [col, val] : row)
+				{
+					std::cout << "  " << col << " = ";
+					std::visit([](const auto& v) { std::cout << v; }, val);
+					std::cout << "  ";
+				}
+				std::cout << std::endl;
+			}
+		}
+	}
+
+	// -------------------------------------------------------
+	// Scenario 2: Rollback on error
+	// -------------------------------------------------------
+	std::cout << "\n--- Scenario 2: Rollback on error ---" << std::endl;
+	{
+		auto begin_result = db_manager->begin_transaction();
+		if (!begin_result.is_ok())
+		{
+			std::cerr << "Failed to begin transaction" << std::endl;
+			return 1;
+		}
+
+		// Debit Alice
+		db_manager->execute_query_result(
+			"UPDATE accounts SET balance = balance - 5000 WHERE name = 'Alice'");
+
+		// Simulate a business rule check: Alice would go negative
+		auto check = db_manager->select_query_result(
+			"SELECT balance FROM accounts WHERE name = 'Alice'");
+
+		bool should_rollback = false;
+		if (check.is_ok() && !check.value().empty())
+		{
+			const auto& balance_val = check.value()[0].at("balance");
+			// Check if balance went negative (as a string comparison for simplicity)
+			std::visit(
+				[&should_rollback](const auto& v)
+				{
+					using T = std::decay_t<decltype(v)>;
+					if constexpr (std::is_same_v<T, double>)
+					{
+						should_rollback = (v < 0.0);
+					}
+					else if constexpr (std::is_same_v<T, std::string>)
+					{
+						// Some backends return numeric values as strings
+						should_rollback = (!v.empty() && v[0] == '-');
+					}
+				},
+				balance_val);
+		}
+
+		if (should_rollback)
+		{
+			std::cout << "Business rule violation detected, rolling back" << std::endl;
+			db_manager->rollback_transaction();
+			std::cout << "Transaction rolled back, in_transaction = "
+					  << std::boolalpha << db_manager->in_transaction() << std::endl;
+		}
+		else
+		{
+			db_manager->commit_transaction();
+			std::cout << "Transaction committed (balance was not negative)" << std::endl;
+		}
+
+		// Verify balances unchanged
+		auto result = db_manager->select_query_result(
+			"SELECT name, balance FROM accounts ORDER BY name");
+		if (result.is_ok())
+		{
+			std::cout << "Balances after rollback:" << std::endl;
+			for (const auto& row : result.value())
+			{
+				for (const auto& [col, val] : row)
+				{
+					std::cout << "  " << col << " = ";
+					std::visit([](const auto& v) { std::cout << v; }, val);
+					std::cout << "  ";
+				}
+				std::cout << std::endl;
+			}
+		}
+	}
+
+	// -------------------------------------------------------
+	// Scenario 3: RAII transaction guard
+	// -------------------------------------------------------
+	std::cout << "\n--- Scenario 3: RAII transaction guard ---" << std::endl;
+	{
+		try
+		{
+			transaction_guard guard(db_manager);
+			std::cout << "Guard started transaction" << std::endl;
+
+			db_manager->execute_query_result(
+				"INSERT INTO accounts (name, balance) VALUES ('Carol', 750.00)");
+
+			// Commit explicitly through the guard
+			guard.commit();
+			std::cout << "Guard committed transaction" << std::endl;
+		}
+		catch (const std::exception& e)
+		{
+			std::cerr << "Transaction error: " << e.what() << std::endl;
+		}
+
+		// Verify Carol was added
+		auto result = db_manager->select_query_result(
+			"SELECT name, balance FROM accounts ORDER BY name");
+		if (result.is_ok())
+		{
+			std::cout << "Accounts after guard commit:" << std::endl;
+			for (const auto& row : result.value())
+			{
+				for (const auto& [col, val] : row)
+				{
+					std::cout << "  " << col << " = ";
+					std::visit([](const auto& v) { std::cout << v; }, val);
+					std::cout << "  ";
+				}
+				std::cout << std::endl;
+			}
+		}
+	}
+
+	// Cleanup
+	db_manager->disconnect_result();
+	std::cout << "\nDisconnected" << std::endl;
+
+	std::cout << "=== transaction_management example completed ===" << std::endl;
+	return 0;
+}


### PR DESCRIPTION
Closes #522

## Summary
- Add `examples/` directory with 6 introductory C++20 examples demonstrating core database_system features
- Examples cover: basic connection, query builder API, transaction management, Result<T> error handling, ORM entity metadata/SQL generation, and multi-threaded usage
- Add `BUILD_DATABASE_EXAMPLES` CMake option (default OFF) integrated into root CMakeLists.txt
- Include `examples/README.md` documenting each example with build instructions
- Exclude examples from code coverage calculations
- Two examples (query_builder_usage, orm_entity_demo) run without a database; the rest require PostgreSQL

## Test Plan
- [x] All 6 examples compile successfully with `BUILD_DATABASE_EXAMPLES=ON`
- [x] `example_query_builder_usage` runs and produces correct SQL output
- [x] `example_orm_entity_demo` runs and produces correct metadata/SQL output
- [ ] Examples compile successfully in CI (all platforms)
- [ ] Each example demonstrates a practical, focused use case
- [ ] README in examples/ documents all examples