### PR TITLE
fix(vcpkg): align source-local portfile version to 0.1.1

### DIFF
--- a/vcpkg-ports/kcenon-database-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-database-system/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kcenon/database_system
     REF "v${VERSION}"
-    SHA512 7207570689fad1ae2afc96b4b7c79be3690a174e6f7e9c704ec470fa71f74e18ab872becbbd4a15bb3ace5a7d5eb9d5d7a5125ccca49062abab7f61b2d06185f
+    SHA512 51d9168bafe0c5041154bdf5bc1865ee4c7bb0b1923a2355bd58416fbaba9d66a8bbc8e2e690cbc1bae164cd802b13a90822cb9a1ed036deb6b92f75186ff0f5
     HEAD_REF main
 )
 

--- a/vcpkg-ports/kcenon-database-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-database-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-database-system",
-  "version-semver": "0.1.0",
-  "port-version": 6,
+  "version-semver": "0.1.1",
+  "port-version": 2,
   "description": "Pure, lightweight C++20 Core DAL library with unified access to PostgreSQL, SQLite, MongoDB, and Redis",
   "homepage": "https://github.com/kcenon/database_system",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
## What

### Summary
Aligns the source-local portfile with the registry version, updating the
version from 0.1.0 to 0.1.1 and syncing the SHA512 hash.

### Change Type
- [x] Bugfix

### Affected Components
- `vcpkg-ports/kcenon-database-system/vcpkg.json`
- `vcpkg-ports/kcenon-database-system/portfile.cmake`

## Why

### Related Issues
- Part of kcenon/vcpkg-registry#76

### Motivation
The source-local portfile was pinned to v0.1.0 with port-version 6, while
the registry has moved to v0.1.1 with port-version 2. The SHA512 hash also
needed updating to match the v0.1.1 release archive.

## Where

### Files Changed
| File | Change |
|------|--------|
| `vcpkg-ports/kcenon-database-system/vcpkg.json` | version-semver 0.1.0 → 0.1.1, port-version 6 → 2 |
| `vcpkg-ports/kcenon-database-system/portfile.cmake` | Updated SHA512 hash for v0.1.1 archive |

## How

### Implementation Details
1. Updated `version-semver` from `0.1.0` to `0.1.1`
2. Updated `port-version` from 6 to 2 (reset for new version)
3. Updated SHA512 hash to match the v0.1.1 release archive

### Verification
- Confirmed v0.1.1 tag exists in repository
- SHA512 computed from `https://github.com/kcenon/database_system/archive/refs/tags/v0.1.1.tar.gz`
- Portfile logic (features, cmake options) already matches registry — no changes needed

### Breaking Changes
None