### PR TITLE
fix(cmake): standardize exported target name to database_system::database_system

### DIFF
--- a/cmake/database_system-config.cmake.in
+++ b/cmake/database_system-config.cmake.in
@@ -4,7 +4,8 @@
 # database_system Package Configuration
 #
 # Provides imported targets:
-#   database_system::database             - Core DAL library
+#   database_system::database_system      - Core DAL library (canonical)
+#   database_system::database             - Backward compatibility alias
 #   database_system::integrated_database  - Integrated adapter layer (if built)
 ##################################################
 
@@ -44,6 +45,11 @@ if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/database_system-targets.cmake")
     include("${CMAKE_CURRENT_LIST_DIR}/database_system-targets.cmake")
 endif()
 
+# Backward compatibility alias
+if(NOT TARGET database_system::database)
+    add_library(database_system::database ALIAS database_system::database_system)
+endif()
+
 # Verify targets exist
 check_required_components(database_system)
 
@@ -53,6 +59,6 @@ set(database_system_FOUND TRUE)
 # Provide information about the package
 set(database_system_VERSION @PROJECT_VERSION@)
 set(database_system_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@/database_system")
-set(database_system_LIBRARIES database_system::database)
+set(database_system_LIBRARIES database_system::database_system)
 
 message(STATUS "Found database_system: ${database_system_VERSION}")

--- a/database/CMakeLists.txt
+++ b/database/CMakeLists.txt
@@ -192,6 +192,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
     CXX_STANDARD 20
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF
+    EXPORT_NAME database_system
 )
 
 # Add HAS_COROUTINES definition if C++20 coroutines are available

--- a/docs/README.kr.md
+++ b/docs/README.kr.md
@@ -16,14 +16,14 @@ category: "GUID"
 
 ## 목차
 
