### PR TITLE
docs: add YAML frontmatter to all docs/ markdown files

### DIFF
--- a/docs/ADAPTER_PATTERNS.md
+++ b/docs/ADAPTER_PATTERNS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-GUID-001"
+doc_title: "Adapter Pattern Best Practices"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "GUID"
+---
+
 # Adapter Pattern Best Practices
 
 > **Language:** **English** | [한국어](ADAPTER_PATTERNS.kr.md)

--- a/docs/API_REFERENCE.kr.md
+++ b/docs/API_REFERENCE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-API-001"
+doc_title: "Database System API Reference"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "API"
+---
+
 # Database System API Reference
 
 > **Language:** [English](API_REFERENCE.md) | **한국어**

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-API-002"
+doc_title: "Database System API Reference"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "API"
+---
+
 # Database System API Reference
 
 > **Language:** **English** | [한국어](API_REFERENCE.kr.md)

--- a/docs/ARCHITECTURE.kr.md
+++ b/docs/ARCHITECTURE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-ARCH-001"
+doc_title: "Database System Architecture"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "ARCH"
+---
+
 # Database System Architecture
 
 > **Language:** [English](ARCHITECTURE.md) | **한국어**

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-ARCH-002"
+doc_title: "Database System Architecture"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "ARCH"
+---
+
 # Database System Architecture
 
 > **Language:** **English** | [한국어](ARCHITECTURE.kr.md)

--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-GUID-002"
+doc_title: "Backend Stability Overview"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "GUID"
+---
+
 # Backend Stability Overview
 
 This document describes the maturity level of each database backend in the

--- a/docs/BENCHMARKS.kr.md
+++ b/docs/BENCHMARKS.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-PERF-001"
+doc_title: "Database System 성능 벤치마크"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "PERF"
+---
+
 # Database System 성능 벤치마크
 
 **언어:** [English](BENCHMARKS.md) | **한국어**

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-PERF-002"
+doc_title: "Database System Performance Benchmarks"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "PERF"
+---
+
 # Database System Performance Benchmarks
 
 **Last Updated**: 2025-11-15

--- a/docs/CHANGELOG.kr.md
+++ b/docs/CHANGELOG.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-PROJ-001"
+doc_title: "📜 Database System - 개발 히스토리"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "PROJ"
+---
+
 # 📜 Database System - 개발 히스토리
 
 [English](CHANGELOG.md) | **한국어**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-PROJ-002"
+doc_title: "📜 Database System - Development History"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "PROJ"
+---
+
 # 📜 Database System - Development History
 
 **English** | [한국어](CHANGELOG.kr.md)

--- a/docs/FEATURES.kr.md
+++ b/docs/FEATURES.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-FEAT-001"
+doc_title: "Database System 기능"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "FEAT"
+---
+
 # Database System 기능
 
 **언어:** [English](FEATURES.md) | **한국어**

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-FEAT-002"
+doc_title: "Database System Features"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "FEAT"
+---
+
 # Database System Features
 
 **Last Updated**: 2026-02-08

--- a/docs/MIGRATION_database_base.md
+++ b/docs/MIGRATION_database_base.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-MIGR-001"
+doc_title: "Migrating from database_base to database_backend"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "MIGR"
+---
+
 # Migrating from database_base to database_backend
 
 ## Overview

--- a/docs/ORM_GUIDE.md
+++ b/docs/ORM_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-GUID-003"
+doc_title: "ORM Framework Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "GUID"
+---
+
 # ORM Framework Guide
 
 > **Status**: Full Support (C++17 SFINAE-based)

--- a/docs/PRODUCTION_QUALITY.kr.md
+++ b/docs/PRODUCTION_QUALITY.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-QUAL-001"
+doc_title: "Database System 프로덕션 품질"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "QUAL"
+---
+
 # Database System 프로덕션 품질
 
 **언어:** [English](PRODUCTION_QUALITY.md) | **한국어**

--- a/docs/PRODUCTION_QUALITY.md
+++ b/docs/PRODUCTION_QUALITY.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-QUAL-002"
+doc_title: "Database System Production Quality"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "QUAL"
+---
+
 # Database System Production Quality
 
 **Last Updated**: 2025-11-15

