### PR TITLE
feat(release): prepare database_system for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-04-16
+
 ### Changed
 
 - **BREAKING**: Unified CMake package name from `DatabaseSystem` to `database_system` for vcpkg consumption; use `find_package(database_system CONFIG REQUIRED)` ([#547](https://github.com/kcenon/database_system/issues/547))
+- **BREAKING**: `unified_database_system::builder::build()` now returns `Result<std::unique_ptr<unified_database_system>>` instead of throwing on failure ([#564](https://github.com/kcenon/database_system/issues/564))
+- `unified_database_system` constructor defers coordinator initialization to `connect()` for no-throw guarantee ([#564](https://github.com/kcenon/database_system/issues/564))
+- All synchronous public APIs now use `Result<T>` for error propagation with zero `throw` statements ([#564](https://github.com/kcenon/database_system/issues/564))
 
 ### Documentation
 
 - Modernize Doxygen with doxygen-awesome-css theme, dark mode toggle, and standardized mainpage ([#537](https://github.com/kcenon/database_system/issues/537))
+- Add v1.0 migration guide in README for CMake and builder API changes ([#564](https://github.com/kcenon/database_system/issues/564))
 
 ### Security
 
@@ -46,3 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - vcpkg manifest with backend-specific features
 - codecov.io integration
 - Cross-platform support (Linux, macOS, Windows)
+
+[Unreleased]: https://github.com/kcenon/database_system/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/kcenon/database_system/compare/v0.1.0...v1.0.0
+[0.1.0]: https://github.com/kcenon/database_system/releases/tag/v0.1.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ cmake_minimum_required(VERSION 3.20)
 
 # Project definition
 project(database_system
-    VERSION 0.1.0
+    VERSION 1.0.0
     DESCRIPTION "Pure, Lightweight C++20 Core DAL Library"
     LANGUAGES CXX
 )

--- a/README.md
+++ b/README.md
@@ -39,7 +39,14 @@ A modern C++20 database abstraction layer providing unified access to multiple d
 >
 > Currently, DirectMode is the only production option. Connection pooling has been removed locally (Phase 4.3) in preparation for server-side pooling via ProxyMode. See [migration guide](docs/migration/database_base.md) for details. <!-- TODO: dedicated proxy-mode.md migration doc -->
 
-### Latest Updates (2026-01)
+### v1.0.0 Release (2026-04)
+
+- **API Frozen**: All synchronous public APIs use `Result<T>` for error propagation — no `throw` in public API paths
+- **BREAKING**: `builder::build()` now returns `Result<std::unique_ptr<unified_database_system>>` instead of raw pointer
+- **BREAKING**: CMake package name unified to `database_system`; use `find_package(database_system CONFIG REQUIRED)`
+- **Migration from 0.x**: Update `builder::build()` call sites to handle `Result` (see [CHANGELOG](CHANGELOG.md))
+
+### Previous Updates (2026-01)
 
 - **C++20 Module Support**: Added module files for modern C++20 module imports
   - Primary module: `kcenon.database`

--- a/database/CMakeLists.txt
+++ b/database/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 # Project definition
 project(database
-    VERSION 0.1.0.0
+    VERSION 1.0.0.0
     DESCRIPTION "Database abstraction layer with PostgreSQL support"
     LANGUAGES CXX
 )

--- a/database/integrated/unified_database_system.cpp
+++ b/database/integrated/unified_database_system.cpp
@@ -289,15 +289,10 @@ public:
         , coordinator_(std::make_unique<database_coordinator>(config))
         , backend_type_(backend_type::postgres)
         , connected_(false)
+        , initialized_(false)
     {
-        // Initialize coordinator
-        auto init_result = coordinator_->initialize();
-        if (!init_result.is_ok()) {
-            throw std::runtime_error("Failed to initialize database coordinator: " +
-                init_result.error().message);
-        }
-
-        // Initialize metrics
+        // Coordinator initialization is deferred to ensure_initialized()
+        // to maintain the no-throw guarantee documented in the public API.
         metrics_.measurement_start = std::chrono::steady_clock::now();
     }
 
@@ -310,6 +305,11 @@ public:
 
     kcenon::common::VoidResult connect(backend_type backend, const std::string& connection_string) {
         std::lock_guard<std::mutex> lock(mutex_);
+
+        auto init_result = ensure_initialized();
+        if (!init_result.is_ok()) {
+            return init_result;
+        }
 
         if (connected_) {
             return make_error("Already connected", -1, "unified_database_system");
@@ -607,6 +607,19 @@ public:
     }
 
 private:
+    kcenon::common::VoidResult ensure_initialized() {
+        if (initialized_) {
+            return kcenon::common::ok();
+        }
+        auto init_result = coordinator_->initialize();
+        if (!init_result.is_ok()) {
+            return make_error("Failed to initialize database coordinator: " +
+                init_result.error().message, -10, "unified_database_system");
+        }
+        initialized_ = true;
+        return kcenon::common::ok();
+    }
+
     void update_metrics(std::chrono::microseconds latency, bool success) {
         ++metrics_.total_queries;
 
@@ -659,6 +672,7 @@ private:
     backend_type backend_type_;
     std::string connection_string_;
     bool connected_;
+    bool initialized_;
 
     std::shared_ptr<core::database_backend> backend_; // shared_ptr for transaction support
 
@@ -878,18 +892,22 @@ unified_database_system::builder& unified_database_system::builder::set_slow_que
     return *this;
 }
 
-std::unique_ptr<unified_database_system> unified_database_system::builder::build() {
+kcenon::common::Result<std::unique_ptr<unified_database_system>> unified_database_system::builder::build() {
     auto system = std::make_unique<unified_database_system>(config_);
 
     // Auto-connect if connection string provided
     if (!connection_string_.empty()) {
         auto result = system->connect(config_.database.type, connection_string_);
         if (!result.is_ok()) {
-            throw std::runtime_error("Failed to connect: " + result.error().message);
+            return kcenon::common::error_info{
+                result.error().code,
+                "Failed to connect: " + result.error().message,
+                result.error().source
+            };
         }
     }
 
-    return system;
+    return std::move(system);
 }
 
 unified_database_system::builder unified_database_system::create_builder() {

--- a/database/integrated/unified_database_system.h
+++ b/database/integrated/unified_database_system.h
@@ -338,9 +338,9 @@ public:
 
         /**
          * @brief Build and return the configured database system
-         * @return Unique pointer to configured unified_database_system
+         * @return Result containing unique pointer to configured system, or error
          */
-        std::unique_ptr<unified_database_system> build();
+        kcenon::common::Result<std::unique_ptr<unified_database_system>> build();
 
     private:
         unified_db_config config_;

--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -43,7 +43,7 @@ database\_system project.
 - Comprehensive integration test coverage
 - CI-validated on Linux, macOS, and Windows
 
-> **Note (Phase 4.3)**: Local client-side connection pooling has been removed. Production pooling is handled server-side via ProxyMode with `database_server` middleware. See [CHANGELOG](CHANGELOG.md) and [README](../README.md#overview).
+> **Note (Phase 4.3)**: Local client-side connection pooling has been removed. Production pooling is handled server-side via ProxyMode with `database_server` middleware. See [CHANGELOG](CHANGELOG.md) and [README](../README.md).
 
 ### SQLite
 

--- a/docs/FEATURES_POOLING_SECURITY.md
+++ b/docs/FEATURES_POOLING_SECURITY.md
@@ -17,7 +17,7 @@ category: "FEAT"
 
 ---
 
-> **DEPRECATION NOTICE (Phase 4.3)**: Local connection pooling (`connection_pool`, `connection_pool_v2`, `connection_pool_v3`) and the resilience classes (`connection_health_monitor`, `resilient_database_connection`) **have been removed**. See [CHANGELOG](CHANGELOG.md) and [README](../README.md#overview) for details. <!-- TODO: CHANGELOG.md has no 0.4.3 entry yet; pool-removal record should be added under [Unreleased] --> The sections below are retained as historical reference only; **they do not describe current behavior**. Production deployments should rely on ProxyMode with `database_server` middleware for server-side pooling.
+> **DEPRECATION NOTICE (Phase 4.3)**: Local connection pooling (`connection_pool`, `connection_pool_v2`, `connection_pool_v3`) and the resilience classes (`connection_health_monitor`, `resilient_database_connection`) **have been removed**. See [CHANGELOG](CHANGELOG.md) and [README](../README.md) for details. <!-- TODO: CHANGELOG.md has no 0.4.3 entry yet; pool-removal record should be added under [Unreleased] --> The sections below are retained as historical reference only; **they do not describe current behavior**. Production deployments should rely on ProxyMode with `database_server` middleware for server-side pooling.
 
 ---
 
@@ -41,7 +41,7 @@ category: "FEAT"
 **Status**: **REMOVED (Phase 4.3)** — kept below for historical reference only.
 **Implementation**: Previously `connection_pool.h/cpp` (removed). ProxyMode with `database_server` middleware is the forward path.
 
-> The subsections that follow document the legacy local pool design. They are **not** the current behavior. See [CHANGELOG](CHANGELOG.md) and [README](../README.md#overview).
+> The subsections that follow document the legacy local pool design. They are **not** the current behavior. See [CHANGELOG](CHANGELOG.md) and [README](../README.md).
 
 ### Connection Pool v3 Features (Historical)
 

--- a/samples/integrated/async_queries.cpp
+++ b/samples/integrated/async_queries.cpp
@@ -221,17 +221,18 @@ int main(int argc, char* argv[]) {
     // Create database instance
     std::cout << "Creating database instance with async support...\n";
 
-    auto db = unified_database_system::create_builder()
+    auto db_result = unified_database_system::create_builder()
         .enable_logging(db_log_level::info, "./logs")
         .enable_monitoring(true)
         .enable_async(8)  // 8 async worker threads
         .set_pool_size(2, 10)
         .build();
 
-    if (!db) {
-        std::cerr << "❌ Failed to create database instance\n";
+    if (db_result.is_err()) {
+        std::cerr << "Failed to create database instance: " << db_result.error().message << "\n";
         return 1;
     }
+    auto db = std::move(db_result.value());
 
     std::cout << "✅ Database instance created with async support\n";
 

--- a/samples/integrated/basic_usage.cpp
+++ b/samples/integrated/basic_usage.cpp
@@ -89,16 +89,17 @@ int main(int argc, char* argv[]) {
     // Step 1: Create database instance with zero-config
     std::cout << "Step 1: Creating database instance...\n";
 
-    auto db = unified_database_system::create_builder()
+    auto db_result = unified_database_system::create_builder()
         .enable_logging(db_log_level::info, "./logs")
         .enable_monitoring(true)
         .set_pool_size(2, 10)
         .build();
 
-    if (!db) {
-        std::cerr << "❌ Failed to create database instance\n";
+    if (db_result.is_err()) {
+        std::cerr << "Failed to create database instance: " << db_result.error().message << "\n";
         return 1;
     }
+    auto db = std::move(db_result.value());
 
     std::cout << "✅ Database instance created\n";
 

--- a/samples/integrated/migration_from_legacy.cpp
+++ b/samples/integrated/migration_from_legacy.cpp
@@ -51,14 +51,15 @@ int main() {
     std::cout << "  - Result<T> for explicit error handling\n\n";
 
     std::cout << "Example:\n";
-    auto db = unified_database_system::create_builder()
+    auto db_result = unified_database_system::create_builder()
         .enable_logging(db_log_level::info, "./logs")
         .enable_monitoring(true)
         .set_pool_size(2, 10)
         .build();
 
-    if (db) {
-        std::cout << "✅ Database instance created with integrated API\n";
+    if (db_result.is_ok()) {
+        auto db = std::move(db_result.value());
+        std::cout << "Database instance created with integrated API\n";
     }
 
     // ========================================

--- a/samples/integrated/monitoring.cpp
+++ b/samples/integrated/monitoring.cpp
@@ -315,7 +315,7 @@ int main(int argc, char* argv[]) {
     // Create database instance with monitoring enabled
     std::cout << "Creating database instance with monitoring...\n";
 
-    auto db = unified_database_system::create_builder()
+    auto db_result = unified_database_system::create_builder()
         .enable_logging(db_log_level::info, "./logs")
         .enable_monitoring(true)
         .enable_async(4)
@@ -323,10 +323,11 @@ int main(int argc, char* argv[]) {
         .set_slow_query_threshold(milliseconds(100))
         .build();
 
-    if (!db) {
-        std::cerr << "❌ Failed to create database instance\n";
+    if (db_result.is_err()) {
+        std::cerr << "Failed to create database instance: " << db_result.error().message << "\n";
         return 1;
     }
+    auto db = std::move(db_result.value());
 
     std::cout << "✅ Database instance created\n";
 

--- a/tests/integrated/test_unified_database_system.cpp
+++ b/tests/integrated/test_unified_database_system.cpp
@@ -155,8 +155,10 @@ bool test_builder_default() {
     TEST_START("Builder Pattern - Default Configuration");
 
     auto builder = unified_database_system::create_builder();
-    auto db = builder.build();
+    auto db_result = builder.build();
 
+    ASSERT_TRUE(db_result.is_ok(), "Builder should succeed");
+    auto db = std::move(db_result.value());
     ASSERT_TRUE(db != nullptr, "Builder should create database instance");
 
     TEST_END();
@@ -169,27 +171,23 @@ bool test_builder_default() {
 bool test_builder_custom() {
     TEST_START("Builder Pattern - Custom Configuration");
 
-    try {
-        auto db = unified_database_system::create_builder()
-            .set_backend(backend_type::postgres)
-            .set_connection_string("host=localhost dbname=test")
-            .set_pool_size(5, 20)
-            .enable_logging(db_log_level::debug, "./test_logs")
-            .enable_monitoring(true)
-            .enable_async(8)
-            .set_slow_query_threshold(std::chrono::milliseconds(500))
-            .build();
+    auto db_result = unified_database_system::create_builder()
+        .set_backend(backend_type::postgres)
+        .set_connection_string("host=localhost dbname=test")
+        .set_pool_size(5, 20)
+        .enable_logging(db_log_level::debug, "./test_logs")
+        .enable_monitoring(true)
+        .enable_async(8)
+        .set_slow_query_threshold(std::chrono::milliseconds(500))
+        .build();
 
-        ASSERT_TRUE(db != nullptr, "Builder with custom config should create instance");
-
-        // Note: Connection is not established yet, just configuration
-        // Actual connection would happen on connect() or first query
-
-    } catch (const std::exception& e) {
+    if (db_result.is_err()) {
         // If PostgreSQL is not available or not compiled in, that's acceptable
         // This test is just verifying the builder API works
-        std::cout << "  ℹ️  Note: Database connection not available: " << e.what() << "\n";
-        std::cout << "  ℹ️  Builder API test passed (connection test skipped)\n";
+        std::cout << "  Note: Database connection not available: " << db_result.error().message << "\n";
+        std::cout << "  Builder API test passed (connection test skipped)\n";
+    } else {
+        ASSERT_TRUE(db_result.value() != nullptr, "Builder with custom config should create instance");
     }
 
     TEST_END();
@@ -239,10 +237,12 @@ bool test_config_construction() {
 bool test_move_semantics() {
     TEST_START("Move Semantics");
 
-    auto db1 = unified_database_system::create_builder()
+    auto db1_result = unified_database_system::create_builder()
         .set_backend(backend_type::postgres)
         .build();
 
+    ASSERT_TRUE(db1_result.is_ok(), "Builder should succeed");
+    auto db1 = std::move(db1_result.value());
     ASSERT_TRUE(db1 != nullptr, "Original instance should be valid");
 
     // Move construction
@@ -250,7 +250,9 @@ bool test_move_semantics() {
     ASSERT_TRUE(db2 != nullptr, "Moved instance should be valid");
 
     // Move assignment
-    auto db3 = unified_database_system::create_builder().build();
+    auto db3_result = unified_database_system::create_builder().build();
+    ASSERT_TRUE(db3_result.is_ok(), "Builder should succeed");
+    auto db3 = std::move(db3_result.value());
     db3 = std::move(db2);
     ASSERT_TRUE(db3 != nullptr, "Move-assigned instance should be valid");
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "kcenon-database-system",
-  "version-semver": "0.1.0",
-  "port-version": 6,
+  "version-semver": "1.0.0",
+  "port-version": 0,
   "description": "Advanced C++20 Database System with Multi-Backend Support",
   "homepage": "https://github.com/kcenon/database_system",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
Closes #564

## Summary
- Replace `throw` with `Result<T>` in `unified_database_system` to align with documented no-throw guarantee
- Change `builder::build()` return type to `Result<std::unique_ptr<unified_database_system>>`
- Bump version from 0.1.0 to 1.0.0 across CMakeLists.txt, vcpkg.json
- Update CHANGELOG with v1.0.0 release notes including breaking changes
- Update README with v1.0 migration notes
- Fix pre-existing broken markdown anchors in docs

## What
### Change Type
- [x] Feature (new functionality)
- [x] Refactor (no functional changes)
- [x] Documentation

### Affected Components
- `database/integrated/unified_database_system.h` — builder API signature change
- `database/integrated/unified_database_system.cpp` — lazy init, Result return
- `tests/integrated/test_unified_database_system.cpp` — updated for new API
- `samples/integrated/*.cpp` — updated for new API

## Why
### Problem Solved
The `unified_database_system` class documented a "No-throw guarantee" but the constructor
and `builder::build()` method threw `std::runtime_error` on failure. This violated the
documented API contract. For v1.0, all synchronous public APIs must use `Result<T>` for
error propagation.

### Related Issues
- Closes #564 (Prepare database_system for v1.0 release)
- Part of kcenon/common_system#639 (Ecosystem v1.0 release)

## How
### Implementation Details
1. **Lazy initialization**: `impl` constructor no longer calls `coordinator_->initialize()`. 
   Initialization is deferred to `ensure_initialized()`, called from `connect()`.
2. **Result return type**: `builder::build()` returns `Result<unique_ptr<>>` instead of 
   throwing on connection failure.
3. **Version bump**: 0.1.0 → 1.0.0 in CMakeLists.txt (root + database), vcpkg.json.

### Breaking Changes
- `builder::build()` return type changed from `std::unique_ptr<unified_database_system>` 
  to `Result<std::unique_ptr<unified_database_system>>`
- CMake package name unified to `database_system` (from prior unreleased change)

### Test Plan
- [ ] Unit tests pass (test_unified_database_system updated for new API)
- [ ] CI multi-platform build passes (Linux GCC/Clang, macOS, Windows MSVC)
- [ ] Samples compile with new Result-based builder API