### PR TITLE
feat(backends): implement native prepared statements for PostgreSQL and SQLite

### DIFF
--- a/database/backends/postgresql_backend.cpp
+++ b/database/backends/postgresql_backend.cpp
@@ -390,6 +390,325 @@ kcenon::common::VoidResult postgresql_backend::execute_query(const std::string& 
 #endif
 }
 
+kcenon::common::Result<core::database_result> postgresql_backend::select_prepared(
+	const std::string& query,
+	const std::vector<core::database_value>& params)
+{
+	if (!is_initialized()) {
+		last_error_ = "Backend not initialized";
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"postgresql_backend"
+		};
+	}
+
+	core::database_result result;
+
+#ifdef USE_POSTGRESQL
+	if (!connection_) {
+		last_error_ = "No active connection";
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::connection_failed),
+			last_error_,
+			"postgresql_backend"
+		};
+	}
+	try {
+		pqxx::connection* conn = static_cast<pqxx::connection*>(connection_);
+		pqxx::work txn(*conn);
+
+		// Build pqxx::params from database_value vector
+		pqxx::params pq_params;
+		for (const auto& val : params) {
+			std::visit([&pq_params](const auto& v) {
+				using T = std::decay_t<decltype(v)>;
+				if constexpr (std::is_same_v<T, std::nullptr_t>) {
+					pq_params.append();
+				} else if constexpr (std::is_same_v<T, bool>) {
+					pq_params.append(v);
+				} else if constexpr (std::is_same_v<T, int64_t>) {
+					pq_params.append(v);
+				} else if constexpr (std::is_same_v<T, double>) {
+					pq_params.append(v);
+				} else if constexpr (std::is_same_v<T, std::string>) {
+					pq_params.append(v);
+				}
+			}, val);
+		}
+
+		pqxx::result pqxx_result = txn.exec_params(query, pq_params);
+		txn.commit();
+
+		for (const auto& row : pqxx_result) {
+			core::database_row db_row;
+			for (size_t i = 0; i < row.size(); ++i) {
+				std::string column_name = pqxx_result.column_name(i);
+				if (row[i].is_null()) {
+					db_row[column_name] = nullptr;
+				} else {
+					if (row[i].type() == PG_INT8OID ||
+						row[i].type() == PG_INT4OID) {
+						db_row[column_name] = row[i].as<int64_t>();
+					} else if (row[i].type() == PG_FLOAT8OID ||
+							   row[i].type() == PG_FLOAT4OID) {
+						db_row[column_name] = row[i].as<double>();
+					} else if (row[i].type() == PG_BOOLOID) {
+						db_row[column_name] = row[i].as<bool>();
+					} else {
+						db_row[column_name] = row[i].as<std::string>();
+					}
+				}
+			}
+			result.push_back(std::move(db_row));
+		}
+	} catch (const std::exception& e) {
+		last_error_ = std::string("Select prepared error: ") + e.what();
+		logger_.error("select_prepared", last_error_);
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"postgresql_backend"
+		};
+	}
+#elif defined(HAVE_LIBPQ)
+	if (!connection_) {
+		last_error_ = "No active connection";
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::connection_failed),
+			last_error_,
+			"postgresql_backend"
+		};
+	}
+	try {
+		// Convert params to C string array for PQexecParams
+		std::vector<std::string> param_strings;
+		std::vector<const char*> param_values;
+		param_strings.reserve(params.size());
+		param_values.reserve(params.size());
+
+		for (const auto& val : params) {
+			std::visit([&param_strings, &param_values](const auto& v) {
+				using T = std::decay_t<decltype(v)>;
+				if constexpr (std::is_same_v<T, std::nullptr_t>) {
+					param_strings.emplace_back();
+					param_values.push_back(nullptr);
+				} else if constexpr (std::is_same_v<T, bool>) {
+					param_strings.push_back(v ? "t" : "f");
+					param_values.push_back(param_strings.back().c_str());
+				} else if constexpr (std::is_same_v<T, std::string>) {
+					param_strings.push_back(v);
+					param_values.push_back(param_strings.back().c_str());
+				} else {
+					param_strings.push_back(std::to_string(v));
+					param_values.push_back(param_strings.back().c_str());
+				}
+			}, val);
+		}
+
+		PGresult* pg_result = PQexecParams(
+			static_cast<PGconn*>(connection_),
+			query.c_str(),
+			static_cast<int>(params.size()),
+			nullptr,  // let server infer types
+			param_values.data(),
+			nullptr,  // text format lengths
+			nullptr,  // text format
+			0         // text result format
+		);
+
+		if (PQresultStatus(pg_result) != PGRES_TUPLES_OK) {
+			last_error_ = PQerrorMessage(static_cast<PGconn*>(connection_));
+			PQclear(pg_result);
+			return kcenon::common::error_info{
+				static_cast<int>(database::error_code::query_failed),
+				last_error_,
+				"postgresql_backend"
+			};
+		}
+
+		int rows = PQntuples(pg_result);
+		int cols = PQnfields(pg_result);
+
+		for (int row = 0; row < rows; ++row) {
+			core::database_row db_row;
+			for (int col = 0; col < cols; ++col) {
+				std::string column_name = PQfname(pg_result, col);
+				if (PQgetisnull(pg_result, row, col)) {
+					db_row[column_name] = nullptr;
+				} else {
+					const char* value = PQgetvalue(pg_result, row, col);
+					Oid type = PQftype(pg_result, col);
+
+					if (type == 20 || type == 21 || type == 23) {
+						db_row[column_name] = static_cast<int64_t>(std::stoll(value));
+					} else if (type == 700 || type == 701) {
+						db_row[column_name] = std::stod(value);
+					} else if (type == 16) {
+						db_row[column_name] = (*value == 't' || *value == '1');
+					} else {
+						db_row[column_name] = std::string(value);
+					}
+				}
+			}
+			result.push_back(std::move(db_row));
+		}
+		PQclear(pg_result);
+	} catch (const std::exception& e) {
+		last_error_ = std::string("Select prepared error: ") + e.what();
+		logger_.error("select_prepared", last_error_);
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"postgresql_backend"
+		};
+	}
+#else
+	// Fallback to string interpolation for mock mode
+	return database_backend::select_prepared(query, params);
+#endif
+
+	last_error_.clear();
+	return result;
+}
+
+kcenon::common::VoidResult postgresql_backend::execute_prepared(
+	const std::string& query,
+	const std::vector<core::database_value>& params)
+{
+	if (!is_initialized()) {
+		last_error_ = "Backend not initialized";
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"postgresql_backend"
+		};
+	}
+
+#ifdef USE_POSTGRESQL
+	try {
+		if (!connection_) {
+			last_error_ = "No active PostgreSQL connection";
+			logger_.error("execute_prepared", last_error_);
+			return kcenon::common::error_info{
+				static_cast<int>(database::error_code::connection_failed),
+				last_error_,
+				"postgresql_backend"
+			};
+		}
+
+		pqxx::connection* conn = static_cast<pqxx::connection*>(connection_);
+		pqxx::work txn(*conn);
+
+		pqxx::params pq_params;
+		for (const auto& val : params) {
+			std::visit([&pq_params](const auto& v) {
+				using T = std::decay_t<decltype(v)>;
+				if constexpr (std::is_same_v<T, std::nullptr_t>) {
+					pq_params.append();
+				} else if constexpr (std::is_same_v<T, bool>) {
+					pq_params.append(v);
+				} else if constexpr (std::is_same_v<T, int64_t>) {
+					pq_params.append(v);
+				} else if constexpr (std::is_same_v<T, double>) {
+					pq_params.append(v);
+				} else if constexpr (std::is_same_v<T, std::string>) {
+					pq_params.append(v);
+				}
+			}, val);
+		}
+
+		txn.exec_params(query, pq_params);
+		txn.commit();
+		last_error_.clear();
+		return kcenon::common::ok();
+	} catch (const std::exception& e) {
+		last_error_ = std::string("Execute prepared error: ") + e.what();
+		logger_.error("execute_prepared", last_error_);
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"postgresql_backend"
+		};
+	}
+#elif defined(HAVE_LIBPQ)
+	if (!connection_) {
+		last_error_ = "No active PostgreSQL connection";
+		logger_.error("execute_prepared", last_error_);
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::connection_failed),
+			last_error_,
+			"postgresql_backend"
+		};
+	}
+
+	std::vector<std::string> param_strings;
+	std::vector<const char*> param_values;
+	param_strings.reserve(params.size());
+	param_values.reserve(params.size());
+
+	for (const auto& val : params) {
+		std::visit([&param_strings, &param_values](const auto& v) {
+			using T = std::decay_t<decltype(v)>;
+			if constexpr (std::is_same_v<T, std::nullptr_t>) {
+				param_strings.emplace_back();
+				param_values.push_back(nullptr);
+			} else if constexpr (std::is_same_v<T, bool>) {
+				param_strings.push_back(v ? "t" : "f");
+				param_values.push_back(param_strings.back().c_str());
+			} else if constexpr (std::is_same_v<T, std::string>) {
+				param_strings.push_back(v);
+				param_values.push_back(param_strings.back().c_str());
+			} else {
+				param_strings.push_back(std::to_string(v));
+				param_values.push_back(param_strings.back().c_str());
+			}
+		}, val);
+	}
+
+	PGresult* pg_result = PQexecParams(
+		static_cast<PGconn*>(connection_),
+		query.c_str(),
+		static_cast<int>(params.size()),
+		nullptr,
+		param_values.data(),
+		nullptr,
+		nullptr,
+		0
+	);
+
+	if (pg_result == nullptr) {
+		last_error_ = "PostgreSQL execute prepared failed";
+		logger_.error("execute_prepared", last_error_);
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"postgresql_backend"
+		};
+	}
+
+	ExecStatusType status = PQresultStatus(pg_result);
+	bool success = (status == PGRES_COMMAND_OK) || (status == PGRES_TUPLES_OK);
+
+	if (!success) {
+		last_error_ = PQerrorMessage(static_cast<PGconn*>(connection_));
+		logger_.error("execute_prepared", last_error_);
+		PQclear(pg_result);
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"postgresql_backend"
+		};
+	}
+
+	PQclear(pg_result);
+	last_error_.clear();
+	return kcenon::common::ok();
+#else
+	return database_backend::execute_prepared(query, params);
+#endif
+}
+
 kcenon::common::VoidResult postgresql_backend::begin_transaction()
 {
 	if (!is_initialized()) {

--- a/database/backends/postgresql_backend.h
+++ b/database/backends/postgresql_backend.h
@@ -93,6 +93,14 @@ public:
 
 	kcenon::common::VoidResult execute_query(const std::string& query_string) override;
 
+	[[nodiscard]] kcenon::common::Result<core::database_result> select_prepared(
+		const std::string& query,
+		const std::vector<core::database_value>& params) override;
+
+	[[nodiscard]] kcenon::common::VoidResult execute_prepared(
+		const std::string& query,
+		const std::vector<core::database_value>& params) override;
+
 	kcenon::common::VoidResult begin_transaction() override;
 
 	kcenon::common::VoidResult commit_transaction() override;

--- a/database/backends/sqlite_backend.cpp
+++ b/database/backends/sqlite_backend.cpp
@@ -326,6 +326,202 @@ kcenon::common::VoidResult sqlite_backend::execute_query(const std::string& quer
 #endif
 }
 
+kcenon::common::Result<core::database_result> sqlite_backend::select_prepared(
+	const std::string& query,
+	const std::vector<core::database_value>& params)
+{
+	if (!is_initialized()) {
+		last_error_ = "Backend not initialized";
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"sqlite_backend"
+		};
+	}
+
+	core::database_result result;
+
+#ifdef USE_SQLITE
+	if (!connection_) {
+		last_error_ = "No active connection";
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::connection_failed),
+			last_error_,
+			"sqlite_backend"
+		};
+	}
+
+	std::lock_guard<std::recursive_mutex> lock(sqlite_mutex_);
+	sqlite3* db = static_cast<sqlite3*>(connection_);
+	sqlite3_stmt* stmt = nullptr;
+
+	int rc = sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr);
+	if (rc != SQLITE_OK) {
+		last_error_ = std::string("Prepare error: ") + sqlite3_errmsg(db);
+		logger_.error("select_prepared", last_error_);
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"sqlite_backend"
+		};
+	}
+
+	// Bind parameters
+	for (size_t i = 0; i < params.size(); ++i) {
+		int bind_idx = static_cast<int>(i + 1); // SQLite uses 1-based indexing
+		int bind_rc = SQLITE_OK;
+
+		std::visit([&bind_rc, stmt, bind_idx](const auto& v) {
+			using T = std::decay_t<decltype(v)>;
+			if constexpr (std::is_same_v<T, std::nullptr_t>) {
+				bind_rc = sqlite3_bind_null(stmt, bind_idx);
+			} else if constexpr (std::is_same_v<T, bool>) {
+				bind_rc = sqlite3_bind_int(stmt, bind_idx, v ? 1 : 0);
+			} else if constexpr (std::is_same_v<T, int64_t>) {
+				bind_rc = sqlite3_bind_int64(stmt, bind_idx, v);
+			} else if constexpr (std::is_same_v<T, double>) {
+				bind_rc = sqlite3_bind_double(stmt, bind_idx, v);
+			} else if constexpr (std::is_same_v<T, std::string>) {
+				bind_rc = sqlite3_bind_text(stmt, bind_idx, v.c_str(),
+					static_cast<int>(v.size()), SQLITE_TRANSIENT);
+			}
+		}, params[i]);
+
+		if (bind_rc != SQLITE_OK) {
+			last_error_ = std::string("Bind error at param ") + std::to_string(i + 1)
+				+ ": " + sqlite3_errmsg(db);
+			logger_.error("select_prepared", last_error_);
+			sqlite3_finalize(stmt);
+			return kcenon::common::error_info{
+				static_cast<int>(database::error_code::query_failed),
+				last_error_,
+				"sqlite_backend"
+			};
+		}
+	}
+
+	// Execute and collect results
+	int col_count = sqlite3_column_count(stmt);
+	while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+		core::database_row db_row;
+		for (int col = 0; col < col_count; ++col) {
+			std::string column_name = sqlite3_column_name(stmt, col);
+			db_row[column_name] = convert_sqlite_value(stmt, col);
+		}
+		result.push_back(std::move(db_row));
+	}
+
+	sqlite3_finalize(stmt);
+
+	if (rc != SQLITE_DONE) {
+		last_error_ = std::string("Step error: ") + sqlite3_errmsg(db);
+		logger_.error("select_prepared", last_error_);
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"sqlite_backend"
+		};
+	}
+#else
+	return database_backend::select_prepared(query, params);
+#endif
+
+	last_error_.clear();
+	return result;
+}
+
+kcenon::common::VoidResult sqlite_backend::execute_prepared(
+	const std::string& query,
+	const std::vector<core::database_value>& params)
+{
+	if (!is_initialized()) {
+		last_error_ = "Backend not initialized";
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::invalid_state),
+			last_error_,
+			"sqlite_backend"
+		};
+	}
+
+#ifdef USE_SQLITE
+	if (!connection_) {
+		last_error_ = "No active SQLite connection";
+		logger_.error("execute_prepared", last_error_);
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::connection_failed),
+			last_error_,
+			"sqlite_backend"
+		};
+	}
+
+	std::lock_guard<std::recursive_mutex> lock(sqlite_mutex_);
+	sqlite3* db = static_cast<sqlite3*>(connection_);
+	sqlite3_stmt* stmt = nullptr;
+
+	int rc = sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr);
+	if (rc != SQLITE_OK) {
+		last_error_ = std::string("Prepare error: ") + sqlite3_errmsg(db);
+		logger_.error("execute_prepared", last_error_);
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"sqlite_backend"
+		};
+	}
+
+	for (size_t i = 0; i < params.size(); ++i) {
+		int bind_idx = static_cast<int>(i + 1);
+		int bind_rc = SQLITE_OK;
+
+		std::visit([&bind_rc, stmt, bind_idx](const auto& v) {
+			using T = std::decay_t<decltype(v)>;
+			if constexpr (std::is_same_v<T, std::nullptr_t>) {
+				bind_rc = sqlite3_bind_null(stmt, bind_idx);
+			} else if constexpr (std::is_same_v<T, bool>) {
+				bind_rc = sqlite3_bind_int(stmt, bind_idx, v ? 1 : 0);
+			} else if constexpr (std::is_same_v<T, int64_t>) {
+				bind_rc = sqlite3_bind_int64(stmt, bind_idx, v);
+			} else if constexpr (std::is_same_v<T, double>) {
+				bind_rc = sqlite3_bind_double(stmt, bind_idx, v);
+			} else if constexpr (std::is_same_v<T, std::string>) {
+				bind_rc = sqlite3_bind_text(stmt, bind_idx, v.c_str(),
+					static_cast<int>(v.size()), SQLITE_TRANSIENT);
+			}
+		}, params[i]);
+
+		if (bind_rc != SQLITE_OK) {
+			last_error_ = std::string("Bind error at param ") + std::to_string(i + 1)
+				+ ": " + sqlite3_errmsg(db);
+			logger_.error("execute_prepared", last_error_);
+			sqlite3_finalize(stmt);
+			return kcenon::common::error_info{
+				static_cast<int>(database::error_code::query_failed),
+				last_error_,
+				"sqlite_backend"
+			};
+		}
+	}
+
+	rc = sqlite3_step(stmt);
+	sqlite3_finalize(stmt);
+
+	if (rc != SQLITE_DONE && rc != SQLITE_ROW) {
+		last_error_ = std::string("Execute prepared error: ") + sqlite3_errmsg(db);
+		logger_.error("execute_prepared", last_error_);
+		return kcenon::common::error_info{
+			static_cast<int>(database::error_code::query_failed),
+			last_error_,
+			"sqlite_backend"
+		};
+	}
+
+	last_error_.clear();
+	return kcenon::common::ok();
+#else
+	return database_backend::execute_prepared(query, params);
+#endif
+}
+
 kcenon::common::VoidResult sqlite_backend::begin_transaction()
 {
 	if (!is_initialized()) {

--- a/database/backends/sqlite_backend.h
+++ b/database/backends/sqlite_backend.h
@@ -90,6 +90,14 @@ public:
 
 	kcenon::common::VoidResult execute_query(const std::string& query_string) override;
 
+	[[nodiscard]] kcenon::common::Result<core::database_result> select_prepared(
+		const std::string& query,
+		const std::vector<core::database_value>& params) override;
+
+	[[nodiscard]] kcenon::common::VoidResult execute_prepared(
+		const std::string& query,
+		const std::vector<core::database_value>& params) override;
+
 	kcenon::common::VoidResult begin_transaction() override;
 
 	kcenon::common::VoidResult commit_transaction() override;

--- a/tests/security/sql_injection_test.cpp
+++ b/tests/security/sql_injection_test.cpp
@@ -348,6 +348,118 @@ TEST_F(SQLInjectionTest, BooleanValueHandling) {
 }
 
 //=============================================================================
+// Prepared Statement Tests (Wire-Level Parameterization)
+//=============================================================================
+
+/**
+ * @test PreparedSelectReturnsCorrectResults
+ * @brief Tests that prepared SELECT queries bind parameters correctly
+ */
+TEST_F(SQLInjectionTest, PreparedSelectReturnsCorrectResults) {
+#ifdef USE_SQLITE
+    std::vector<core::database_value> params = {std::string("Alice")};
+    auto result = db_->select_prepared(
+        "SELECT * FROM users WHERE name = ?", params);
+
+    ASSERT_TRUE(result.is_ok());
+    ASSERT_EQ(result.value().size(), 1u);
+
+    const auto& row = result.value()[0];
+    auto it = row.find("email");
+    ASSERT_NE(it, row.end());
+    EXPECT_EQ(std::get<std::string>(it->second), "alice@test.com");
+#else
+    GTEST_SKIP() << "SQLite not available";
+#endif
+}
+
+/**
+ * @test PreparedSelectBlocksInjection
+ * @brief Tests that prepared statements prevent SQL injection at wire level
+ */
+TEST_F(SQLInjectionTest, PreparedSelectBlocksInjection) {
+#ifdef USE_SQLITE
+    std::string malicious = "' OR '1'='1";
+    std::vector<core::database_value> params = {malicious};
+    auto result = db_->select_prepared(
+        "SELECT * FROM users WHERE name = ?", params);
+
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().size(), 0u)
+        << "Prepared statement should treat malicious input as literal string";
+#else
+    GTEST_SKIP() << "SQLite not available";
+#endif
+}
+
+/**
+ * @test PreparedExecuteWithTypedParams
+ * @brief Tests that execute_prepared handles typed parameters
+ */
+TEST_F(SQLInjectionTest, PreparedExecuteWithTypedParams) {
+#ifdef USE_SQLITE
+    std::vector<core::database_value> params = {
+        int64_t(10),
+        std::string("Charlie"),
+        std::string("charlie@test.com"),
+        std::string("hash_prep")
+    };
+    auto exec_result = db_->execute_prepared(
+        "INSERT INTO users (id, name, email, password_hash) VALUES (?, ?, ?, ?)",
+        params);
+    ASSERT_TRUE(exec_result.is_ok());
+
+    // Verify the row was inserted
+    std::vector<core::database_value> select_params = {int64_t(10)};
+    auto select_result = db_->select_prepared(
+        "SELECT name FROM users WHERE id = ?", select_params);
+    ASSERT_TRUE(select_result.is_ok());
+    ASSERT_EQ(select_result.value().size(), 1u);
+    EXPECT_EQ(std::get<std::string>(select_result.value()[0].at("name")), "Charlie");
+#else
+    GTEST_SKIP() << "SQLite not available";
+#endif
+}
+
+/**
+ * @test PreparedBatchStatementInjectionBlocked
+ * @brief Tests that prepared statements block batch statement injection
+ */
+TEST_F(SQLInjectionTest, PreparedBatchStatementInjectionBlocked) {
+#ifdef USE_SQLITE
+    std::string malicious = "'; DROP TABLE users; --";
+    std::vector<core::database_value> params = {malicious};
+    db_->select_prepared("SELECT * FROM users WHERE name = ?", params);
+
+    // Verify the table still exists
+    auto check = db_->select_query("SELECT COUNT(*) as cnt FROM users");
+    ASSERT_TRUE(check.is_ok());
+    EXPECT_FALSE(check.value().empty())
+        << "CRITICAL: Table dropped via prepared statement injection!";
+#else
+    GTEST_SKIP() << "SQLite not available";
+#endif
+}
+
+/**
+ * @test PreparedNullParameterHandling
+ * @brief Tests that NULL parameters bind correctly in prepared statements
+ */
+TEST_F(SQLInjectionTest, PreparedNullParameterHandling) {
+#ifdef USE_SQLITE
+    std::vector<core::database_value> params = {nullptr};
+    auto result = db_->select_prepared(
+        "SELECT * FROM users WHERE name = ?", params);
+
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().size(), 0u)
+        << "NULL comparison should match no rows (NULL != NULL in SQL)";
+#else
+    GTEST_SKIP() << "SQLite not available";
+#endif
+}
+
+//=============================================================================
 // Query Builder State Tests
 //=============================================================================
 