--- a/docs/PROJECT_STRUCTURE.kr.md
+++ b/docs/PROJECT_STRUCTURE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-PROJ-003"
+doc_title: "Database System 프로젝트 구조"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "PROJ"
+---
+
 # Database System 프로젝트 구조
 
 **언어:** [English](PROJECT_STRUCTURE.md) | **한국어**

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-PROJ-004"
+doc_title: "Database System Project Structure"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "PROJ"
+---
+
 # Database System Project Structure
 
 **Last Updated**: 2025-11-15

--- a/docs/README.kr.md
+++ b/docs/README.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-GUID-004"
+doc_title: "Database System 문서"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "GUID"
+---
+
 # Database System 문서
 
 > **Language:** [English](README.md) | **한국어**

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-GUID-005"
+doc_title: "Database System Documentation"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "GUID"
+---
+
 # Database System Documentation
 
 > **Language:** **English** | [한국어](README.kr.md)

--- a/docs/SOUP.md
+++ b/docs/SOUP.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-PROJ-005"
+doc_title: "SOUP List &mdash; database_system"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "PROJ"
+---
+
 # SOUP List &mdash; database_system
 
 > **Software of Unknown Provenance (SOUP) Register per IEC 62304:2006+AMD1:2015 &sect;8.1.2**

--- a/docs/advanced/ARCHITECTURE.md
+++ b/docs/advanced/ARCHITECTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-ARCH-003"
+doc_title: "Database System Architecture"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "ARCH"
+---
+
 # Database System Architecture
 
 > **Version:** 0.1.0.0

--- a/docs/advanced/ARCHITECTURE_ISSUES.kr.md
+++ b/docs/advanced/ARCHITECTURE_ISSUES.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-ARCH-004"
+doc_title: "Architecture Issues - Phase 0 식별"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "ARCH"
+---
+
 # Architecture Issues - Phase 0 식별
 
 > **Language:** [English](ARCHITECTURE_ISSUES.md) | **한국어**

--- a/docs/advanced/ARCHITECTURE_ISSUES.md
+++ b/docs/advanced/ARCHITECTURE_ISSUES.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-ARCH-005"
+doc_title: "Architecture Issues - Phase 0 Identification"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "ARCH"
+---
+
 # Architecture Issues - Phase 0 Identification
 
 > **Language:** **English** | [한국어](ARCHITECTURE_ISSUES.kr.md)

--- a/docs/advanced/CURRENT_STATE.kr.md
+++ b/docs/advanced/CURRENT_STATE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-GUID-006"
+doc_title: "시스템 현재 상태 - Phase 0 베이스라인"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "GUID"
+---
+
 # 시스템 현재 상태 - Phase 0 베이스라인
 
 > **Language:** [English](CURRENT_STATE.md) | **한국어**

--- a/docs/advanced/CURRENT_STATE.md
+++ b/docs/advanced/CURRENT_STATE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-GUID-007"
+doc_title: "System Current State - Phase 0 Baseline"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "GUID"
+---
+
 # System Current State - Phase 0 Baseline
 
 > **Language:** **English** | [한국어](CURRENT_STATE.kr.md)

--- a/docs/advanced/MIGRATION.md
+++ b/docs/advanced/MIGRATION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-MIGR-002"
+doc_title: "Database System Migration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "MIGR"
+---
+
 # Database System Migration Guide
 
 > **Version:** 0.1.0.0

--- a/docs/advanced/STRUCTURE.md
+++ b/docs/advanced/STRUCTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-ARCH-006"
+doc_title: "Database System Project Structure"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "ARCH"
+---
+
 # Database System Project Structure
 
 > **Version:** 0.1.0.0

--- a/docs/advanced/THREAD_ADAPTER_EVALUATION.kr.md
+++ b/docs/advanced/THREAD_ADAPTER_EVALUATION.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-PROJ-006"
+doc_title: "Thread Adapter 통합 평가"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "PROJ"
+---
+
 # Thread Adapter 통합 평가
 
 이 문서는 단일 백그라운드 스레드를 사용하는 모듈에 `thread_adapter`를 통합하는 것에 대한 평가 결과를 기록합니다.

--- a/docs/advanced/THREAD_ADAPTER_EVALUATION.md
+++ b/docs/advanced/THREAD_ADAPTER_EVALUATION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-PROJ-007"
+doc_title: "Thread Adapter Integration Evaluation"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "PROJ"
+---
+
 # Thread Adapter Integration Evaluation
 
 This document records the evaluation outcome for integrating `thread_adapter` into modules that use single background threads.

