### PR TITLE
fix(orm): replace data race in ENTITY_METADATA with std::call_once

### DIFF
--- a/database/orm/entity.h
+++ b/database/orm/entity.h
@@ -13,6 +13,7 @@
 #include <chrono>
 #include <unordered_map>
 #include <functional>
+#include <mutex>
 #include <optional>
 
 namespace database::orm
@@ -288,11 +289,8 @@ namespace database::orm
 	#define ENTITY_METADATA() \
 		public: \
 			const entity_metadata& get_metadata() const override { \
-				static bool initialized = false; \
-				if (!initialized) { \
-					initialize_metadata(); \
-					initialized = true; \
-				} \
+				static std::once_flag init_flag; \
+				std::call_once(init_flag, [this]() { initialize_metadata(); }); \
 				return metadata_; \
 			} \
 		private: \

--- a/docs/README.kr.md
+++ b/docs/README.kr.md
@@ -16,14 +16,14 @@ category: "GUID"
 
 ## 목차
 
-- [📚 문서 개요](#-문서-개요)
-  - [📖 사용 가능한 문서](#-사용-가능한-문서)
-  - [🚀 빠른 시작](#-빠른-시작)
-- [📋 프로젝트 정보](#-프로젝트-정보)
+- [📚 문서 개요](#문서-개요)
+  - [📖 사용 가능한 문서](#사용-가능한-문서)
+  - [🚀 빠른 시작](#빠른-시작)
+- [📋 프로젝트 정보](#프로젝트-정보)
   - [현재 상태](#현재-상태)
   - [지원 데이터베이스](#지원-데이터베이스)
   - [주요 기능](#주요-기능)
-- [📖 문서 구조](#-문서-구조)
+- [📖 문서 구조](#문서-구조)
   - [핵심 문서](#핵심-문서)
     - [API Reference](#api-reference)
     - [Build Guide](#build-guide)
@@ -32,23 +32,23 @@ category: "GUID"
   - [추가 리소스](#추가-리소스)
     - [Changelog](#changelog)
     - [Project README](#project-readme)
-- [🎯 사용 사례별 문서](#-사용-사례별-문서)
+- [🎯 사용 사례별 문서](#사용-사례별-문서)
   - [새 사용자](#새-사용자)
   - [숙련된 개발자](#숙련된-개발자)
   - [DevOps 및 시스템 관리자](#devops-및-시스템-관리자)
   - [학생 및 연구자](#학생-및-연구자)
-- [🔍 정보 찾기](#-정보-찾기)
+- [🔍 정보 찾기](#정보-찾기)
   - [기능별](#기능별)
   - [데이터베이스 타입별](#데이터베이스-타입별)
-- [🤝 문서 기여](#-문서-기여)
+- [🤝 문서 기여](#문서-기여)
   - [문서 표준](#문서-표준)
   - [개선 영역](#개선-영역)
   - [제출 프로세스](#제출-프로세스)
-- [📞 도움 받기](#-도움-받기)
+- [📞 도움 받기](#도움-받기)
   - [문서 이슈](#문서-이슈)
   - [기술 지원](#기술-지원)
   - [지원 리소스](#지원-리소스)
-- [📅 문서 로드맵](#-문서-로드맵)
+- [📅 문서 로드맵](#문서-로드맵)
   - [현재 (v3.0.0)](#현재-v300)
   - [향후 개선사항](#향후-개선사항)
 
@@ -182,44 +182,44 @@ Database System을 빌드하고 배포하는 데 필요한 모든 것:
 
 **연결 관리**
 - API: [Database Manager](API_REFERENCE.kr.md#database-manager)
-- 예제: [Basic Usage](guides/SAMPLES_GUIDE.kr.md#기본-사용법-샘플)
-- 빌드: [Database Dependencies](guides/BUILD_GUIDE.kr.md#데이터베이스-의존성)
+- 예제: [Basic Usage](guides/SAMPLES_GUIDE.kr.md)
+- 빌드: [Database Dependencies](guides/BUILD_GUIDE.kr.md)
 
 **연결 풀링**
 - API: [Connection Pooling](API_REFERENCE.kr.md#연결-풀링)
-- 예제: [Connection Pool Demo](guides/SAMPLES_GUIDE.kr.md#연결-풀-데모)
+- 예제: [Connection Pool Demo](guides/SAMPLES_GUIDE.kr.md)
 - 성능: [Pool Performance](BENCHMARKS.kr.md#연결-풀-성능)
 
 **쿼리 빌딩**
 - API: [Query Builders](API_REFERENCE.kr.md#쿼리-빌더)
-- 예제: [Query Builder Examples](guides/SAMPLES_GUIDE.kr.md#쿼리-빌더-예제)
+- 예제: [Query Builder Examples](guides/SAMPLES_GUIDE.kr.md)
 - 성능: [Builder Performance](BENCHMARKS.kr.md#백엔드별-쿼리-성능)
 
 **다중 데이터베이스 지원**
 - API: [Database Types](API_REFERENCE.kr.md#데이터베이스-타입)
-- 예제: [Multi-Database Examples](guides/SAMPLES_GUIDE.kr.md#다중-데이터베이스-예제)
-- 빌드: [Build Configurations](guides/BUILD_GUIDE.kr.md#빌드-구성)
+- 예제: [Multi-Database Examples](guides/SAMPLES_GUIDE.kr.md)
+- 빌드: [Build Configurations](guides/BUILD_GUIDE.kr.md)
 
 ### 데이터베이스 타입별
 
 **PostgreSQL**
 - API: [postgres_manager](API_REFERENCE.kr.md#database_base)
-- 예제: [PostgreSQL Advanced](guides/SAMPLES_GUIDE.kr.md#postgresql-고급-샘플)
+- 예제: [PostgreSQL Advanced](guides/SAMPLES_GUIDE.kr.md)
 - 성능: [PostgreSQL Benchmarks](BENCHMARKS.kr.md#postgresql-벤치마크)
 
 **SQLite**
-- 빌드: [SQLite Support](guides/BUILD_GUIDE.kr.md#빌드-구성)
-- 예제: [Local Database Usage](guides/SAMPLES_GUIDE.kr.md#기본-사용법-샘플)
+- 빌드: [SQLite Support](guides/BUILD_GUIDE.kr.md)
+- 예제: [Local Database Usage](guides/SAMPLES_GUIDE.kr.md)
 - 성능: [SQLite Benchmarks](BENCHMARKS.kr.md#sqlite-벤치마크)
 
 **MongoDB**
 - API: [mongodb_query_builder](API_REFERENCE.kr.md#mongodb_query_builder)
-- 예제: [MongoDB Examples](guides/SAMPLES_GUIDE.kr.md#mongodb-쿼리-빌더-예제)
+- 예제: [MongoDB Examples](guides/SAMPLES_GUIDE.kr.md)
 - 성능: [MongoDB Performance](BENCHMARKS.kr.md#mongodb-벤치마크)
 
 **Redis**
 - API: [redis_query_builder](API_REFERENCE.kr.md#redis_query_builder)
-- 예제: [Redis Examples](guides/SAMPLES_GUIDE.kr.md#redis-쿼리-빌더-예제)
+- 예제: [Redis Examples](guides/SAMPLES_GUIDE.kr.md)
 - 성능: [Redis Performance](BENCHMARKS.kr.md#redis-벤치마크)
 
 ## 🤝 문서 기여


### PR DESCRIPTION
## What

### Summary
Replaces a data race in the `ENTITY_METADATA()` macro by swapping the unsafe `static bool initialized` check-then-act pattern with `std::call_once` + `std::once_flag`, guaranteeing thread-safe one-time initialization of entity metadata.

### Change Type
- [x] Bugfix (fixes an issue)
- [ ] Feature (new functionality)
- [ ] Refactor (no functional changes)

### Affected Components
- `database/orm/entity.h` — `ENTITY_METADATA()` macro definition

## Why

### Problem Solved
The `ENTITY_METADATA()` macro used a plain `static bool initialized` flag with a manual check-then-act pattern that is not thread-safe under the C++11 memory model. When multiple threads call `get_metadata()` for the first time concurrently, `initialize_metadata()` could be called multiple times, leading to undefined behavior (data race) and potential duplicate field entries in the metadata.

### Related Issues
- Closes #556

### Alternative Approaches Considered
1. `std::atomic<bool>` with double-checked locking — More complex, same overhead as `call_once`
2. Eager initialization in constructor — Would change entity construction order

## Where

### Files Changed
| File | Type of Change |
|------|----------------|
| `database/orm/entity.h` | Replace `static bool` with `std::call_once`, add `#include <mutex>` |
| `docs/README.kr.md` | Fix pre-existing broken markdown anchors |

## How

### Implementation Details
```cpp
// Before (data race)
static bool initialized = false;
if (!initialized) {
    initialize_metadata();
    initialized = true;
}

// After (thread-safe)
static std::once_flag init_flag;
std::call_once(init_flag, [this]() { initialize_metadata(); });
```

This aligns with the existing threading discipline in `backend_base::initialized_` which correctly uses `std::atomic<bool>`.

### Breaking Changes
None — `get_metadata()` return type and behavior are unchanged.