### PR TITLE
docs: fix traceability matrix doc_id collision with production quality

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -67,7 +67,7 @@ Total documents: **59**
 | 46 | DBS-INTR-001 | Integration Guide - Database System | [INTEGRATION.md](./guides/INTEGRATION.md) | Released |
 | 47 | DBS-QUAL-001 | Database System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
 | 48 | DBS-QUAL-002 | Database System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
-| 49 | DBS-QUAL-002 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
+| 49 | DBS-QUAL-003 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
 | 50 | DBS-ADR-001 | ADR-001: Multi-Backend Database Abstraction | [ADR-001-multi-backend-abstraction.md](./adr/ADR-001-multi-backend-abstraction.md) | Accepted |
 | 51 | DBS-ADR-002 | ADR-002: Connection Pool Architecture | [ADR-002-connection-pool-architecture.md](./adr/ADR-002-connection-pool-architecture.md) | Accepted |
 | 52 | DBS-PROJ-001 | 📜 Database System - 개발 히스토리 | [CHANGELOG.kr.md](./CHANGELOG.kr.md) | Released |
@@ -168,7 +168,7 @@ Total documents: **59**
 |--------|-------|----------|--------|
 | DBS-QUAL-001 | Database System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
 | DBS-QUAL-002 | Database System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
-| DBS-QUAL-002 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
+| DBS-QUAL-003 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
 
 ### Architecture Decision Records (2)
 

--- a/docs/TRACEABILITY.md
+++ b/docs/TRACEABILITY.md
@@ -1,5 +1,5 @@
 ---
-doc_id: "DBS-QUAL-002"
+doc_id: "DBS-QUAL-003"
 doc_title: "Feature-Test-Module Traceability Matrix"
 doc_version: "1.0.0"
 doc_date: "2026-04-04"


### PR DESCRIPTION
## Summary

- Fix doc_id collision: `TRACEABILITY.md` and `PRODUCTION_QUALITY.md` both used `DBS-QUAL-002`
- Assign unique `DBS-QUAL-003` to `TRACEABILITY.md` (next available QUAL number)
- Update SSOT registry (`docs/README.md`) to reflect the corrected doc_id

Related to kcenon/common_system#566

## What

The traceability matrix document (`docs/TRACEABILITY.md`) was sharing `DBS-QUAL-002` with `PRODUCTION_QUALITY.md`. Each document in the SSOT registry must have a unique `doc_id`. This PR assigns `DBS-QUAL-003` to the traceability matrix.

## How

- Updated `doc_id` in `docs/TRACEABILITY.md` YAML frontmatter from `DBS-QUAL-002` to `DBS-QUAL-003`
- Updated both entries in `docs/README.md` (numbered table and category index)

## Test Plan

- [x] Verify `DBS-QUAL-003` is not used by any other document
- [x] Verify TRACEABILITY.md YAML frontmatter matches README.md registry entry
- [x] Verify all feature-test mappings are accurate (test files exist)
- [x] Verify coverage summary totals match actual feature count (29)