-- [📚 문서 개요](#-문서-개요)
-  - [📖 사용 가능한 문서](#-사용-가능한-문서)
-  - [🚀 빠른 시작](#-빠른-시작)
-- [📋 프로젝트 정보](#-프로젝트-정보)
+- [📚 문서 개요](#문서-개요)
+  - [📖 사용 가능한 문서](#사용-가능한-문서)
+  - [🚀 빠른 시작](#빠른-시작)
+- [📋 프로젝트 정보](#프로젝트-정보)
   - [현재 상태](#현재-상태)
   - [지원 데이터베이스](#지원-데이터베이스)
   - [주요 기능](#주요-기능)
-- [📖 문서 구조](#-문서-구조)
+- [📖 문서 구조](#문서-구조)
   - [핵심 문서](#핵심-문서)
     - [API Reference](#api-reference)
     - [Build Guide](#build-guide)
@@ -32,23 +32,23 @@ category: "GUID"
   - [추가 리소스](#추가-리소스)
     - [Changelog](#changelog)
     - [Project README](#project-readme)
-- [🎯 사용 사례별 문서](#-사용-사례별-문서)
+- [🎯 사용 사례별 문서](#사용-사례별-문서)
   - [새 사용자](#새-사용자)
   - [숙련된 개발자](#숙련된-개발자)
   - [DevOps 및 시스템 관리자](#devops-및-시스템-관리자)
   - [학생 및 연구자](#학생-및-연구자)
-- [🔍 정보 찾기](#-정보-찾기)
+- [🔍 정보 찾기](#정보-찾기)
   - [기능별](#기능별)
   - [데이터베이스 타입별](#데이터베이스-타입별)
-- [🤝 문서 기여](#-문서-기여)
+- [🤝 문서 기여](#문서-기여)
   - [문서 표준](#문서-표준)
   - [개선 영역](#개선-영역)
   - [제출 프로세스](#제출-프로세스)
-- [📞 도움 받기](#-도움-받기)
+- [📞 도움 받기](#도움-받기)
   - [문서 이슈](#문서-이슈)
   - [기술 지원](#기술-지원)
   - [지원 리소스](#지원-리소스)
-- [📅 문서 로드맵](#-문서-로드맵)
+- [📅 문서 로드맵](#문서-로드맵)
   - [현재 (v3.0.0)](#현재-v300)
   - [향후 개선사항](#향후-개선사항)
 
@@ -182,44 +182,44 @@ Database System을 빌드하고 배포하는 데 필요한 모든 것:
 
 **연결 관리**
 - API: [Database Manager](API_REFERENCE.kr.md#database-manager)
-- 예제: [Basic Usage](guides/SAMPLES_GUIDE.kr.md#기본-사용법-샘플)
-- 빌드: [Database Dependencies](guides/BUILD_GUIDE.kr.md#데이터베이스-의존성)
+- 예제: [Basic Usage](guides/SAMPLES_GUIDE.kr.md)
+- 빌드: [Database Dependencies](guides/BUILD_GUIDE.kr.md)
 
 **연결 풀링**
 - API: [Connection Pooling](API_REFERENCE.kr.md#연결-풀링)
-- 예제: [Connection Pool Demo](guides/SAMPLES_GUIDE.kr.md#연결-풀-데모)
+- 예제: [Connection Pool Demo](guides/SAMPLES_GUIDE.kr.md)
 - 성능: [Pool Performance](BENCHMARKS.kr.md#연결-풀-성능)
 
 **쿼리 빌딩**
 - API: [Query Builders](API_REFERENCE.kr.md#쿼리-빌더)
-- 예제: [Query Builder Examples](guides/SAMPLES_GUIDE.kr.md#쿼리-빌더-예제)
+- 예제: [Query Builder Examples](guides/SAMPLES_GUIDE.kr.md)
 - 성능: [Builder Performance](BENCHMARKS.kr.md#백엔드별-쿼리-성능)
 
 **다중 데이터베이스 지원**
 - API: [Database Types](API_REFERENCE.kr.md#데이터베이스-타입)
-- 예제: [Multi-Database Examples](guides/SAMPLES_GUIDE.kr.md#다중-데이터베이스-예제)
-- 빌드: [Build Configurations](guides/BUILD_GUIDE.kr.md#빌드-구성)
+- 예제: [Multi-Database Examples](guides/SAMPLES_GUIDE.kr.md)
+- 빌드: [Build Configurations](guides/BUILD_GUIDE.kr.md)
 
 ### 데이터베이스 타입별
 
 **PostgreSQL**
 - API: [postgres_manager](API_REFERENCE.kr.md#database_base)
-- 예제: [PostgreSQL Advanced](guides/SAMPLES_GUIDE.kr.md#postgresql-고급-샘플)
+- 예제: [PostgreSQL Advanced](guides/SAMPLES_GUIDE.kr.md)
 - 성능: [PostgreSQL Benchmarks](BENCHMARKS.kr.md#postgresql-벤치마크)
 
 **SQLite**
-- 빌드: [SQLite Support](guides/BUILD_GUIDE.kr.md#빌드-구성)
-- 예제: [Local Database Usage](guides/SAMPLES_GUIDE.kr.md#기본-사용법-샘플)
+- 빌드: [SQLite Support](guides/BUILD_GUIDE.kr.md)
+- 예제: [Local Database Usage](guides/SAMPLES_GUIDE.kr.md)
 - 성능: [SQLite Benchmarks](BENCHMARKS.kr.md#sqlite-벤치마크)
 
 **MongoDB**
 - API: [mongodb_query_builder](API_REFERENCE.kr.md#mongodb_query_builder)
-- 예제: [MongoDB Examples](guides/SAMPLES_GUIDE.kr.md#mongodb-쿼리-빌더-예제)
+- 예제: [MongoDB Examples](guides/SAMPLES_GUIDE.kr.md)
 - 성능: [MongoDB Performance](BENCHMARKS.kr.md#mongodb-벤치마크)
 
 **Redis**
 - API: [redis_query_builder](API_REFERENCE.kr.md#redis_query_builder)
-- 예제: [Redis Examples](guides/SAMPLES_GUIDE.kr.md#redis-쿼리-빌더-예제)
+- 예제: [Redis Examples](guides/SAMPLES_GUIDE.kr.md)
 - 성능: [Redis Performance](BENCHMARKS.kr.md#redis-벤치마크)
 
 ## 🤝 문서 기여


### PR DESCRIPTION
## What

### Summary
Standardize the CMake exported target name from `database_system::database` to
`database_system::database_system`, following the `<package>::<package>` convention.

### Change Type
- [x] Bugfix (fixes an issue)

### Affected Components
- `database/CMakeLists.txt` - Added `EXPORT_NAME database_system` property
- `cmake/database_system-config.cmake.in` - Added backward compatibility alias

## Why

### Problem Solved
After `find_package(database_system)`, consumers previously got
`database_system::database` instead of the conventional
`database_system::database_system`. This deviates from the standard
`<package>::<package>` naming convention used by most CMake packages.

### Related Issues
- Part of kcenon/vcpkg-registry#78

## Where

### Files Changed
| File | Type of Change |
|------|----------------|
| `database/CMakeLists.txt` | Added `EXPORT_NAME` property |
| `cmake/database_system-config.cmake.in` | Added alias + updated docs |
| `docs/README.kr.md` | Fixed pre-existing broken anchors |

## How

### Implementation Details
1. Added `EXPORT_NAME database_system` to `set_target_properties()` in
   `database/CMakeLists.txt` so the exported target becomes
   `database_system::database_system` without renaming the actual CMake target.

2. Added a backward-compatible alias in the config template:
   ```cmake
   if(NOT TARGET database_system::database)
       add_library(database_system::database ALIAS database_system::database_system)
   endif()
   ```

3. Updated `database_system_LIBRARIES` variable and documentation comments
   in the config template.

### Breaking Changes
None - existing consumers using `database_system::database` will continue
to work via the backward-compatible alias.