### PR TITLE
feat(core): add parameterized query interface to database_backend

### DIFF
--- a/database/core/database_backend.h
+++ b/database/core/database_backend.h
@@ -152,6 +152,47 @@ public:
 	virtual kcenon::common::VoidResult execute_query(const std::string& query_string) = 0;
 
 	/**
+	 * @brief Execute a parameterized SELECT query (prepared statement)
+	 *
+	 * Parameters are bound at the wire-protocol level, providing stronger
+	 * SQL injection protection than string escaping. Backends that support
+	 * native prepared statements (PostgreSQL, SQLite) should override this.
+	 *
+	 * @param query SQL with positional placeholders ($1, $2, ... or ?, ?, ...)
+	 * @param params Parameter values to bind
+	 * @return Query results as rows, or error
+	 *
+	 * @note Default implementation falls back to string interpolation via
+	 *       execute_query/select_query for backends that have not yet
+	 *       implemented native prepared statement support.
+	 */
+	[[nodiscard]] virtual kcenon::common::Result<database_result> select_prepared(
+		const std::string& query,
+		const std::vector<database_value>& params)
+	{
+		// Default fallback: substitute params inline (less secure, but functional)
+		auto expanded = expand_params(query, params);
+		return select_query(expanded);
+	}
+
+	/**
+	 * @brief Execute a parameterized DML/DDL query (prepared statement)
+	 *
+	 * @param query SQL with positional placeholders ($1, $2, ... or ?, ?, ...)
+	 * @param params Parameter values to bind
+	 * @return VoidResult::ok() on success, error on failure
+	 *
+	 * @see select_prepared for details on parameterized queries
+	 */
+	[[nodiscard]] virtual kcenon::common::VoidResult execute_prepared(
+		const std::string& query,
+		const std::vector<database_value>& params)
+	{
+		auto expanded = expand_params(query, params);
+		return execute_query(expanded);
+	}
+
+	/**
 	 * @brief Begin a transaction
 	 * @return VoidResult::ok() on success, error on failure
 	 */
@@ -188,6 +229,71 @@ public:
 	 * Example keys: "server_version", "connection_id", "protocol_version"
 	 */
 	virtual std::map<std::string, std::string> connection_info() const = 0;