--- a/docs/advanced/THREAD_SYSTEM_MIGRATION.md
+++ b/docs/advanced/THREAD_SYSTEM_MIGRATION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-MIGR-003"
+doc_title: "thread_system Migration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "MIGR"
+---
+
 # thread_system Migration Guide
 
 > **Version**: 0.1.0.0

--- a/docs/advanced/TYPE_SYSTEM.md
+++ b/docs/advanced/TYPE_SYSTEM.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-API-003"
+doc_title: "Database System Type System Documentation"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "API"
+---
+
 # Database System Type System Documentation
 
 **Version**: 0.1.0.0

--- a/docs/analysis/BACKEND_USAGE_ANALYSIS.md
+++ b/docs/analysis/BACKEND_USAGE_ANALYSIS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-GUID-008"
+doc_title: "Backend Usage Analysis Report"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "GUID"
+---
+
 # Backend Usage Analysis Report
 
 ## Overview

--- a/docs/contributing/CI_CD_GUIDE.md
+++ b/docs/contributing/CI_CD_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-GUID-009"
+doc_title: "CI/CD Guide for database_system"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "GUID"
+---
+
 # CI/CD Guide for database_system
 
 **Version:** 0.1.0

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-PROJ-008"
+doc_title: "Contributing to Database System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "PROJ"
+---
+
 # Contributing to Database System
 
 **Version:** 0.1.0.0

--- a/docs/guides/ASYNC_OPERATIONS.md
+++ b/docs/guides/ASYNC_OPERATIONS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-GUID-010"
+doc_title: "Async Database Operations Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "GUID"
+---
+
 # Async Database Operations Guide
 
 > **Language:** **English** | [한국어](ASYNC_OPERATIONS.kr.md)

--- a/docs/guides/BEST_PRACTICES.md
+++ b/docs/guides/BEST_PRACTICES.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-GUID-011"
+doc_title: "Database System - Best Practices Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "GUID"
+---
+
 # Database System - Best Practices Guide
 
 > **Version:** 0.1.0

--- a/docs/guides/BUILD_GUIDE.kr.md
+++ b/docs/guides/BUILD_GUIDE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-GUID-012"
+doc_title: "Database System Build Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "GUID"
+---
+
 # Database System Build Guide
 
 > **Language:** [English](BUILD_GUIDE.md) | **한국어**

--- a/docs/guides/BUILD_GUIDE.md
+++ b/docs/guides/BUILD_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-GUID-013"
+doc_title: "Database System Build Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "GUID"
+---
+
 # Database System Build Guide
 
 > **Language:** **English** | [한국어](BUILD_GUIDE.kr.md)

--- a/docs/guides/FAQ.md
+++ b/docs/guides/FAQ.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-GUID-014"
+doc_title: "Database System - Frequently Asked Questions"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "GUID"
+---
+
 # Database System - Frequently Asked Questions
 
 **Version:** 0.1.0

--- a/docs/guides/INTEGRATION.md
+++ b/docs/guides/INTEGRATION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-INTR-001"
+doc_title: "Integration Guide - Database System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "INTR"
+---
+
 # Integration Guide - Database System
 
 > **Language:** **English** | [한국어](INTEGRATION.kr.md)

--- a/docs/guides/QUICK_START.kr.md
+++ b/docs/guides/QUICK_START.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-GUID-015"
+doc_title: "Database System 빠른 시작 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "GUID"
+---
+
 # Database System 빠른 시작 가이드
 
 > **Language:** [English](QUICK_START.md) | **한국어**

--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-GUID-016"
+doc_title: "Database System Quick Start Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "GUID"
+---
+
 # Database System Quick Start Guide
 
 **Version:** 0.1.0

--- a/docs/guides/SAMPLES_GUIDE.kr.md
+++ b/docs/guides/SAMPLES_GUIDE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-GUID-017"
+doc_title: "Database System Samples Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "GUID"
+---
+
 # Database System Samples Guide
 
 > **Language:** [English](SAMPLES_GUIDE.md) | **한국어**

--- a/docs/guides/SAMPLES_GUIDE.md
+++ b/docs/guides/SAMPLES_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-GUID-018"
+doc_title: "Database System Samples Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "GUID"
+---
+
 # Database System Samples Guide
 
 > **Language:** **English** | [한국어](SAMPLES_GUIDE.kr.md)

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-GUID-019"
+doc_title: "Database System Troubleshooting Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "GUID"
+---
+
 # Database System Troubleshooting Guide
 
 **Version**: 0.1.0.0