### PR DESCRIPTION
## What

### Summary
Implements native wire-level prepared statement support in PostgreSQL and SQLite backends by overriding `select_prepared()` and `execute_prepared()` from the base interface added in PR #559.

### Change Type
- [x] Feature (new functionality)

### Affected Components
- `database/backends/postgresql_backend.h/.cpp` — Native prepared statement overrides
- `database/backends/sqlite_backend.h/.cpp` — Native prepared statement overrides
- `tests/security/sql_injection_test.cpp` — Prepared statement injection tests

## Why

### Problem Solved
Phase 1 (#559) added the prepared statement interface with string-interpolation fallback. This Phase 2 PR replaces the fallback with true wire-level parameter binding, providing defense-in-depth against SQL injection.

### Related Issues
- Part of #557 (Phase 2 of 3)
- Depends on #559 (merged — Phase 1 interface)
- Phase 3 will wire `unified_database_system` to use prepared path by default

### Alternative Approaches Considered
1. Template-based parameter packs — Rejected for ABI stability with virtual interface
2. Separate `prepared_statement` object — Deferred to Phase 3 if caching is needed

## Where

### Files Changed
| File | Type of Change |
|------|----------------|
| `database/backends/postgresql_backend.h` | Add override declarations |
| `database/backends/postgresql_backend.cpp` | Implement `select_prepared`/`execute_prepared` via pqxx and libpq |
| `database/backends/sqlite_backend.h` | Add override declarations |
| `database/backends/sqlite_backend.cpp` | Implement via `sqlite3_prepare_v2`/`sqlite3_bind_*` |
| `tests/security/sql_injection_test.cpp` | 5 new tests for prepared statement path |

## How

### Implementation Details
- **PostgreSQL (pqxx)**: Uses `pqxx::params` + `pqxx::work::exec_params()` for wire-level binding
- **PostgreSQL (libpq)**: Uses `PQexecParams()` with `paramValues` array, letting server infer types
- **SQLite**: Uses `sqlite3_prepare_v2()` → type-specific `sqlite3_bind_*()` → `sqlite3_step()`
- **Mock mode**: Falls back to base class string interpolation when backends are not compiled
- All implementations follow existing error handling patterns (`Result<T>`, `VoidResult`)

### Testing Done
- [x] 5 new prepared statement security tests added
- [x] Tests cover: correct results, injection blocking, typed params, batch injection, NULL handling
- [x] Existing tests unaffected (prepared methods are additive overrides)

### Test Plan
1. Run `ctest --output-on-failure` — all tests should pass
2. Verify `PreparedSelectBlocksInjection` passes (injection treated as literal)
3. Verify `PreparedBatchStatementInjectionBlocked` passes (table survives)

### Breaking Changes
None — additive overrides only, existing `execute_query`/`select_query` unchanged