+
+protected:
+	/**
+	 * @brief Expand positional parameters into a SQL string (fallback)
+	 *
+	 * Substitutes $1, $2, ... or ?, ?, ... placeholders with stringified
+	 * parameter values. Used by the default select_prepared/execute_prepared
+	 * implementations. Backends with native prepared statements should
+	 * override the virtual methods instead of relying on this.
+	 *
+	 * @warning This performs string interpolation, NOT wire-level binding.
+	 *          Override select_prepared/execute_prepared for true security.
+	 */
+	static std::string expand_params(
+		const std::string& query,
+		const std::vector<database_value>& params)
+	{
+		std::string result = query;
+
+		// Replace $N placeholders (PostgreSQL-style, 1-indexed)
+		for (size_t i = params.size(); i > 0; --i) {
+			auto placeholder = "$" + std::to_string(i);
+			auto pos = result.find(placeholder);
+			if (pos != std::string::npos) {
+				result.replace(pos, placeholder.size(), value_to_sql(params[i - 1]));
+			}
+		}
+
+		// Replace ? placeholders (SQLite-style, left-to-right)
+		size_t param_idx = 0;
+		auto pos = result.find('?');
+		while (pos != std::string::npos && param_idx < params.size()) {
+			auto val = value_to_sql(params[param_idx++]);
+			result.replace(pos, 1, val);
+			pos = result.find('?', pos + val.size());
+		}
+
+		return result;
+	}
+
+private:
+	static std::string value_to_sql(const database_value& val)
+	{
+		return std::visit([](const auto& v) -> std::string {
+			using T = std::decay_t<decltype(v)>;
+			if constexpr (std::is_same_v<T, std::nullptr_t>) {
+				return "NULL";
+			} else if constexpr (std::is_same_v<T, bool>) {
+				return v ? "TRUE" : "FALSE";
+			} else if constexpr (std::is_same_v<T, std::string>) {
+				// Basic escaping — backends should override for proper security
+				std::string escaped;
+				escaped.reserve(v.size() + 2);
+				escaped += '\'';
+				for (char c : v) {
+					if (c == '\'') escaped += "''";
+					else escaped += c;
+				}
+				escaped += '\'';
+				return escaped;
+			} else {
+				return std::to_string(v);
+			}
+		}, val);
+	}
 };
 
 /**

--- a/docs/README.kr.md
+++ b/docs/README.kr.md
@@ -16,14 +16,14 @@ category: "GUID"
 
 ## 목차
 
-- [📚 문서 개요](#-문서-개요)
-  - [📖 사용 가능한 문서](#-사용-가능한-문서)
-  - [🚀 빠른 시작](#-빠른-시작)
-- [📋 프로젝트 정보](#-프로젝트-정보)
+- [📚 문서 개요](#문서-개요)
+  - [📖 사용 가능한 문서](#사용-가능한-문서)
+  - [🚀 빠른 시작](#빠른-시작)
+- [📋 프로젝트 정보](#프로젝트-정보)
   - [현재 상태](#현재-상태)
   - [지원 데이터베이스](#지원-데이터베이스)
   - [주요 기능](#주요-기능)
-- [📖 문서 구조](#-문서-구조)
+- [📖 문서 구조](#문서-구조)
   - [핵심 문서](#핵심-문서)
     - [API Reference](#api-reference)
     - [Build Guide](#build-guide)
@@ -32,23 +32,23 @@ category: "GUID"
   - [추가 리소스](#추가-리소스)
     - [Changelog](#changelog)
     - [Project README](#project-readme)
-- [🎯 사용 사례별 문서](#-사용-사례별-문서)
+- [🎯 사용 사례별 문서](#사용-사례별-문서)
   - [새 사용자](#새-사용자)
   - [숙련된 개발자](#숙련된-개발자)
   - [DevOps 및 시스템 관리자](#devops-및-시스템-관리자)
   - [학생 및 연구자](#학생-및-연구자)
-- [🔍 정보 찾기](#-정보-찾기)
+- [🔍 정보 찾기](#정보-찾기)
   - [기능별](#기능별)
   - [데이터베이스 타입별](#데이터베이스-타입별)
-- [🤝 문서 기여](#-문서-기여)
+- [🤝 문서 기여](#문서-기여)
   - [문서 표준](#문서-표준)
   - [개선 영역](#개선-영역)
   - [제출 프로세스](#제출-프로세스)
-- [📞 도움 받기](#-도움-받기)
+- [📞 도움 받기](#도움-받기)
   - [문서 이슈](#문서-이슈)
   - [기술 지원](#기술-지원)
   - [지원 리소스](#지원-리소스)
-- [📅 문서 로드맵](#-문서-로드맵)
+- [📅 문서 로드맵](#문서-로드맵)
   - [현재 (v3.0.0)](#현재-v300)
   - [향후 개선사항](#향후-개선사항)
 
@@ -182,44 +182,44 @@ Database System을 빌드하고 배포하는 데 필요한 모든 것:
 
 **연결 관리**
 - API: [Database Manager](API_REFERENCE.kr.md#database-manager)
-- 예제: [Basic Usage](guides/SAMPLES_GUIDE.kr.md#기본-사용법-샘플)
-- 빌드: [Database Dependencies](guides/BUILD_GUIDE.kr.md#데이터베이스-의존성)
+- 예제: [Basic Usage](guides/SAMPLES_GUIDE.kr.md)
+- 빌드: [Database Dependencies](guides/BUILD_GUIDE.kr.md)
 
 **연결 풀링**
 - API: [Connection Pooling](API_REFERENCE.kr.md#연결-풀링)
-- 예제: [Connection Pool Demo](guides/SAMPLES_GUIDE.kr.md#연결-풀-데모)
+- 예제: [Connection Pool Demo](guides/SAMPLES_GUIDE.kr.md)
 - 성능: [Pool Performance](BENCHMARKS.kr.md#연결-풀-성능)
 
 **쿼리 빌딩**
 - API: [Query Builders](API_REFERENCE.kr.md#쿼리-빌더)
-- 예제: [Query Builder Examples](guides/SAMPLES_GUIDE.kr.md#쿼리-빌더-예제)
+- 예제: [Query Builder Examples](guides/SAMPLES_GUIDE.kr.md)
 - 성능: [Builder Performance](BENCHMARKS.kr.md#백엔드별-쿼리-성능)
 
 **다중 데이터베이스 지원**
 - API: [Database Types](API_REFERENCE.kr.md#데이터베이스-타입)
-- 예제: [Multi-Database Examples](guides/SAMPLES_GUIDE.kr.md#다중-데이터베이스-예제)
-- 빌드: [Build Configurations](guides/BUILD_GUIDE.kr.md#빌드-구성)
+- 예제: [Multi-Database Examples](guides/SAMPLES_GUIDE.kr.md)
+- 빌드: [Build Configurations](guides/BUILD_GUIDE.kr.md)
 
 ### 데이터베이스 타입별
 
 **PostgreSQL**
 - API: [postgres_manager](API_REFERENCE.kr.md#database_base)
-- 예제: [PostgreSQL Advanced](guides/SAMPLES_GUIDE.kr.md#postgresql-고급-샘플)
+- 예제: [PostgreSQL Advanced](guides/SAMPLES_GUIDE.kr.md)
 - 성능: [PostgreSQL Benchmarks](BENCHMARKS.kr.md#postgresql-벤치마크)
 
 **SQLite**
-- 빌드: [SQLite Support](guides/BUILD_GUIDE.kr.md#빌드-구성)
-- 예제: [Local Database Usage](guides/SAMPLES_GUIDE.kr.md#기본-사용법-샘플)
+- 빌드: [SQLite Support](guides/BUILD_GUIDE.kr.md)
+- 예제: [Local Database Usage](guides/SAMPLES_GUIDE.kr.md)
 - 성능: [SQLite Benchmarks](BENCHMARKS.kr.md#sqlite-벤치마크)
 
 **MongoDB**
 - API: [mongodb_query_builder](API_REFERENCE.kr.md#mongodb_query_builder)
-- 예제: [MongoDB Examples](guides/SAMPLES_GUIDE.kr.md#mongodb-쿼리-빌더-예제)
+- 예제: [MongoDB Examples](guides/SAMPLES_GUIDE.kr.md)
 - 성능: [MongoDB Performance](BENCHMARKS.kr.md#mongodb-벤치마크)
 
 **Redis**
 - API: [redis_query_builder](API_REFERENCE.kr.md#redis_query_builder)
-- 예제: [Redis Examples](guides/SAMPLES_GUIDE.kr.md#redis-쿼리-빌더-예제)
+- 예제: [Redis Examples](guides/SAMPLES_GUIDE.kr.md)
 - 성능: [Redis Performance](BENCHMARKS.kr.md#redis-벤치마크)
 
 ## 🤝 문서 기여


### PR DESCRIPTION
## What

### Summary
Adds `select_prepared()` and `execute_prepared()` virtual methods to the `database_backend` interface, establishing the foundation for wire-level prepared statement support. Default implementations fall back to string interpolation for backward compatibility.

### Change Type
- [x] Feature (new functionality)

### Affected Components
- `database/core/database_backend.h` — New virtual methods + fallback helpers

## Why

### Problem Solved
All SQL execution currently relies on string-level escaping via `value_formatter` to prevent SQL injection. This PR establishes the interface for true parameterized queries where SQL and values travel separately. The default fallback ensures zero breakage for existing backends — they compile without changes.

### Related Issues
- Part of #557 (Phase 1 of 3)
- Phase 2 (backend overrides with native `libpq`/`sqlite3` prepared statements) will follow
- Phase 3 (wire `unified_database_system` to use prepared path by default) will follow

## Where

### Files Changed
| File | Type of Change |
|------|----------------|
| `database/core/database_backend.h` | Add `select_prepared`, `execute_prepared`, `expand_params`, `value_to_sql` |
| `docs/README.kr.md` | Fix pre-existing broken markdown anchors |

## How

### Implementation Details

**New virtual methods** (with default fallback):
```cpp
[[nodiscard]] virtual Result<database_result> select_prepared(
    const std::string& query,
    const std::vector<database_value>& params);

[[nodiscard]] virtual VoidResult execute_prepared(
    const std::string& query,
    const std::vector<database_value>& params);
```

**Fallback mechanism**:
- `expand_params()` substitutes `$N` (PostgreSQL, reverse order to avoid `$1`/`$10` collision) and `?` (SQLite, left-to-right)
- `value_to_sql()` converts `database_value` variant to SQL literal with basic escaping

**Future override pattern** (Phase 2):
```cpp
// In postgresql_backend:
Result<database_result> select_prepared(...) override {
    // Use pqxx::work::exec_params() for native binding
}
```

### Breaking Changes
None — new methods have default implementations. Existing backends compile without modification.

### Test Plan
- [ ] CI verification: existing tests pass with new interface methods
- [ ] Phase 2 will add prepared-statement-specific tests per backend