--- a/docs/guides/UNIFIED_SYSTEM.md
+++ b/docs/guides/UNIFIED_SYSTEM.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-GUID-020"
+doc_title: "Unified Database System Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "GUID"
+---
+
 # Unified Database System Guide
 
 > **Language:** **English** | [한국어](UNIFIED_SYSTEM.kr.md)

--- a/docs/integration/README.md
+++ b/docs/integration/README.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-GUID-021"
+doc_title: "Database System Integration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "GUID"
+---
+
 # Database System Integration Guide
 
 ## Overview

--- a/docs/migration/database_base.md
+++ b/docs/migration/database_base.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-GUID-022"
+doc_title: "database_base Migration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "GUID"
+---
+
 # database_base Migration Guide
 
 ## Overview

--- a/docs/migration/legacy_api.md
+++ b/docs/migration/legacy_api.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-GUID-023"
+doc_title: "Migrating from Legacy Bool-Returning API to Result-Based API"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "GUID"
+---
+
 # Migrating from Legacy Bool-Returning API to Result-Based API
 
 ## Overview

--- a/docs/performance/BASELINE.kr.md
+++ b/docs/performance/BASELINE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-PERF-003"
+doc_title: "Database System - 성능 기준 메트릭"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "PERF"
+---
+
 <<<<<<< HEAD
 # Database System - 성능 기준 메트릭
 

--- a/docs/performance/BASELINE.md
+++ b/docs/performance/BASELINE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-PERF-004"
+doc_title: "Database System - Performance Baseline Metrics"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "PERF"
+---
+
 # Database System - Performance Baseline Metrics
 
 **English** | [한국어](BASELINE.kr.md)

--- a/docs/performance/BENCHMARKS.kr.md
+++ b/docs/performance/BENCHMARKS.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-PERF-005"
+doc_title: "Database System 성능 벤치마크"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "PERF"
+---
+
 # Database System 성능 벤치마크
 
 > **Language:** [English](PERFORMANCE_BENCHMARKS.md) | **한국어**

--- a/docs/performance/BENCHMARKS.md
+++ b/docs/performance/BENCHMARKS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-PERF-006"
+doc_title: "Database System Performance Benchmarks"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "PERF"
+---
+
 # Database System Performance Benchmarks
 
 > **Language:** **English** | [한국어](PERFORMANCE_BENCHMARKS.kr.md)

--- a/docs/performance/STATIC_ANALYSIS_BASELINE.kr.md
+++ b/docs/performance/STATIC_ANALYSIS_BASELINE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-PERF-007"
+doc_title: "정적 분석 베이스라인 - database_system"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "PERF"
+---
+
 # 정적 분석 베이스라인 - database_system
 
 > **Language:** [English](STATIC_ANALYSIS_BASELINE.md) | **한국어**

--- a/docs/performance/STATIC_ANALYSIS_BASELINE.md
+++ b/docs/performance/STATIC_ANALYSIS_BASELINE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-PERF-008"
+doc_title: "Static Analysis Baseline - database_system"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "PERF"
+---
+
 # Static Analysis Baseline - database_system
 
 > **Language:** **English** | [한국어](STATIC_ANALYSIS_BASELINE.kr.md)

--- a/docs/performance/TUNING_GUIDE.md
+++ b/docs/performance/TUNING_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "DBS-PERF-009"
+doc_title: "Database System Performance Tuning Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "database_system"
+category: "PERF"
+---
+
 # Database System Performance Tuning Guide
 
 ## Overview


### PR DESCRIPTION
Part of kcenon/common_system#562

## Summary
- Add standardized YAML frontmatter metadata to 57 markdown files in `docs/`
- Each file gets a unique `doc_id` (`DBS-{CATEGORY}-{NNN}`), title, version, date, status, project, and category

## Category Breakdown (57 files)
| Category | Count | Description |
|----------|-------|-------------|
| API | 3 | API Reference |
| ARCH | 6 | Architecture |
| FEAT | 2 | Features |
| GUID | 23 | User Guides |
| INTR | 1 | Integration |
| MIGR | 3 | Migration |
| PERF | 9 | Performance |
| PROJ | 8 | Project Info |
| QUAL | 2 | Quality |

## Test Plan
- [x] Script runs idempotently (re-running skips all files)
- [x] No duplicate doc_id values
- [x] Existing document content unchanged (frontmatter prepended only)