### PR TITLE
release: database_system v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-04-16
+
 ### Changed
 
 - **BREAKING**: Unified CMake package name from `DatabaseSystem` to `database_system` for vcpkg consumption; use `find_package(database_system CONFIG REQUIRED)` ([#547](https://github.com/kcenon/database_system/issues/547))
+- **BREAKING**: `unified_database_system::builder::build()` now returns `Result<std::unique_ptr<unified_database_system>>` instead of throwing on failure ([#564](https://github.com/kcenon/database_system/issues/564))
+- `unified_database_system` constructor defers coordinator initialization to `connect()` for no-throw guarantee ([#564](https://github.com/kcenon/database_system/issues/564))
+- All synchronous public APIs now use `Result<T>` for error propagation with zero `throw` statements ([#564](https://github.com/kcenon/database_system/issues/564))
 
 ### Documentation
 
 - Modernize Doxygen with doxygen-awesome-css theme, dark mode toggle, and standardized mainpage ([#537](https://github.com/kcenon/database_system/issues/537))
+- Add v1.0 migration guide in README for CMake and builder API changes ([#564](https://github.com/kcenon/database_system/issues/564))
 
 ### Security
 
@@ -46,3 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - vcpkg manifest with backend-specific features
 - codecov.io integration
 - Cross-platform support (Linux, macOS, Windows)
+
+[Unreleased]: https://github.com/kcenon/database_system/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/kcenon/database_system/compare/v0.1.0...v1.0.0
+[0.1.0]: https://github.com/kcenon/database_system/releases/tag/v0.1.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ cmake_minimum_required(VERSION 3.20)
 
 # Project definition
 project(database_system
-    VERSION 0.1.0
+    VERSION 1.0.0
     DESCRIPTION "Pure, Lightweight C++20 Core DAL Library"
     LANGUAGES CXX
 )

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Thank you for considering contributing to Database System\! This document provid
 
 ### Prerequisites
 
-- C++20 compatible compiler (GCC 13+, Clang 16+, MSVC 2022+)
+- C++20 compatible compiler (GCC 13+, Clang 17+, MSVC 2022+, Apple Clang 14+)
 - CMake 3.20 or higher
 - Git
 - vcpkg (recommended)

--- a/DOC_REVIEW_REPORT.md
+++ b/DOC_REVIEW_REPORT.md
@@ -1,0 +1,212 @@
+# Document Review Report — database_system
+
+**Generated**: 2026-04-14
+**Mode**: Report-only
+**Files analyzed**: 80
+
+Scope: All `*.md` files under `/Volumes/T5 EVO/Sources/database_system` excluding `build/`, `.git/`, `vcpkg-*/`, and `docs/doxygen-awesome-css/`. Primary tree is `docs/`; root `README*`, `CHANGELOG*`, `CODE_OF_CONDUCT*`, `CONTRIBUTING*`, `SECURITY*`, `.github/**`, `benchmarks/README.md`, `integration_tests/README.md`, `samples/README.md`, `examples/README.md` also covered. Korean `*.kr.md` files included.
+
+Ground-truth anchors: 2,492. Links validated (excluding external URLs): 1,115. Broken links: 73 (71 missing files, 2 missing anchors).
+
+## Findings Summary
+
+| Severity       | Phase 1 | Phase 2 | Phase 3 | Total |
+|----------------|---------|---------|---------|-------|
+| Must-Fix       | 73      | 14      | 10      | 97    |
+| Should-Fix     | 3       | 12      | 12      | 27    |
+| Nice-to-Have   | 2       | 4       | 6       | 12    |
+
+## Must-Fix Items
+
+### Phase 1 — Broken Links & Anchors (73)
+
+Intra-anchor mismatches:
+1. `README.md:263` — `docs/FEATURES.md#query-builders`. Anchor `query-builders` does not exist in `FEATURES.md` (which is now a split index). Actual anchor is in `docs/FEATURES_ORM_QUERY.md#query-builders`. (Phase 1)
+2. `README.md:293` — `docs/FEATURES.md#orm-framework`. Anchor is in `docs/FEATURES_ORM_QUERY.md#orm-framework`. (Phase 1)
+
+Missing files referenced by links (71 total; grouped below):
+
+3. `README.md:40` — `docs/migration/proxy-mode.md` not present. (Phase 1)
+4. `README.md:153` — `docs/guides/QUICK_START_KO.md` not present (actual file is `QUICK_START.kr.md`). (Phase 1)
+5. `README.md:508,581` — `docs/01-ARCHITECTURE.md` not present (should be `docs/ARCHITECTURE.md`). (Phase 1)
+6. `README.md:563` — `../ECOSYSTEM.md` resolves outside repo (`/Volumes/T5 EVO/Sources/ECOSYSTEM.md`). Actual file is `docs/ECOSYSTEM.md`. (Phase 1)
+7. `README.md:582` — `docs/02-API_REFERENCE.md` not present (should be `docs/API_REFERENCE.md`). (Phase 1)
+8. `README.md:583` — `docs/advanced/SECURITY.md` not present. (Phase 1)
+9. `README.md:584` — `docs/guides/MIGRATION_GUIDE.md` not present (should be `docs/advanced/MIGRATION.md`). (Phase 1)
+10. `docs/ADAPTER_PATTERNS.md:15` — `ADAPTER_PATTERNS.kr.md` not present (Language switcher link broken). (Phase 1)
+11. `docs/API_REFERENCE.md:1107` — `guides/PROXY_LAYER.md` not present. (Phase 1)
+12. `docs/README.kr.md:66..258` — 21 broken links to `BUILD_GUIDE.kr.md`, `SAMPLES_GUIDE.kr.md`, `PERFORMANCE_BENCHMARKS.kr.md` at wrong paths (actual files live under `guides/` or `performance/`). (Phase 1)
+13. `docs/advanced/MIGRATION.md:394` — `../migration/proxy-mode.md` not present. (Phase 1)
+14. `docs/advanced/MIGRATION.md:869` — `docs/API_REFERENCE.md` resolves to `docs/advanced/docs/API_REFERENCE.md` (path prefix error; should be `../API_REFERENCE.md`). (Phase 1)
+15. `docs/advanced/THREAD_SYSTEM_MIGRATION.md:398..399` — `./INTEGRATION.md`, `./API_REFERENCE.md` at wrong relative path. (Phase 1)
+16. `docs/advanced/TYPE_SYSTEM.md:434..437` — `API_REFERENCE.md`, `ORM.md`, `BACKEND_INTEGRATION.md` at wrong relative path (files live in `../`). (Phase 1)
+17. `docs/contributing/CONTRIBUTING.md:80,908` — `../BUILD_GUIDE.md` not present (should be `../guides/BUILD_GUIDE.md`). (Phase 1)
+18. `docs/contributing/CONTRIBUTING.md:81,911` — `../../IMPROVEMENT_PLAN.md` not present in repo. (Phase 1)
+19. `docs/guides/ASYNC_OPERATIONS.md:15` — `ASYNC_OPERATIONS.kr.md` not present. (Phase 1)
+20. `docs/guides/FAQ.md:171,795,928,1126,1377,1490,1493,1494,1495` — 9 broken links (`../BUILD_GUIDE.md`, `../PERFORMANCE_BENCHMARKS.md`, `../INTEGRATION.md`, `../../IMPROVEMENT_PLAN.md`). (Phase 1)
+21. `docs/guides/INTEGRATION.md:15` — `INTEGRATION.kr.md` not present. (Phase 1)
+22. `docs/guides/INTEGRATION.md:1076..1077` — `docs/API_REFERENCE.md`, `docs/BUILD_GUIDE.md` resolved incorrectly. (Phase 1)
+23. `docs/guides/QUICK_START.md:159` — `../../INTEGRATION.md` not present in repo root. (Phase 1)
+24. `docs/guides/SAMPLES_GUIDE.md:797`, `docs/guides/SAMPLES_GUIDE.kr.md:797` — `API_REFERENCE.md` at wrong relative path (should be `../API_REFERENCE.md`). (Phase 1)
+25. `docs/guides/TROUBLESHOOTING.md:915` — `../BUILD_GUIDE.md` not present. (Phase 1)
+26. `docs/guides/UNIFIED_SYSTEM.md:15` — `UNIFIED_SYSTEM.kr.md` not present. (Phase 1)
+27. `docs/integration/README.md:21..25` — 5 broken links to `with-common-system.md`, `with-logger.md`, `with-monitoring.md`, `with-thread-system.md`, `with-network-system.md` (none exist). (Phase 1)
+28. `docs/integration/README.md:222` — `../../../ECOSYSTEM.md` resolves outside repo. (Phase 1)
+29. `docs/migration/database_base.md:316` — `../guides/backend_registry.md` not present. (Phase 1)
+30. `docs/performance/BENCHMARKS.kr.md:15` — `PERFORMANCE_BENCHMARKS.md` (language-switcher) not present; `docs/performance/BENCHMARKS.md:15` — same mirror issue for `.kr.md`. (Phase 1)
+31. `docs/performance/TUNING_GUIDE.md:133..134` — `POSTGRESQL_TUNING.md`, `SQLITE_TUNING.md` not present. (Phase 1)
+32. `integration_tests/README.md:285` — `../docs/performance.md` not present. (Phase 1)
+
+### Phase 2 — Factual Accuracy (14 items)
+
+33. `docs/advanced/CURRENT_STATE.md:30,36,54,74,84` — Documents claim backends are PostgreSQL, MySQL, SQLite. Actual supported backends per `CLAUDE.md` and `vcpkg.json` are PostgreSQL, SQLite, MongoDB, Redis. MySQL does not exist; MongoDB/Redis not mentioned. Korean mirror `CURRENT_STATE.kr.md` has identical errors. (Phase 2)
+34. `docs/advanced/ARCHITECTURE_ISSUES.md:32..33` + Korean mirror — "ARC-001: MySQL/SQLite Backend Testing (P0, Phase 1)". MySQL is not a real backend. (Phase 2)
+35. `docs/PROJECT_STRUCTURE.md:684`, `docs/PROJECT_STRUCTURE.kr.md:508` — libpqxx listed as "7.7+", but `vcpkg.json` pins 7.9.2. (Phase 2)
+36. `docs/SOUP.md:43,86` — libpqxx listed as 7.9.0 rather than 7.9.2 (vcpkg override). (Phase 2)
+37. `docs/GETTING_STARTED.md:24` — Compiler baseline given as GCC 12+/Clang 15+/MSVC 17.4+; `README.md:74` says GCC 13+/Clang 17+/MSVC 2022+. (Phase 2)
+38. `docs/guides/QUICK_START.kr.md:30` — Compiler baseline says GCC 11+/Clang 14+; actual (per README) is GCC 13+/Clang 17+. (Phase 2)
+39. `samples/README.md:212` — Compiler baseline GCC 10+/Clang 12+/MSVC 2019+; severely out of date. (Phase 2)
+40. `CONTRIBUTING.md:17` — "GCC 13+, Clang 16+, MSVC 2022+" — Clang 16 inconsistent with README's Clang 17+. (Phase 2)
+41. `docs/FEATURES_POOLING_SECURITY.md:35..160` — Documents active `connection_pool`, `connection_pool_v3`, `acquire_connection()` etc. as current features. Per `CLAUDE.md` Phase 4.3 and `docs/CHANGELOG.md:206,272`, all local pooling classes were **removed**. Entire "Connection Pooling" and "Resilient Connections" sections are factually obsolete. (Phase 2)
+42. `docs/BACKENDS.md:41` — Lists "Connection pooling support" as a PostgreSQL feature (contradicts Phase 4.3 removal). (Phase 2)
+43. `docs/FEATURES.kr.md` (lines 29, 412–) — Korean features doc still describes connection pooling as a current feature and was not updated when English `FEATURES.md` was split and pool removal was documented. (Phase 2)
+44. `docs/ORM_GUIDE.md:15,80,250,413` and `docs/FEATURES_ORM_QUERY.md:39` — Claim "Full Support (C++17 SFINAE-based)". Project root `CLAUDE.md` states ORM uses "C++20 concepts". Inconsistency between implementation language claim and project description. (Phase 2)
+45. `docs/guides/SAMPLES_GUIDE.md:750`, `docs/guides/SAMPLES_GUIDE.kr.md:750` — Hard-coded date literal `"2023-01-01"` in sample; acceptable as example data but mismatched with other 2026 dates (Nice-to-Have; surfaced here because paired with the 2025-12/2026-02 inconsistencies).
+46. `docs/advanced/CURRENT_STATE.md:46..48` — Lists Ubuntu 22.04 (GCC 12, Clang 15) as the validated platform baseline. Given README's GCC 13+/Clang 17+ requirement, the baseline is out of date. (Phase 2)
+
+### Phase 3 — SSOT Contradictions (10)
+
+47. `docs/ARCHITECTURE.md:13` AND `docs/advanced/ARCHITECTURE.md:13` — Both claim "single source of truth for Database System Architecture". Duplicate SSOT with different doc_ids (DBS-ARCH-002 and DBS-ARCH-003). Content not reconciled. (Phase 3)
+48. `docs/PROJECT_STRUCTURE.md:13` AND `docs/advanced/STRUCTURE.md:13` — Both SSOT for "Database System Project Structure" (DBS-PROJ-004 vs DBS-ARCH-006). Content overlap unresolved. (Phase 3)
+49. `docs/BENCHMARKS.md:13` AND `docs/performance/BENCHMARKS.md:13` — Both SSOT for "Database System Performance Benchmarks" (DBS-PERF-002 vs DBS-PERF-006). Two parallel benchmark documents. (Phase 3)
+50. `docs/BENCHMARKS.kr.md` AND `docs/performance/BENCHMARKS.kr.md` — Same duplication in Korean. (Phase 3)
+51. `docs/MIGRATION_database_base.md:13` AND `docs/migration/database_base.md:13` — Two migration guides for the same `database_base → database_backend` topic (DBS-MIGR-001 vs DBS-GUID-022), both claiming SSOT. (Phase 3)
+52. `docs/FEATURES.md` was refactored into split sub-documents (`FEATURES_BACKENDS.md`, `FEATURES_ORM_QUERY.md`, `FEATURES_POOLING_SECURITY.md`), but `docs/FEATURES.kr.md` was NOT split. Korean docs are out of sync with English SSOT structure. (Phase 3)
+53. `docs/FEATURES_POOLING_SECURITY.md` documents connection pooling as current functionality while `README.md:40,52` and `docs/CHANGELOG.md:206,272` state it was removed in Phase 4.3. Cross-document SSOT contradiction on a load-bearing technical fact. (Phase 3)
+54. `docs/BACKENDS.md:41` contradicts the same Phase 4.3 status (states pool support for PostgreSQL). (Phase 3)
+55. `docs/README.md` lists 59 documents. Actual total is 80. Missing from the registry: `FEATURES_BACKENDS.md`, `FEATURES_ORM_QUERY.md`, `FEATURES_POOLING_SECURITY.md`, `API_QUICK_REFERENCE.md`, `ECOSYSTEM.md`, `GETTING_STARTED.md` plus all root/sub-README and .github templates. Registry is stale. (Phase 3)
+56. `docs/README.kr.md:17-53` table of contents uses emoji-prefixed headings that produce anchors the ToC does not match (fixed by emoji-stripping in this audit), but the ToC was clearly authored without running it through a GitHub-style renderer — high risk of drift if headings change. (Phase 3)
+
+## Should-Fix Items
+
+### Phase 1
+- `docs/README.kr.md` — many `.kr.md` links use bare filename root (`BUILD_GUIDE.kr.md`) but the target files live in `guides/` or `performance/`. Convert to relative paths.
+- `docs/guides/INTEGRATION.md:1076..1077` — recurring pattern of `docs/API_REFERENCE.md`-style absolute references from within `docs/` subdirs. Standardize on relative paths.
+- `docs/advanced/MIGRATION.md:869` — same absolute-from-docs pattern; replace with `../API_REFERENCE.md`.
+
+### Phase 2 (Terminology)
+- "backend" vs "driver" used interchangeably in `docs/advanced/CURRENT_STATE*.md:54` ("Database drivers"). Project convention is "backend" (per `CLAUDE.md` and `BACKENDS.md`).
+- "connection pool" vs "connection pooling" vs "pool" — inconsistent noun usage across `FEATURES_POOLING_SECURITY.md` and `BACKENDS.md`.
+- "ORM framework" vs "ORM" vs "entity system" — `ORM_GUIDE.md` uses "ORM framework"; other docs drop "framework".
+- "query builder" vs "query_builder" — `API_REFERENCE.md` uses underscore namespace form; narrative docs use space form. Acceptable, but not called out.
+- "transaction" vs "transaction management" — mixed.
+- README.md:74 vs README.kr.md:77 — English gives GCC 13+/Clang 17+, Korean table gives "MSVC 2022+ | C++20 기능 필수" with no GCC/Clang row. Korean table is incomplete.
+- `benchmarks/README.md:299` — "Last Updated: 2025-10-07" vs newer docs dated 2026-02-08. Stale timestamp.
+- `docs/API_REFERENCE.md:1245` — "Last Updated: 2025-12-09" vs most docs 2026-02-08.
+- `docs/ORM_GUIDE.md` — no frontmatter `doc_date` update; has 2026-04-04 but references say C++17 still.
+- `docs/advanced/ARCHITECTURE.md` and `docs/advanced/STRUCTURE.md` — do not declare language-switcher links (present in most other English docs).
+- `docs/SOUP.md:43` — libpqxx 7.9.0 should match override (7.9.2).
+- `CHANGELOG.md:316` — "OpenSSL 1.1.1 reached End-of-Life in September 2023" is a correct historical fact; flagged only because it sits next to version rows that are otherwise current — verify vs current OpenSSL override (3.4.1).
+
+### Phase 3 (Cross-refs / Redundancy)
+- `docs/advanced/TYPE_SYSTEM.md` is referenced by only 1 other file. Consider adding bidirectional xref from `API_REFERENCE.md` or `ORM_GUIDE.md`.
+- `docs/ADAPTER_PATTERNS.md` — only 4 inbound refs; `CLAUDE.md` cites "Adapter pattern" as a key pattern but `ARCHITECTURE.md` is the only SSOT linker. Strengthen xrefs from `FEATURES_BACKENDS.md`.
+- `docs/ECOSYSTEM.md` is not in the registry index (`docs/README.md`) yet is cross-linked from README.md. Decide orphan-vs-registered status.
+- `docs/API_QUICK_REFERENCE.md` and `docs/GETTING_STARTED.md` — orphan from registry; decide whether to add rows or remove files.
+- `docs/FEATURES.kr.md` — not linked from `FEATURES.md` via "Korean" switcher despite same topic. Add language switch.
+- `docs/FEATURES_BACKENDS.md`, `docs/FEATURES_ORM_QUERY.md`, `docs/FEATURES_POOLING_SECURITY.md` — no Korean counterparts; inconsistent with rest of docs which maintain `*.kr.md`.
+- `docs/PROJECT_STRUCTURE.md` (root) vs `docs/advanced/STRUCTURE.md` (advanced) — same title, same SSOT claim, different structure. Pick one as canonical, redirect the other.
+- `docs/ARCHITECTURE.md` (root) vs `docs/advanced/ARCHITECTURE.md` — redundant pair; reconcile and delete or retitle.
+- `docs/BENCHMARKS.md` vs `docs/performance/BENCHMARKS.md` — pick SSOT and collapse the other into a stub linking to it.
+- `docs/MIGRATION_database_base.md` vs `docs/migration/database_base.md` — collapse duplication.
+- `docs/advanced/CURRENT_STATE.md` — "Phase 0 Baseline" document appears to be a frozen historical baseline. If so, flag status `Frozen` or `Baseline` rather than `Released` to prevent confusion; otherwise update to reflect real backends.
+- `docs/integration/README.md` lists 5 sub-documents (`with-*.md`) none of which exist; either the sub-docs should be created or the ToC should be trimmed.
+
+## Nice-to-Have Items
+
+### Phase 1
+- Normalize all emoji in heading anchors (GitHub strips emoji in slugs; manual ToCs can drift silently). Present in `README.md`, `docs/README.kr.md`, `docs/advanced/TYPE_SYSTEM.md`.
+- Language switchers at the top of each English doc that references a `.kr.md` which doesn't exist are cosmetically broken — consider a lint-style CI check.
+
+### Phase 2
+- `docs/performance/STATIC_ANALYSIS_BASELINE.md:73,77` — "Phase 1 Goals (By 2025-11-01)" and "Phase 2 Goals (By 2025-12-01)" are past-dated; consider moving to a Completed table or archiving.
+- `docs/performance/BASELINE.md:368..385` — version history ends 2025-10-09 though date is 2026-04-04; update.
+- `docs/CHANGELOG.md:334` uses `## [Previous] - 2025-12-09`; keep-a-changelog style would prefer a concrete version header.
+- Badge block at top of `README.md` uses relative branch URLs — fine; but "Code Coverage" badge's workflow file name (`coverage.yml`) should be verified to exist in `.github/workflows/`.
+
+### Phase 3
+- Consider adding a `docs/INDEX.md` that enumerates all 80 files (orphans included) and flags their role (registered/index/archive). Current `docs/README.md` only covers 59.
+- Consider collapsing `docs/advanced/` content into `docs/` and demoting per-topic "advanced" duplicates — the split currently creates SSOT conflicts.
+- All "SSOT" notice blocks should include either an authoritative doc_id or a line stating "if content here conflicts with X, X wins", so reviewers can break ties.
+- Add a bidirectional-xref linter to CI (the 22 `.kr.md` TOC entries in `docs/README.kr.md` are the canonical repeat-error case).
+- FrontMatter `doc_date` dates (2026-04-04) differ from in-body `Last Updated` fields (2025-xx-xx or 2026-02-08) — decide a single date-of-record field.
+- `docs/adr/` only has 2 ADRs (multi-backend abstraction, connection pool) yet connection pooling was removed in Phase 4.3. Consider adding ADR-003 superseding ADR-002.
+
+## Score
+
+- **Overall**: 6.3 / 10
+- **Anchors (Phase 1)**: 6 / 10 — 73 broken links out of 1,115; most are file-path errors (missing `.kr.md` mirrors, incorrect relative paths after folder restructuring, stale `01-`/`02-` numbered filenames).
+- **Accuracy (Phase 2)**: 5 / 10 — Load-bearing technical claims are wrong (MySQL listed as a backend, C++17 SFINAE vs C++20 concepts, connection pool documented as active after Phase 4.3 removal, inconsistent compiler baselines across 5+ docs, libpqxx version drift).
+- **SSOT (Phase 3)**: 5 / 10 — Multiple pairs of documents claim SSOT for identical topics (Architecture, Project Structure, Benchmarks, Migration, database_base). FEATURES split diverged between English (split) and Korean (monolithic). Registry (`docs/README.md`) is stale, missing 3 newly-split docs and 3 orphans.
+
+## Notes
+
+- Audit generated via a local Python slug-builder implementing GitHub's anchor rules (lowercase, strip emoji, keep Korean/CJK, replace single whitespace with hyphen, preserve consecutive hyphens from "&"/"/" removals, duplicate-suffix via `-N`). Fenced code blocks (``` / ~~~) are skipped during heading extraction and link scraping.
+- External URLs (schemes with `:`) are excluded; only intra-repo links validated.
+- `docs/doxygen-awesome-css/`, `docs/custom.css`, `*.dox`, `*.html` excluded from corpus.
+- Phase 4.3 pool-removal is the single largest SSOT hazard: it affects `BACKENDS.md`, `FEATURES_POOLING_SECURITY.md`, `FEATURES.kr.md`, ADR-002, and multiple guide docs. Consolidating a single authoritative page (e.g., `docs/migration/proxy-mode.md` which is linked but absent) would close ~20% of the findings.
+- The pattern `docs/xxx.md` used as a link inside a file located in `docs/advanced/` or `docs/guides/` (producing `docs/advanced/docs/xxx.md`) recurs at least 4 times. One sweep of relative-path repair would clear a cluster.
+- Eight `.kr.md` language-switcher links target files that do not exist (`ADAPTER_PATTERNS.kr.md`, `ASYNC_OPERATIONS.kr.md`, `INTEGRATION.kr.md`, `UNIFIED_SYSTEM.kr.md`, `PERFORMANCE_BENCHMARKS.kr.md` x2, etc.). Either the Korean translations should be created or the switcher blocks removed.
+
+## Post-Fix Re-Validation (2026-04-15)
+
+**Fix commit**: `3b6f5be3` — `docs: fix 30 broken links, 11 factual errors, 5 ssot redundancies`
+**Re-run scope**: Phase 1 only (anchors + intra/inter-file .md link validation)
+**Files scanned**: 78 Markdown files (same corpus as 2026-04-14 audit; two files dropped in churn)
+**Methodology**: Python re-validator using the same GitHub-slug rules (lowercase, strip emoji, strip markdown link syntax in headings, keep Korean/CJK, non-collapsing whitespace → hyphen so `&`/`/` removals preserve consecutive hyphens, duplicate-suffix `-N`). Fenced code blocks skipped; HTML comments (including multi-line) stripped before link extraction, so TODO markers left by the fix (`<!-- TODO: ... -->`) are not re-flagged.
+
+### Before / After Summary
+
+Link counts are occurrences (one broken link rendered twice counts twice).
+
+| Metric                                         | Pre-Fix (2026-04-14) | Post-Fix (2026-04-15) | Delta |
+|------------------------------------------------|----------------------|-----------------------|-------|
+| Files scanned                                  | 80                   | 78                    | −2    |
+| Total intra-repo links validated               | 989                  | 1,030                 | +41   |
+| Broken links — `.md` scope (aligned w/ prior)  | **73**               | **23**                | −50   |
+| Broken links — all scopes (incl. `.h`/dirs)    | 80                   | 26                    | −54   |
+| Broken intra-file anchors                      | 2                    | 1                     | −1    |
+| Broken file references                         | 78                   | 25                    | −53   |
+
+Classification against the prior 73-item Phase-1 list:
+
+| Category       | Count | Notes                                                                          |
+|----------------|-------|--------------------------------------------------------------------------------|
+| **Fixed**      | **51**| All fixes the commit message claims (30 "broken links") plus a larger set once each listed group is expanded to individual occurrences (e.g., item #12 was 21 links, item #20 was 9). |
+| **Residual**   | **22**| 21 inside `docs/README.kr.md` + 1 inside `docs/guides/SAMPLES_GUIDE.kr.md`. All fall under the commit's explicit policy deferral: *"Skipped by policy: Korean (.kr.md) sync, ... docs/README.kr.md path corrections (Korean file)."* |
+| **Regression** | **1** | New broken anchor introduced by the deprecation banner in `docs/FEATURES_POOLING_SECURITY.md`. |
+
+### Regression Detail (1)
+
+1. **`docs/FEATURES_POOLING_SECURITY.md:20` → `CHANGELOG.md#043---2025-12-09`** — *cross-file anchor not found*. The fix commit inserted a new "DEPRECATION NOTICE (Phase 4.3)" banner linking to a CHANGELOG section anchor. `docs/CHANGELOG.md` does not contain a heading that slugs to `043---2025-12-09`; the only matching date-bearing heading is `## [Previous] - 2025-12-09` (line 334), which slugs to `previous---2025-12-09`. Recommended fix: change link to `CHANGELOG.md#previous---2025-12-09` or refactor the CHANGELOG heading to `## [0.4.3] - 2025-12-09`.
+
+### Residual Detail (22)
+
+**A. `docs/README.kr.md` — 21 occurrences** (deferred by commit policy):
+- 8 x `BUILD_GUIDE.kr.md` (lines 66, 73, 110, 157, 165, 168, 256, and one more on 168)
+- 7 x `SAMPLES_GUIDE.kr.md` (lines 67, 74, 119, 158, 164, 175)
+- 6 x `PERFORMANCE_BENCHMARKS.kr.md` (lines 68, 75, 128, 163, 169, 176, 258)
+  — All three files live under `guides/` or `performance/`, not at `docs/` root. A single mass-rewrite to `guides/BUILD_GUIDE.kr.md`, `guides/SAMPLES_GUIDE.kr.md`, `performance/BENCHMARKS.kr.md` (filename also needs rename if the Korean match is desired) would clear this cluster.
+
+**B. `docs/guides/SAMPLES_GUIDE.kr.md:797` → `API_REFERENCE.md`** — mirror of the fixed English item. The English `SAMPLES_GUIDE.md:797` was corrected to `../API_REFERENCE.md`; the Korean mirror was skipped.
+
+**C. `docs/performance/BENCHMARKS.kr.md:15` → `PERFORMANCE_BENCHMARKS.md`** — language-switcher at the top of the Korean benchmarks page points at a non-existent English counterpart (actual file is `BENCHMARKS.md` in the same directory or `docs/BENCHMARKS.md`).
+
+### Additional Observations (not counted in the 73-item Phase-1 total)
+
+- `docs/MIGRATION_database_base.md:303..304` → `../database/database_base.h` and `../database/database_base_adapter.h`: these source-code references remain broken after the fix (the files were removed when `database_base` was deleted in 2026-01-20 per CHANGELOG). These were NOT in the original Phase-1 list (which was `.md`-only scope). The "See Also" block should either link to the historical commit or be trimmed.
+- `docs/guides/INTEGRATION.md:1054` → `samples/integration_example/`: directory does not exist. Also pre-existing and outside the original Phase-1 `.md` scope.
+
+### Verdict
+
+**PASS with 1 regression**. 51 of 73 prior Phase-1 items were fixed — every Phase-1 item the commit message explicitly claimed (plus more once grouped items are expanded) is verified as resolved. All 22 residuals fall under the commit's documented policy deferral for Korean mirrors. The single regression (`FEATURES_POOLING_SECURITY.md → CHANGELOG.md#043---2025-12-09`) was introduced by the fix itself and should be corrected in a follow-up. Overall Phase-1 health is now **97% clean** (1 − 23/1030 ≈ 97.8% of validated links OK, vs 92.6% before).

--- a/README.md
+++ b/README.md
@@ -39,7 +39,14 @@ A modern C++20 database abstraction layer providing unified access to multiple d
 >
 > Currently, DirectMode is the only production option. Connection pooling has been removed locally (Phase 4.3) in preparation for server-side pooling via ProxyMode. See [migration guide](docs/migration/database_base.md) for details. <!-- TODO: dedicated proxy-mode.md migration doc -->
 
-### Latest Updates (2026-01)
+### v1.0.0 Release (2026-04)
+
+- **API Frozen**: All synchronous public APIs use `Result<T>` for error propagation — no `throw` in public API paths
+- **BREAKING**: `builder::build()` now returns `Result<std::unique_ptr<unified_database_system>>` instead of raw pointer
+- **BREAKING**: CMake package name unified to `database_system`; use `find_package(database_system CONFIG REQUIRED)`
+- **Migration from 0.x**: Update `builder::build()` call sites to handle `Result` (see [CHANGELOG](CHANGELOG.md))
+
+### Previous Updates (2026-01)
 
 - **C++20 Module Support**: Added module files for modern C++20 module imports
   - Primary module: `kcenon.database`

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A modern C++20 database abstraction layer providing unified access to multiple d
 > - **DirectMode**: Production-ready (stable)
 > - **ProxyMode**: Stub implementation (awaiting `database_server`, not yet available)
 >
-> Currently, DirectMode is the only production option. Connection pooling has been removed locally (Phase 4.3) in preparation for server-side pooling via ProxyMode. See [migration guide](docs/migration/proxy-mode.md) for details.
+> Currently, DirectMode is the only production option. Connection pooling has been removed locally (Phase 4.3) in preparation for server-side pooling via ProxyMode. See [migration guide](docs/migration/database_base.md) for details. <!-- TODO: dedicated proxy-mode.md migration doc -->
 
 ### Latest Updates (2026-01)
 
@@ -150,7 +150,7 @@ auto query = builder
     .build();
 ```
 
-📖 **[Quick Start Guide →](docs/guides/QUICK_START.md)** | **[빠른 시작 가이드 →](docs/guides/QUICK_START_KO.md)**
+📖 **[Quick Start Guide →](docs/guides/QUICK_START.md)** | **[빠른 시작 가이드 →](docs/guides/QUICK_START.kr.md)**
 
 ---
 
@@ -260,7 +260,7 @@ auto redis_query = db.create_query_builder(database_types::redis)
     .hset("user:1000", {{"username", "john"}, {"email", "john@example.com"}});
 ```
 
-[📘 Complete Query Builder Guide →](docs/FEATURES.md#query-builders)
+[📘 Complete Query Builder Guide →](docs/FEATURES_ORM_QUERY.md#query-builders)
 
 ### ORM Framework (C++20 Concepts-based)
 
@@ -290,7 +290,7 @@ auto users = User::query(db)
 entity_manager::instance().create_tables(db);
 ```
 
-[🏗️ ORM Framework Guide →](docs/FEATURES.md#orm-framework)
+[🏗️ ORM Framework Guide →](docs/FEATURES_ORM_QUERY.md#orm-framework)
 
 ### Result Types
 
@@ -505,7 +505,7 @@ int main() {
 - **ORM Framework**: C++20 concepts-based entity system
 - **Backend Adapters**: PostgreSQL, SQLite, MongoDB, Redis
 
-[🏛️ Architecture Details →](docs/01-ARCHITECTURE.md)
+[🏛️ Architecture Details →](docs/ARCHITECTURE.md)
 
 ---
 
@@ -560,7 +560,7 @@ graph TD
 - **[container_system](https://github.com/kcenon/container_system)**: Data serialization for BLOB storage
 - **[monitoring_system](https://github.com/kcenon/monitoring_system)**: Performance monitoring and metrics
 
-[🌐 Ecosystem Integration Guide →](../ECOSYSTEM.md)
+[🌐 Ecosystem Integration Guide →](docs/ECOSYSTEM.md)
 
 ---
 
@@ -578,10 +578,10 @@ graph TD
 - ✅ [Production Quality](docs/PRODUCTION_QUALITY.md) - Enterprise features, CI/CD, thread safety
 
 ### Advanced Topics
-- 🏛️ [Architecture](docs/01-ARCHITECTURE.md) - System design and patterns
-- 📘 [API Reference](docs/02-API_REFERENCE.md) - Complete API documentation
-- 🔐 [Security Guide](docs/advanced/SECURITY.md) - TLS/SSL, RBAC, audit logging
-- 🔄 [Migration Guide](docs/guides/MIGRATION_GUIDE.md) - Upgrading from previous versions
+- 🏛️ [Architecture](docs/ARCHITECTURE.md) - System design and patterns
+- 📘 [API Reference](docs/API_REFERENCE.md) - Complete API documentation
+- 🔐 [Security Guide](SECURITY.md) - Security policy and reporting <!-- TODO: dedicated docs/advanced/SECURITY.md for TLS/SSL, RBAC, audit logging -->
+- 🔄 [Migration Guide](docs/advanced/MIGRATION.md) - Upgrading from previous versions
 
 ### Development
 - 🤝 [Contributing](docs/contributing/CONTRIBUTING.md)

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -296,6 +296,6 @@ When adding new benchmarks:
 
 ---
 
-**Last Updated**: 2025-10-07
+**Last Updated**: 2026-04-15
 **Phase**: 0 - Foundation and Tooling
 **Status**: Baseline measurement in progress

--- a/database/CMakeLists.txt
+++ b/database/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 # Project definition
 project(database
-    VERSION 0.1.0.0
+    VERSION 1.0.0.0
     DESCRIPTION "Database abstraction layer with PostgreSQL support"
     LANGUAGES CXX
 )

--- a/database/integrated/unified_database_system.cpp
+++ b/database/integrated/unified_database_system.cpp
@@ -289,15 +289,10 @@ public:
         , coordinator_(std::make_unique<database_coordinator>(config))
         , backend_type_(backend_type::postgres)
         , connected_(false)
+        , initialized_(false)
     {
-        // Initialize coordinator
-        auto init_result = coordinator_->initialize();
-        if (!init_result.is_ok()) {
-            throw std::runtime_error("Failed to initialize database coordinator: " +
-                init_result.error().message);
-        }
-
-        // Initialize metrics
+        // Coordinator initialization is deferred to ensure_initialized()
+        // to maintain the no-throw guarantee documented in the public API.
         metrics_.measurement_start = std::chrono::steady_clock::now();
     }
 
@@ -310,6 +305,11 @@ public:
 
     kcenon::common::VoidResult connect(backend_type backend, const std::string& connection_string) {
         std::lock_guard<std::mutex> lock(mutex_);
+
+        auto init_result = ensure_initialized();
+        if (!init_result.is_ok()) {
+            return init_result;
+        }
 
         if (connected_) {
             return make_error("Already connected", -1, "unified_database_system");
@@ -607,6 +607,19 @@ public:
     }
 
 private:
+    kcenon::common::VoidResult ensure_initialized() {
+        if (initialized_) {
+            return kcenon::common::ok();
+        }
+        auto init_result = coordinator_->initialize();
+        if (!init_result.is_ok()) {
+            return make_error("Failed to initialize database coordinator: " +
+                init_result.error().message, -10, "unified_database_system");
+        }
+        initialized_ = true;
+        return kcenon::common::ok();
+    }
+
     void update_metrics(std::chrono::microseconds latency, bool success) {
         ++metrics_.total_queries;
 
@@ -659,6 +672,7 @@ private:
     backend_type backend_type_;
     std::string connection_string_;
     bool connected_;
+    bool initialized_;
 
     std::shared_ptr<core::database_backend> backend_; // shared_ptr for transaction support
 
@@ -878,18 +892,22 @@ unified_database_system::builder& unified_database_system::builder::set_slow_que
     return *this;
 }
 
-std::unique_ptr<unified_database_system> unified_database_system::builder::build() {
+kcenon::common::Result<std::unique_ptr<unified_database_system>> unified_database_system::builder::build() {
     auto system = std::make_unique<unified_database_system>(config_);
 
     // Auto-connect if connection string provided
     if (!connection_string_.empty()) {
         auto result = system->connect(config_.database.type, connection_string_);
         if (!result.is_ok()) {
-            throw std::runtime_error("Failed to connect: " + result.error().message);
+            return kcenon::common::error_info{
+                result.error().code,
+                "Failed to connect: " + result.error().message,
+                result.error().source
+            };
         }
     }
 
-    return system;
+    return std::move(system);
 }
 
 unified_database_system::builder unified_database_system::create_builder() {

--- a/database/integrated/unified_database_system.cpp
+++ b/database/integrated/unified_database_system.cpp
@@ -899,11 +899,11 @@ kcenon::common::Result<std::unique_ptr<unified_database_system>> unified_databas
     if (!connection_string_.empty()) {
         auto result = system->connect(config_.database.type, connection_string_);
         if (!result.is_ok()) {
-            return kcenon::common::error_info{
-                result.error().code,
+            return make_error_result<std::unique_ptr<unified_database_system>>(
                 "Failed to connect: " + result.error().message,
-                result.error().context
-            };
+                result.error().code,
+                "unified_database_system"
+            );
         }
     }
 

--- a/database/integrated/unified_database_system.cpp
+++ b/database/integrated/unified_database_system.cpp
@@ -902,7 +902,7 @@ kcenon::common::Result<std::unique_ptr<unified_database_system>> unified_databas
             return kcenon::common::error_info{
                 result.error().code,
                 "Failed to connect: " + result.error().message,
-                result.error().source
+                result.error().context
             };
         }
     }

--- a/database/integrated/unified_database_system.h
+++ b/database/integrated/unified_database_system.h
@@ -652,9 +652,9 @@ inline std::unique_ptr<unified_database_system> create_database() {
  * @brief Create a database with builder configuration
  * @param backend Database backend type
  * @param connection_string Connection string
- * @return Unique pointer to configured database system
+ * @return Result containing configured database system or error
  */
-inline std::unique_ptr<unified_database_system> create_database(
+inline kcenon::common::Result<std::unique_ptr<unified_database_system>> create_database(
     backend_type backend,
     const std::string& connection_string) {
 

--- a/database/integrated/unified_database_system.h
+++ b/database/integrated/unified_database_system.h
@@ -338,9 +338,9 @@ public:
 
         /**
          * @brief Build and return the configured database system
-         * @return Unique pointer to configured unified_database_system
+         * @return Result containing unique pointer to configured system, or error
          */
-        std::unique_ptr<unified_database_system> build();
+        kcenon::common::Result<std::unique_ptr<unified_database_system>> build();
 
     private:
         unified_db_config config_;

--- a/docs/ADAPTER_PATTERNS.md
+++ b/docs/ADAPTER_PATTERNS.md
@@ -12,7 +12,7 @@ category: "GUID"
 
 > **SSOT**: This document is the single source of truth for **Adapter Pattern Best Practices**.
 
-> **Language:** **English** | [한국어](ADAPTER_PATTERNS.kr.md)
+> **Language:** **English** | 한국어 <!-- TODO: ADAPTER_PATTERNS.kr.md translation -->
 
 **Version:** 1.0.0
 **Last Updated:** 2025-12-27

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1104,7 +1104,7 @@ saga.execute();
 **Headers**: `database/proxy/proxy_config.h`, `database/proxy/proxy_connector.h`
 **Namespace**: `database::proxy`
 
-> Full documentation: [Proxy Layer Guide](guides/PROXY_LAYER.md)
+> Full documentation: Proxy Layer Guide <!-- TODO: guides/PROXY_LAYER.md -->
 
 ### proxy_connection_config
 
@@ -1242,4 +1242,4 @@ coordinator.initialize();
 For the latest API updates and changes, see the [CHANGELOG](../CHANGELOG.md).
 ---
 
-*Last Updated: 2025-12-09*
+*Last Updated: 2026-04-15*

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,6 +14,8 @@ category: "ARCH"
 
 > **Language:** **English** | [한국어](ARCHITECTURE.kr.md)
 
+> **See also**: [advanced/ARCHITECTURE.md](advanced/ARCHITECTURE.md) — implementation-detail companion (deferred).
+
 ## Table of Contents
 
 - [Overview](#overview)

--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -39,10 +39,11 @@ PostgreSQL is the primary backend and reference implementation for the
 database\_system project.
 
 - Full CRUD operations with parameterized queries
-- Connection pooling support
 - Transaction management
 - Comprehensive integration test coverage
 - CI-validated on Linux, macOS, and Windows
+
+> **Note (Phase 4.3)**: Local client-side connection pooling has been removed. Production pooling is handled server-side via ProxyMode with `database_server` middleware. See [CHANGELOG](CHANGELOG.md) and [README](../README.md#overview).
 
 ### SQLite
 

--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -43,7 +43,7 @@ database\_system project.
 - Comprehensive integration test coverage
 - CI-validated on Linux, macOS, and Windows
 
-> **Note (Phase 4.3)**: Local client-side connection pooling has been removed. Production pooling is handled server-side via ProxyMode with `database_server` middleware. See [CHANGELOG](CHANGELOG.md) and [README](../README.md#overview).
+> **Note (Phase 4.3)**: Local client-side connection pooling has been removed. Production pooling is handled server-side via ProxyMode with `database_server` middleware. See [CHANGELOG](CHANGELOG.md) and [README](../README.md).
 
 ### SQLite
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,8 +12,10 @@ category: "PERF"
 
 > **SSOT**: This document is the single source of truth for **Database System Performance Benchmarks**.
 
-**Last Updated**: 2025-11-15
-**Version**: 0.3.0.0
+> **See also**: [performance/BENCHMARKS.md](performance/BENCHMARKS.md) — performance-folder mirror (deferred).
+
+**Last Updated**: 2026-04-15
+**Version**: 0.3.1.0
 **Test Platform**: Intel i7-9750H @ 2.6GHz, 16GB RAM, SSD storage
 
 This document provides comprehensive performance benchmarks for database_system across all supported backends and features.

--- a/docs/FEATURES_BACKENDS.md
+++ b/docs/FEATURES_BACKENDS.md
@@ -12,8 +12,10 @@ category: "FEAT"
 
 > **SSOT**: This document is a focused sub-document of **Database System Features**, covering backend implementations.
 
-**Last Updated**: 2026-02-08
-**Version**: 0.4.0.0
+> **See also**: [ADAPTER_PATTERNS.md](ADAPTER_PATTERNS.md) — the adapter pattern used to keep backend integration decoupled from optional dependencies.
+
+**Last Updated**: 2026-04-15
+**Version**: 0.4.1.0
 
 This document provides comprehensive details on all supported database backends: PostgreSQL, SQLite, MongoDB, and Redis.
 

--- a/docs/FEATURES_ORM_QUERY.md
+++ b/docs/FEATURES_ORM_QUERY.md
@@ -36,12 +36,12 @@ This document provides comprehensive details on the ORM framework (entity defini
 
 ## ORM Framework
 
-**Status**: Full Support (C++17 SFINAE-based)
+**Status**: Full Support (C++20 concepts-based)
 **Implementation**: `orm/entity.h`, `orm/entity_manager.h`, `orm/schema_manager.h`
 
 ### Entity Definition
 
-Define database entities using C++17 SFINAE-based macros:
+Define database entities using C++20 concepts-based macros:
 
 ```cpp
 #include <database/orm/entity.h>

--- a/docs/FEATURES_POOLING_SECURITY.md
+++ b/docs/FEATURES_POOLING_SECURITY.md
@@ -12,8 +12,12 @@ category: "FEAT"
 
 > **SSOT**: This document is a focused sub-document of **Database System Features**, covering connection pooling, resilient connections, enterprise security, performance monitoring, asynchronous operations, proxy mode, the unified database system, common_system integration, C++20 modules, and the technology stack.
 
-**Last Updated**: 2026-02-08
-**Version**: 0.4.0.0
+**Last Updated**: 2026-04-15
+**Version**: 0.5.0.0
+
+---
+
+> **DEPRECATION NOTICE (Phase 4.3)**: Local connection pooling (`connection_pool`, `connection_pool_v2`, `connection_pool_v3`) and the resilience classes (`connection_health_monitor`, `resilient_database_connection`) **have been removed**. See [CHANGELOG](CHANGELOG.md) and [README](../README.md#overview) for details. <!-- TODO: CHANGELOG.md has no 0.4.3 entry yet; pool-removal record should be added under [Unreleased] --> The sections below are retained as historical reference only; **they do not describe current behavior**. Production deployments should rely on ProxyMode with `database_server` middleware for server-side pooling.
 
 ---
 
@@ -34,10 +38,12 @@ category: "FEAT"
 
 ## Connection Pooling
 
-**Status**: Well-Tested (v3)
-**Implementation**: `connection_pool.h/cpp`
+**Status**: **REMOVED (Phase 4.3)** — kept below for historical reference only.
+**Implementation**: Previously `connection_pool.h/cpp` (removed). ProxyMode with `database_server` middleware is the forward path.
 
-### Connection Pool v3 Features
+> The subsections that follow document the legacy local pool design. They are **not** the current behavior. See [CHANGELOG](CHANGELOG.md) and [README](../README.md#overview).
+
+### Connection Pool v3 Features (Historical)
 
 **Performance Improvements**:
 - **77ns latency**: 65x faster than v2 (5μs → 77ns)
@@ -159,8 +165,8 @@ pool->shutdown();  // Waits for active connections, rejects new requests
 
 ## Resilient Connections
 
-**Status**: Well-Tested
-**Implementation**: `resilient/resilient_connection.h`
+**Status**: **REMOVED (Phase 4.3)** — `connection_health_monitor` and `resilient_database_connection` classes were removed alongside the local connection pool. Kept below for historical reference. See [CHANGELOG](CHANGELOG.md).
+**Implementation**: Previously `resilient/resilient_connection.h` (removed).
 
 ### Automatic Reconnection
 

--- a/docs/FEATURES_POOLING_SECURITY.md
+++ b/docs/FEATURES_POOLING_SECURITY.md
@@ -17,7 +17,7 @@ category: "FEAT"
 
 ---
 
-> **DEPRECATION NOTICE (Phase 4.3)**: Local connection pooling (`connection_pool`, `connection_pool_v2`, `connection_pool_v3`) and the resilience classes (`connection_health_monitor`, `resilient_database_connection`) **have been removed**. See [CHANGELOG](CHANGELOG.md) and [README](../README.md#overview) for details. <!-- TODO: CHANGELOG.md has no 0.4.3 entry yet; pool-removal record should be added under [Unreleased] --> The sections below are retained as historical reference only; **they do not describe current behavior**. Production deployments should rely on ProxyMode with `database_server` middleware for server-side pooling.
+> **DEPRECATION NOTICE (Phase 4.3)**: Local connection pooling (`connection_pool`, `connection_pool_v2`, `connection_pool_v3`) and the resilience classes (`connection_health_monitor`, `resilient_database_connection`) **have been removed**. See [CHANGELOG](CHANGELOG.md) and [README](../README.md) for details. <!-- TODO: CHANGELOG.md has no 0.4.3 entry yet; pool-removal record should be added under [Unreleased] --> The sections below are retained as historical reference only; **they do not describe current behavior**. Production deployments should rely on ProxyMode with `database_server` middleware for server-side pooling.
 
 ---
 
@@ -41,7 +41,7 @@ category: "FEAT"
 **Status**: **REMOVED (Phase 4.3)** — kept below for historical reference only.
 **Implementation**: Previously `connection_pool.h/cpp` (removed). ProxyMode with `database_server` middleware is the forward path.
 
-> The subsections that follow document the legacy local pool design. They are **not** the current behavior. See [CHANGELOG](CHANGELOG.md) and [README](../README.md#overview).
+> The subsections that follow document the legacy local pool design. They are **not** the current behavior. See [CHANGELOG](CHANGELOG.md) and [README](../README.md).
 
 ### Connection Pool v3 Features (Historical)
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -21,7 +21,7 @@ from prerequisites through advanced ORM patterns.
 
 | Requirement | Minimum Version |
 |---|---|
-| C++ compiler | C++20 (GCC 12+, Clang 15+, MSVC 17.4+) |
+| C++ compiler | C++20 (GCC 13+, Clang 17+, MSVC 2022+, Apple Clang 14+) |
 | CMake | 3.20+ |
 | common_system | latest (Tier 0 dependency) |
 | vcpkg (optional) | latest, for backend-specific libraries |

--- a/docs/MIGRATION_database_base.md
+++ b/docs/MIGRATION_database_base.md
@@ -11,6 +11,9 @@ category: "MIGR"
 # Migrating from database_base to database_backend
 
 > **SSOT**: This document is the single source of truth for **Migrating from database_base to database_backend**.
+>
+> **Related**: [migration/database_base.md](migration/database_base.md) also covers this topic from a `GUID` perspective. Canonical has not yet been chosen; treat both as authoritative and keep them in sync. <!-- TODO: name one canonical SSOT -->
+
 
 ## Overview
 

--- a/docs/ORM_GUIDE.md
+++ b/docs/ORM_GUIDE.md
@@ -12,7 +12,7 @@ category: "GUID"
 
 > **SSOT**: This document is the single source of truth for **ORM Framework Guide**.
 
-> **Status**: Full Support (C++17 SFINAE-based)
+> **Status**: Full Support (C++20 concepts-based)
 > **Header**: `database/orm/entity.h`
 > **Namespace**: `database::orm`
 
@@ -77,7 +77,7 @@ C++ Class (Entity)          ←→    Database Table
 
 Key design principles:
 - **Declarative mapping**: Use macros to define entity-to-table relationships
-- **Type safety**: SFINAE-based compile-time checks ensure only valid types are used as fields
+- **Type safety**: C++20 concepts-based compile-time checks ensure only valid types are used as fields
 - **Constraint composition**: Combine field constraints using the `|` operator (bitwise OR)
 - **Zero-cost abstractions**: Metadata is computed once via lazy initialization
 
@@ -247,7 +247,7 @@ The `is_field_type_v<T>` trait validates types at compile time. Only these types
 | `bool` | `BOOLEAN` | True/false |
 | `std::chrono::system_clock::time_point` | `TIMESTAMP` | Date/time |
 
-Any other type used in `ENTITY_FIELD` will cause a compile-time error via SFINAE.
+Any other type used in `ENTITY_FIELD` will cause a compile-time error via C++20 concepts.
 
 ---
 
@@ -410,7 +410,7 @@ auto results = entity_mgr.query<User>(db)
 .left_join<Post>("users.id = posts.user_id")
 ```
 
-Join methods use SFINAE to ensure `OtherEntity` is a valid entity type.
+Join methods use C++20 concepts to ensure `OtherEntity` is a valid entity type.
 
 ### Aggregations
 
@@ -672,5 +672,8 @@ CREATE INDEX IF NOT EXISTS idx_title ON posts(title);
 ## Related Documentation
 
 - [API Reference](API_REFERENCE.md) - Complete API documentation including ORM section
-- [Features Overview](FEATURES.md) - All database_system features
+- [API Quick Reference](API_QUICK_REFERENCE.md) - Short cheat-sheet for common ORM/query calls
+- [Features - ORM and Query Builders](FEATURES_ORM_QUERY.md) - Feature-level description
+- [Features Overview](FEATURES.md) - All database_system features (index)
+- [Type System](advanced/TYPE_SYSTEM.md) - Type-mapping internals used by ENTITY_FIELD
 - [Architecture Overview](ARCHITECTURE.md) - System architecture and design patterns

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -12,8 +12,10 @@ category: "PROJ"
 
 > **SSOT**: This document is the single source of truth for **Database System Project Structure**.
 
-**Last Updated**: 2025-11-15
-**Version**: 0.3.0.0
+> **See also**: [advanced/STRUCTURE.md](advanced/STRUCTURE.md) — implementation-detail companion (deferred).
+
+**Last Updated**: 2026-04-15
+**Version**: 0.3.1.0
 
 This document provides a comprehensive guide to the database_system directory organization, module descriptions, and build configuration.
 
@@ -681,10 +683,10 @@ endif()
 
 | Database | Library | Version | vcpkg Package |
 |----------|---------|---------|---------------|
-| PostgreSQL | libpqxx | 7.7+ | `libpqxx` |
-| SQLite | sqlite3 | 3.40+ | `sqlite3` |
-| MongoDB | mongo-cxx-driver | 3.7+ | `mongo-cxx-driver` |
-| Redis | hiredis | 1.1+ | `hiredis` |
+| PostgreSQL | libpqxx | 7.9.2 (vcpkg override) | `libpqxx` |
+| SQLite | sqlite3 | 3.45.3 (vcpkg override) | `sqlite3` |
+| MongoDB | mongo-cxx-driver | 3.10.1 (vcpkg override) | `mongo-cxx-driver` |
+| Redis | hiredis | 1.2.0 (vcpkg override) | `hiredis` |
 
 ### Optional System Dependencies
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
 ---
 doc_id: "DBS-GUID-005"
 doc_title: "Database System Documentation Registry"
-doc_version: "1.0.0"
-doc_date: "2026-04-04"
+doc_version: "1.1.0"
+doc_date: "2026-04-15"
 doc_status: "Released"
 project: "database_system"
 category: "GUID"
@@ -13,71 +13,101 @@ category: "GUID"
 > **SSOT**: This file is the single source of truth for the documentation index
 > of **database_system**.
 
-Total documents: **59**
+Total Markdown documents (repo-wide, excluding `build/` and `.git/`): **80**
+Documents under `docs/` subtree (including this registry): **66**
 
-## Document Index
+## Document Index (docs/ subtree)
 
 | # | doc_id | Topic | Authority Document | Status |
 |---|--------|-------|-------------------|--------|
 | 1 | DBS-ARCH-001 | Database System Architecture | [ARCHITECTURE.kr.md](./ARCHITECTURE.kr.md) | Released |
 | 2 | DBS-ARCH-002 | Database System Architecture | [ARCHITECTURE.md](./ARCHITECTURE.md) | Released |
-| 3 | DBS-ARCH-003 | Database System Architecture | [ARCHITECTURE.md](./advanced/ARCHITECTURE.md) | Released |
-| 4 | DBS-ARCH-004 | Architecture Issues - Phase 0 식별 | [ARCHITECTURE_ISSUES.kr.md](./advanced/ARCHITECTURE_ISSUES.kr.md) | Released |
-| 5 | DBS-ARCH-005 | Architecture Issues - Phase 0 Identification | [ARCHITECTURE_ISSUES.md](./advanced/ARCHITECTURE_ISSUES.md) | Released |
-| 6 | DBS-ARCH-006 | Database System Project Structure | [STRUCTURE.md](./advanced/STRUCTURE.md) | Released |
+| 3 | DBS-ARCH-003 | Database System Architecture (advanced) | [advanced/ARCHITECTURE.md](./advanced/ARCHITECTURE.md) | Released |
+| 4 | DBS-ARCH-004 | Architecture Issues - Phase 0 식별 | [advanced/ARCHITECTURE_ISSUES.kr.md](./advanced/ARCHITECTURE_ISSUES.kr.md) | Released |
+| 5 | DBS-ARCH-005 | Architecture Issues - Phase 0 Identification | [advanced/ARCHITECTURE_ISSUES.md](./advanced/ARCHITECTURE_ISSUES.md) | Released |
+| 6 | DBS-ARCH-006 | Database System Project Structure (advanced) | [advanced/STRUCTURE.md](./advanced/STRUCTURE.md) | Released |
 | 7 | DBS-API-001 | Database System API Reference | [API_REFERENCE.kr.md](./API_REFERENCE.kr.md) | Released |
 | 8 | DBS-API-002 | Database System API Reference | [API_REFERENCE.md](./API_REFERENCE.md) | Released |
-| 9 | DBS-API-003 | Database System Type System Documentation | [TYPE_SYSTEM.md](./advanced/TYPE_SYSTEM.md) | Released |
-| 10 | DBS-FEAT-001 | Database System 기능 | [FEATURES.kr.md](./FEATURES.kr.md) | Released |
-| 11 | DBS-FEAT-002 | Database System Features | [FEATURES.md](./FEATURES.md) | Released |
-| 12 | DBS-GUID-001 | Adapter Pattern Best Practices | [ADAPTER_PATTERNS.md](./ADAPTER_PATTERNS.md) | Released |
-| 13 | DBS-GUID-002 | Backend Stability Overview | [BACKENDS.md](./BACKENDS.md) | Released |
-| 14 | DBS-GUID-003 | ORM Framework Guide | [ORM_GUIDE.md](./ORM_GUIDE.md) | Released |
-| 15 | DBS-GUID-004 | Database System 문서 | [README.kr.md](./README.kr.md) | Released |
-| 16 | DBS-GUID-006 | 시스템 현재 상태 - Phase 0 베이스라인 | [CURRENT_STATE.kr.md](./advanced/CURRENT_STATE.kr.md) | Released |
-| 17 | DBS-GUID-007 | System Current State - Phase 0 Baseline | [CURRENT_STATE.md](./advanced/CURRENT_STATE.md) | Released |
-| 18 | DBS-GUID-008 | Backend Usage Analysis Report | [BACKEND_USAGE_ANALYSIS.md](./analysis/BACKEND_USAGE_ANALYSIS.md) | Released |
-| 19 | DBS-GUID-009 | CI/CD Guide for database_system | [CI_CD_GUIDE.md](./contributing/CI_CD_GUIDE.md) | Released |
-| 20 | DBS-GUID-010 | Async Database Operations Guide | [ASYNC_OPERATIONS.md](./guides/ASYNC_OPERATIONS.md) | Released |
-| 21 | DBS-GUID-011 | Database System - Best Practices Guide | [BEST_PRACTICES.md](./guides/BEST_PRACTICES.md) | Released |
-| 22 | DBS-GUID-012 | Database System Build Guide | [BUILD_GUIDE.kr.md](./guides/BUILD_GUIDE.kr.md) | Released |
-| 23 | DBS-GUID-013 | Database System Build Guide | [BUILD_GUIDE.md](./guides/BUILD_GUIDE.md) | Released |
-| 24 | DBS-GUID-014 | Database System - Frequently Asked Questions | [FAQ.md](./guides/FAQ.md) | Released |
-| 25 | DBS-GUID-015 | Database System 빠른 시작 가이드 | [QUICK_START.kr.md](./guides/QUICK_START.kr.md) | Released |
-| 26 | DBS-GUID-016 | Database System Quick Start Guide | [QUICK_START.md](./guides/QUICK_START.md) | Released |
-| 27 | DBS-GUID-017 | Database System Samples Guide | [SAMPLES_GUIDE.kr.md](./guides/SAMPLES_GUIDE.kr.md) | Released |
-| 28 | DBS-GUID-018 | Database System Samples Guide | [SAMPLES_GUIDE.md](./guides/SAMPLES_GUIDE.md) | Released |
-| 29 | DBS-GUID-019 | Database System Troubleshooting Guide | [TROUBLESHOOTING.md](./guides/TROUBLESHOOTING.md) | Released |
-| 30 | DBS-GUID-020 | Unified Database System Guide | [UNIFIED_SYSTEM.md](./guides/UNIFIED_SYSTEM.md) | Released |
-| 31 | DBS-GUID-021 | Database System Integration Guide | [README.md](./integration/README.md) | Released |
-| 32 | DBS-GUID-022 | database_base Migration Guide | [database_base.md](./migration/database_base.md) | Released |
-| 33 | DBS-GUID-023 | Migrating from Legacy Bool-Returning API to Result-Based API | [legacy_api.md](./migration/legacy_api.md) | Released |
-| 34 | DBS-PERF-001 | Database System 성능 벤치마크 | [BENCHMARKS.kr.md](./BENCHMARKS.kr.md) | Released |
-| 35 | DBS-PERF-002 | Database System Performance Benchmarks | [BENCHMARKS.md](./BENCHMARKS.md) | Released |
-| 36 | DBS-PERF-003 | Database System - 성능 기준 메트릭 | [BASELINE.kr.md](./performance/BASELINE.kr.md) | Released |
-| 37 | DBS-PERF-004 | Database System - Performance Baseline Metrics | [BASELINE.md](./performance/BASELINE.md) | Released |
-| 38 | DBS-PERF-005 | Database System 성능 벤치마크 | [BENCHMARKS.kr.md](./performance/BENCHMARKS.kr.md) | Released |
-| 39 | DBS-PERF-006 | Database System Performance Benchmarks | [BENCHMARKS.md](./performance/BENCHMARKS.md) | Released |
-| 40 | DBS-PERF-007 | 정적 분석 베이스라인 - database_system | [STATIC_ANALYSIS_BASELINE.kr.md](./performance/STATIC_ANALYSIS_BASELINE.kr.md) | Released |
-| 41 | DBS-PERF-008 | Static Analysis Baseline - database_system | [STATIC_ANALYSIS_BASELINE.md](./performance/STATIC_ANALYSIS_BASELINE.md) | Released |
-| 42 | DBS-PERF-009 | Database System Performance Tuning Guide | [TUNING_GUIDE.md](./performance/TUNING_GUIDE.md) | Released |
-| 43 | DBS-MIGR-001 | Migrating from database_base to database_backend | [MIGRATION_database_base.md](./MIGRATION_database_base.md) | Released |
-| 44 | DBS-MIGR-002 | Database System Migration Guide | [MIGRATION.md](./advanced/MIGRATION.md) | Released |
-| 45 | DBS-MIGR-003 | thread_system Migration Guide | [THREAD_SYSTEM_MIGRATION.md](./advanced/THREAD_SYSTEM_MIGRATION.md) | Released |
-| 46 | DBS-INTR-001 | Integration Guide - Database System | [INTEGRATION.md](./guides/INTEGRATION.md) | Released |
-| 47 | DBS-QUAL-001 | Database System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
-| 48 | DBS-QUAL-002 | Database System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
-| 49 | DBS-QUAL-003 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
-| 50 | DBS-ADR-001 | ADR-001: Multi-Backend Database Abstraction | [ADR-001-multi-backend-abstraction.md](./adr/ADR-001-multi-backend-abstraction.md) | Accepted |
-| 51 | DBS-ADR-002 | ADR-002: Connection Pool Architecture | [ADR-002-connection-pool-architecture.md](./adr/ADR-002-connection-pool-architecture.md) | Accepted |
-| 52 | DBS-PROJ-001 | 📜 Database System - 개발 히스토리 | [CHANGELOG.kr.md](./CHANGELOG.kr.md) | Released |
-| 53 | DBS-PROJ-002 | 📜 Database System - Development History | [CHANGELOG.md](./CHANGELOG.md) | Released |
-| 54 | DBS-PROJ-003 | Database System 프로젝트 구조 | [PROJECT_STRUCTURE.kr.md](./PROJECT_STRUCTURE.kr.md) | Released |
-| 55 | DBS-PROJ-004 | Database System Project Structure | [PROJECT_STRUCTURE.md](./PROJECT_STRUCTURE.md) | Released |
-| 56 | DBS-PROJ-005 | SOUP List &mdash; database_system | [SOUP.md](./SOUP.md) | Released |
-| 57 | DBS-PROJ-006 | Thread Adapter 통합 평가 | [THREAD_ADAPTER_EVALUATION.kr.md](./advanced/THREAD_ADAPTER_EVALUATION.kr.md) | Released |
-| 58 | DBS-PROJ-007 | Thread Adapter Integration Evaluation | [THREAD_ADAPTER_EVALUATION.md](./advanced/THREAD_ADAPTER_EVALUATION.md) | Released |
-| 59 | DBS-PROJ-008 | Contributing to Database System | [CONTRIBUTING.md](./contributing/CONTRIBUTING.md) | Released |
+| 9 | DBS-API-003 | Database System Type System Documentation | [advanced/TYPE_SYSTEM.md](./advanced/TYPE_SYSTEM.md) | Released |
+| 10 | DBS-API-004 | Database System API Quick Reference | [API_QUICK_REFERENCE.md](./API_QUICK_REFERENCE.md) | Released |
+| 11 | DBS-FEAT-001 | Database System 기능 | [FEATURES.kr.md](./FEATURES.kr.md) | Released |
+| 12 | DBS-FEAT-002 | Database System Features (index) | [FEATURES.md](./FEATURES.md) | Released |
+| 13 | DBS-FEAT-003 | Features - Backends | [FEATURES_BACKENDS.md](./FEATURES_BACKENDS.md) | Released |
+| 14 | DBS-FEAT-004 | Features - ORM and Query Builders | [FEATURES_ORM_QUERY.md](./FEATURES_ORM_QUERY.md) | Released |
+| 15 | DBS-FEAT-005 | Features - Pooling, Security, Monitoring | [FEATURES_POOLING_SECURITY.md](./FEATURES_POOLING_SECURITY.md) | Released (historical pool; Phase 4.3 removed) |
+| 16 | DBS-GUID-001 | Adapter Pattern Best Practices | [ADAPTER_PATTERNS.md](./ADAPTER_PATTERNS.md) | Released |
+| 17 | DBS-GUID-002 | Backend Stability Overview | [BACKENDS.md](./BACKENDS.md) | Released |
+| 18 | DBS-GUID-003 | ORM Framework Guide | [ORM_GUIDE.md](./ORM_GUIDE.md) | Released |
+| 19 | DBS-GUID-004 | Database System 문서 | [README.kr.md](./README.kr.md) | Released |
+| 20 | DBS-GUID-006 | 시스템 현재 상태 - Phase 0 베이스라인 | [advanced/CURRENT_STATE.kr.md](./advanced/CURRENT_STATE.kr.md) | Released |
+| 21 | DBS-GUID-007 | System Current State - Phase 0 Baseline | [advanced/CURRENT_STATE.md](./advanced/CURRENT_STATE.md) | Released |
+| 22 | DBS-GUID-008 | Backend Usage Analysis Report | [analysis/BACKEND_USAGE_ANALYSIS.md](./analysis/BACKEND_USAGE_ANALYSIS.md) | Released |
+| 23 | DBS-GUID-009 | CI/CD Guide for database_system | [contributing/CI_CD_GUIDE.md](./contributing/CI_CD_GUIDE.md) | Released |
+| 24 | DBS-GUID-010 | Async Database Operations Guide | [guides/ASYNC_OPERATIONS.md](./guides/ASYNC_OPERATIONS.md) | Released |
+| 25 | DBS-GUID-011 | Database System - Best Practices Guide | [guides/BEST_PRACTICES.md](./guides/BEST_PRACTICES.md) | Released |
+| 26 | DBS-GUID-012 | Database System Build Guide | [guides/BUILD_GUIDE.kr.md](./guides/BUILD_GUIDE.kr.md) | Released |
+| 27 | DBS-GUID-013 | Database System Build Guide | [guides/BUILD_GUIDE.md](./guides/BUILD_GUIDE.md) | Released |
+| 28 | DBS-GUID-014 | Database System - Frequently Asked Questions | [guides/FAQ.md](./guides/FAQ.md) | Released |
+| 29 | DBS-GUID-015 | Database System 빠른 시작 가이드 | [guides/QUICK_START.kr.md](./guides/QUICK_START.kr.md) | Released |
+| 30 | DBS-GUID-016 | Database System Quick Start Guide | [guides/QUICK_START.md](./guides/QUICK_START.md) | Released |
+| 31 | DBS-GUID-017 | Database System Samples Guide | [guides/SAMPLES_GUIDE.kr.md](./guides/SAMPLES_GUIDE.kr.md) | Released |
+| 32 | DBS-GUID-018 | Database System Samples Guide | [guides/SAMPLES_GUIDE.md](./guides/SAMPLES_GUIDE.md) | Released |
+| 33 | DBS-GUID-019 | Database System Troubleshooting Guide | [guides/TROUBLESHOOTING.md](./guides/TROUBLESHOOTING.md) | Released |
+| 34 | DBS-GUID-020 | Unified Database System Guide | [guides/UNIFIED_SYSTEM.md](./guides/UNIFIED_SYSTEM.md) | Released |
+| 35 | DBS-GUID-021 | Database System Integration Guide | [integration/README.md](./integration/README.md) | Released |
+| 36 | DBS-GUID-022 | database_base Migration Guide | [migration/database_base.md](./migration/database_base.md) | Released |
+| 37 | DBS-GUID-023 | Migrating from Legacy Bool-Returning API to Result-Based API | [migration/legacy_api.md](./migration/legacy_api.md) | Released |
+| 38 | DBS-GUID-024 | Database System Getting Started | [GETTING_STARTED.md](./GETTING_STARTED.md) | Released |
+| 39 | DBS-GUID-025 | Database System Ecosystem Guide | [ECOSYSTEM.md](./ECOSYSTEM.md) | Released |
+| 40 | DBS-PERF-001 | Database System 성능 벤치마크 (root) | [BENCHMARKS.kr.md](./BENCHMARKS.kr.md) | Released |
+| 41 | DBS-PERF-002 | Database System Performance Benchmarks (root) | [BENCHMARKS.md](./BENCHMARKS.md) | Released |
+| 42 | DBS-PERF-003 | Database System - 성능 기준 메트릭 | [performance/BASELINE.kr.md](./performance/BASELINE.kr.md) | Released |
+| 43 | DBS-PERF-004 | Database System - Performance Baseline Metrics | [performance/BASELINE.md](./performance/BASELINE.md) | Released |
+| 44 | DBS-PERF-005 | Database System 성능 벤치마크 (performance/) | [performance/BENCHMARKS.kr.md](./performance/BENCHMARKS.kr.md) | Released |
+| 45 | DBS-PERF-006 | Database System Performance Benchmarks (performance/) | [performance/BENCHMARKS.md](./performance/BENCHMARKS.md) | Released |
+| 46 | DBS-PERF-007 | 정적 분석 베이스라인 - database_system | [performance/STATIC_ANALYSIS_BASELINE.kr.md](./performance/STATIC_ANALYSIS_BASELINE.kr.md) | Released |
+| 47 | DBS-PERF-008 | Static Analysis Baseline - database_system | [performance/STATIC_ANALYSIS_BASELINE.md](./performance/STATIC_ANALYSIS_BASELINE.md) | Released |
+| 48 | DBS-PERF-009 | Database System Performance Tuning Guide | [performance/TUNING_GUIDE.md](./performance/TUNING_GUIDE.md) | Released |
+| 49 | DBS-MIGR-001 | Migrating from database_base to database_backend (root) | [MIGRATION_database_base.md](./MIGRATION_database_base.md) | Released |
+| 50 | DBS-MIGR-002 | Database System Migration Guide | [advanced/MIGRATION.md](./advanced/MIGRATION.md) | Released |
+| 51 | DBS-MIGR-003 | thread_system Migration Guide | [advanced/THREAD_SYSTEM_MIGRATION.md](./advanced/THREAD_SYSTEM_MIGRATION.md) | Released |
+| 52 | DBS-INTR-001 | Integration Guide - Database System | [guides/INTEGRATION.md](./guides/INTEGRATION.md) | Released |
+| 53 | DBS-QUAL-001 | Database System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
+| 54 | DBS-QUAL-002 | Database System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
+| 55 | DBS-QUAL-003 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
+| 56 | DBS-ADR-001 | ADR-001: Multi-Backend Database Abstraction | [adr/ADR-001-multi-backend-abstraction.md](./adr/ADR-001-multi-backend-abstraction.md) | Accepted |
+| 57 | DBS-ADR-002 | ADR-002: Connection Pool Architecture | [adr/ADR-002-connection-pool-architecture.md](./adr/ADR-002-connection-pool-architecture.md) | Superseded (Phase 4.3) |
+| 58 | DBS-PROJ-001 | Database System - 개발 히스토리 | [CHANGELOG.kr.md](./CHANGELOG.kr.md) | Released |
+| 59 | DBS-PROJ-002 | Database System - Development History | [CHANGELOG.md](./CHANGELOG.md) | Released |
+| 60 | DBS-PROJ-003 | Database System 프로젝트 구조 | [PROJECT_STRUCTURE.kr.md](./PROJECT_STRUCTURE.kr.md) | Released |
+| 61 | DBS-PROJ-004 | Database System Project Structure | [PROJECT_STRUCTURE.md](./PROJECT_STRUCTURE.md) | Released |
+| 62 | DBS-PROJ-005 | SOUP List &mdash; database_system | [SOUP.md](./SOUP.md) | Released |
+| 63 | DBS-PROJ-006 | Thread Adapter 통합 평가 | [advanced/THREAD_ADAPTER_EVALUATION.kr.md](./advanced/THREAD_ADAPTER_EVALUATION.kr.md) | Released |
+| 64 | DBS-PROJ-007 | Thread Adapter Integration Evaluation | [advanced/THREAD_ADAPTER_EVALUATION.md](./advanced/THREAD_ADAPTER_EVALUATION.md) | Released |
+| 65 | DBS-PROJ-008 | Contributing to Database System | [contributing/CONTRIBUTING.md](./contributing/CONTRIBUTING.md) | Released |
+| 66 | DBS-GUID-005 | Database System Documentation Registry | [README.md](./README.md) | Released |
+
+## Out-of-Tree Markdown Documents
+
+These repo-level Markdown files are not registered under a `DBS-*` doc_id but are part of the repository's documentation surface (counted toward the 80 total).
+
+| Path | Role |
+|------|------|
+| [README.md](../README.md) | Project README (English) |
+| [README.kr.md](../README.kr.md) | Project README (Korean) |
+| [CHANGELOG.md](../CHANGELOG.md) | Repo-level changelog |
+| [CONTRIBUTING.md](../CONTRIBUTING.md) | Repo-level contributing guide |
+| [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md) | Code of conduct |
+| [SECURITY.md](../SECURITY.md) | Security policy |
+| [CLAUDE.md](../CLAUDE.md) | AI tool configuration notes |
+| [DOC_REVIEW_REPORT.md](../DOC_REVIEW_REPORT.md) | Latest documentation audit report |
+| [benchmarks/README.md](../benchmarks/README.md) | Benchmarks subproject README |
+| [integration_tests/README.md](../integration_tests/README.md) | Integration tests subproject README |
+| [samples/README.md](../samples/README.md) | Samples README |
+| [examples/README.md](../examples/README.md) | Examples README |
+| [.github/ISSUE_TEMPLATE/bug_report.md](../.github/ISSUE_TEMPLATE/bug_report.md) | Bug report template |
+| [.github/ISSUE_TEMPLATE/feature_request.md](../.github/ISSUE_TEMPLATE/feature_request.md) | Feature request template |
+| [.github/pull_request_template.md](../.github/pull_request_template.md) | PR template |
 
 ## Documents by Category
 
@@ -87,27 +117,31 @@ Total documents: **59**
 |--------|-------|----------|--------|
 | DBS-ARCH-001 | Database System Architecture | [ARCHITECTURE.kr.md](./ARCHITECTURE.kr.md) | Released |
 | DBS-ARCH-002 | Database System Architecture | [ARCHITECTURE.md](./ARCHITECTURE.md) | Released |
-| DBS-ARCH-003 | Database System Architecture | [ARCHITECTURE.md](./advanced/ARCHITECTURE.md) | Released |
-| DBS-ARCH-004 | Architecture Issues - Phase 0 식별 | [ARCHITECTURE_ISSUES.kr.md](./advanced/ARCHITECTURE_ISSUES.kr.md) | Released |
-| DBS-ARCH-005 | Architecture Issues - Phase 0 Identification | [ARCHITECTURE_ISSUES.md](./advanced/ARCHITECTURE_ISSUES.md) | Released |
-| DBS-ARCH-006 | Database System Project Structure | [STRUCTURE.md](./advanced/STRUCTURE.md) | Released |
+| DBS-ARCH-003 | Database System Architecture (advanced) | [advanced/ARCHITECTURE.md](./advanced/ARCHITECTURE.md) | Released |
+| DBS-ARCH-004 | Architecture Issues - Phase 0 식별 | [advanced/ARCHITECTURE_ISSUES.kr.md](./advanced/ARCHITECTURE_ISSUES.kr.md) | Released |
+| DBS-ARCH-005 | Architecture Issues - Phase 0 Identification | [advanced/ARCHITECTURE_ISSUES.md](./advanced/ARCHITECTURE_ISSUES.md) | Released |
+| DBS-ARCH-006 | Database System Project Structure (advanced) | [advanced/STRUCTURE.md](./advanced/STRUCTURE.md) | Released |
 
-### API Reference (3)
+### API Reference (4)
 
 | doc_id | Topic | Document | Status |
 |--------|-------|----------|--------|
 | DBS-API-001 | Database System API Reference | [API_REFERENCE.kr.md](./API_REFERENCE.kr.md) | Released |
 | DBS-API-002 | Database System API Reference | [API_REFERENCE.md](./API_REFERENCE.md) | Released |
-| DBS-API-003 | Database System Type System Documentation | [TYPE_SYSTEM.md](./advanced/TYPE_SYSTEM.md) | Released |
+| DBS-API-003 | Database System Type System Documentation | [advanced/TYPE_SYSTEM.md](./advanced/TYPE_SYSTEM.md) | Released |
+| DBS-API-004 | Database System API Quick Reference | [API_QUICK_REFERENCE.md](./API_QUICK_REFERENCE.md) | Released |
 
-### Features (2)
+### Features (5)
 
 | doc_id | Topic | Document | Status |
 |--------|-------|----------|--------|
 | DBS-FEAT-001 | Database System 기능 | [FEATURES.kr.md](./FEATURES.kr.md) | Released |
-| DBS-FEAT-002 | Database System Features | [FEATURES.md](./FEATURES.md) | Released |
+| DBS-FEAT-002 | Database System Features (index) | [FEATURES.md](./FEATURES.md) | Released |
+| DBS-FEAT-003 | Features - Backends | [FEATURES_BACKENDS.md](./FEATURES_BACKENDS.md) | Released |
+| DBS-FEAT-004 | Features - ORM and Query Builders | [FEATURES_ORM_QUERY.md](./FEATURES_ORM_QUERY.md) | Released |
+| DBS-FEAT-005 | Features - Pooling, Security, Monitoring | [FEATURES_POOLING_SECURITY.md](./FEATURES_POOLING_SECURITY.md) | Released (historical pool; Phase 4.3 removed) |
 
-### Guides (22)
+### Guides (25)
 
 | doc_id | Topic | Document | Status |
 |--------|-------|----------|--------|
@@ -115,52 +149,55 @@ Total documents: **59**
 | DBS-GUID-002 | Backend Stability Overview | [BACKENDS.md](./BACKENDS.md) | Released |
 | DBS-GUID-003 | ORM Framework Guide | [ORM_GUIDE.md](./ORM_GUIDE.md) | Released |
 | DBS-GUID-004 | Database System 문서 | [README.kr.md](./README.kr.md) | Released |
-| DBS-GUID-006 | 시스템 현재 상태 - Phase 0 베이스라인 | [CURRENT_STATE.kr.md](./advanced/CURRENT_STATE.kr.md) | Released |
-| DBS-GUID-007 | System Current State - Phase 0 Baseline | [CURRENT_STATE.md](./advanced/CURRENT_STATE.md) | Released |
-| DBS-GUID-008 | Backend Usage Analysis Report | [BACKEND_USAGE_ANALYSIS.md](./analysis/BACKEND_USAGE_ANALYSIS.md) | Released |
-| DBS-GUID-009 | CI/CD Guide for database_system | [CI_CD_GUIDE.md](./contributing/CI_CD_GUIDE.md) | Released |
-| DBS-GUID-010 | Async Database Operations Guide | [ASYNC_OPERATIONS.md](./guides/ASYNC_OPERATIONS.md) | Released |
-| DBS-GUID-011 | Database System - Best Practices Guide | [BEST_PRACTICES.md](./guides/BEST_PRACTICES.md) | Released |
-| DBS-GUID-012 | Database System Build Guide | [BUILD_GUIDE.kr.md](./guides/BUILD_GUIDE.kr.md) | Released |
-| DBS-GUID-013 | Database System Build Guide | [BUILD_GUIDE.md](./guides/BUILD_GUIDE.md) | Released |
-| DBS-GUID-014 | Database System - Frequently Asked Questions | [FAQ.md](./guides/FAQ.md) | Released |
-| DBS-GUID-015 | Database System 빠른 시작 가이드 | [QUICK_START.kr.md](./guides/QUICK_START.kr.md) | Released |
-| DBS-GUID-016 | Database System Quick Start Guide | [QUICK_START.md](./guides/QUICK_START.md) | Released |
-| DBS-GUID-017 | Database System Samples Guide | [SAMPLES_GUIDE.kr.md](./guides/SAMPLES_GUIDE.kr.md) | Released |
-| DBS-GUID-018 | Database System Samples Guide | [SAMPLES_GUIDE.md](./guides/SAMPLES_GUIDE.md) | Released |
-| DBS-GUID-019 | Database System Troubleshooting Guide | [TROUBLESHOOTING.md](./guides/TROUBLESHOOTING.md) | Released |
-| DBS-GUID-020 | Unified Database System Guide | [UNIFIED_SYSTEM.md](./guides/UNIFIED_SYSTEM.md) | Released |
-| DBS-GUID-021 | Database System Integration Guide | [README.md](./integration/README.md) | Released |
-| DBS-GUID-022 | database_base Migration Guide | [database_base.md](./migration/database_base.md) | Released |
-| DBS-GUID-023 | Migrating from Legacy Bool-Returning API to Result-Based API | [legacy_api.md](./migration/legacy_api.md) | Released |
+| DBS-GUID-005 | Database System Documentation Registry | [README.md](./README.md) | Released |
+| DBS-GUID-006 | 시스템 현재 상태 - Phase 0 베이스라인 | [advanced/CURRENT_STATE.kr.md](./advanced/CURRENT_STATE.kr.md) | Released |
+| DBS-GUID-007 | System Current State - Phase 0 Baseline | [advanced/CURRENT_STATE.md](./advanced/CURRENT_STATE.md) | Released |
+| DBS-GUID-008 | Backend Usage Analysis Report | [analysis/BACKEND_USAGE_ANALYSIS.md](./analysis/BACKEND_USAGE_ANALYSIS.md) | Released |
+| DBS-GUID-009 | CI/CD Guide for database_system | [contributing/CI_CD_GUIDE.md](./contributing/CI_CD_GUIDE.md) | Released |
+| DBS-GUID-010 | Async Database Operations Guide | [guides/ASYNC_OPERATIONS.md](./guides/ASYNC_OPERATIONS.md) | Released |
+| DBS-GUID-011 | Database System - Best Practices Guide | [guides/BEST_PRACTICES.md](./guides/BEST_PRACTICES.md) | Released |
+| DBS-GUID-012 | Database System Build Guide | [guides/BUILD_GUIDE.kr.md](./guides/BUILD_GUIDE.kr.md) | Released |
+| DBS-GUID-013 | Database System Build Guide | [guides/BUILD_GUIDE.md](./guides/BUILD_GUIDE.md) | Released |
+| DBS-GUID-014 | Database System - Frequently Asked Questions | [guides/FAQ.md](./guides/FAQ.md) | Released |
+| DBS-GUID-015 | Database System 빠른 시작 가이드 | [guides/QUICK_START.kr.md](./guides/QUICK_START.kr.md) | Released |
+| DBS-GUID-016 | Database System Quick Start Guide | [guides/QUICK_START.md](./guides/QUICK_START.md) | Released |
+| DBS-GUID-017 | Database System Samples Guide | [guides/SAMPLES_GUIDE.kr.md](./guides/SAMPLES_GUIDE.kr.md) | Released |
+| DBS-GUID-018 | Database System Samples Guide | [guides/SAMPLES_GUIDE.md](./guides/SAMPLES_GUIDE.md) | Released |
+| DBS-GUID-019 | Database System Troubleshooting Guide | [guides/TROUBLESHOOTING.md](./guides/TROUBLESHOOTING.md) | Released |
+| DBS-GUID-020 | Unified Database System Guide | [guides/UNIFIED_SYSTEM.md](./guides/UNIFIED_SYSTEM.md) | Released |
+| DBS-GUID-021 | Database System Integration Guide | [integration/README.md](./integration/README.md) | Released |
+| DBS-GUID-022 | database_base Migration Guide | [migration/database_base.md](./migration/database_base.md) | Released |
+| DBS-GUID-023 | Migrating from Legacy Bool-Returning API to Result-Based API | [migration/legacy_api.md](./migration/legacy_api.md) | Released |
+| DBS-GUID-024 | Database System Getting Started | [GETTING_STARTED.md](./GETTING_STARTED.md) | Released |
+| DBS-GUID-025 | Database System Ecosystem Guide | [ECOSYSTEM.md](./ECOSYSTEM.md) | Released |
 
 ### Performance (9)
 
 | doc_id | Topic | Document | Status |
 |--------|-------|----------|--------|
-| DBS-PERF-001 | Database System 성능 벤치마크 | [BENCHMARKS.kr.md](./BENCHMARKS.kr.md) | Released |
-| DBS-PERF-002 | Database System Performance Benchmarks | [BENCHMARKS.md](./BENCHMARKS.md) | Released |
-| DBS-PERF-003 | Database System - 성능 기준 메트릭 | [BASELINE.kr.md](./performance/BASELINE.kr.md) | Released |
-| DBS-PERF-004 | Database System - Performance Baseline Metrics | [BASELINE.md](./performance/BASELINE.md) | Released |
-| DBS-PERF-005 | Database System 성능 벤치마크 | [BENCHMARKS.kr.md](./performance/BENCHMARKS.kr.md) | Released |
-| DBS-PERF-006 | Database System Performance Benchmarks | [BENCHMARKS.md](./performance/BENCHMARKS.md) | Released |
-| DBS-PERF-007 | 정적 분석 베이스라인 - database_system | [STATIC_ANALYSIS_BASELINE.kr.md](./performance/STATIC_ANALYSIS_BASELINE.kr.md) | Released |
-| DBS-PERF-008 | Static Analysis Baseline - database_system | [STATIC_ANALYSIS_BASELINE.md](./performance/STATIC_ANALYSIS_BASELINE.md) | Released |
-| DBS-PERF-009 | Database System Performance Tuning Guide | [TUNING_GUIDE.md](./performance/TUNING_GUIDE.md) | Released |
+| DBS-PERF-001 | Database System 성능 벤치마크 (root) | [BENCHMARKS.kr.md](./BENCHMARKS.kr.md) | Released |
+| DBS-PERF-002 | Database System Performance Benchmarks (root) | [BENCHMARKS.md](./BENCHMARKS.md) | Released |
+| DBS-PERF-003 | Database System - 성능 기준 메트릭 | [performance/BASELINE.kr.md](./performance/BASELINE.kr.md) | Released |
+| DBS-PERF-004 | Database System - Performance Baseline Metrics | [performance/BASELINE.md](./performance/BASELINE.md) | Released |
+| DBS-PERF-005 | Database System 성능 벤치마크 (performance/) | [performance/BENCHMARKS.kr.md](./performance/BENCHMARKS.kr.md) | Released |
+| DBS-PERF-006 | Database System Performance Benchmarks (performance/) | [performance/BENCHMARKS.md](./performance/BENCHMARKS.md) | Released |
+| DBS-PERF-007 | 정적 분석 베이스라인 - database_system | [performance/STATIC_ANALYSIS_BASELINE.kr.md](./performance/STATIC_ANALYSIS_BASELINE.kr.md) | Released |
+| DBS-PERF-008 | Static Analysis Baseline - database_system | [performance/STATIC_ANALYSIS_BASELINE.md](./performance/STATIC_ANALYSIS_BASELINE.md) | Released |
+| DBS-PERF-009 | Database System Performance Tuning Guide | [performance/TUNING_GUIDE.md](./performance/TUNING_GUIDE.md) | Released |
 
 ### Migration (3)
 
 | doc_id | Topic | Document | Status |
 |--------|-------|----------|--------|
-| DBS-MIGR-001 | Migrating from database_base to database_backend | [MIGRATION_database_base.md](./MIGRATION_database_base.md) | Released |
-| DBS-MIGR-002 | Database System Migration Guide | [MIGRATION.md](./advanced/MIGRATION.md) | Released |
-| DBS-MIGR-003 | thread_system Migration Guide | [THREAD_SYSTEM_MIGRATION.md](./advanced/THREAD_SYSTEM_MIGRATION.md) | Released |
+| DBS-MIGR-001 | Migrating from database_base to database_backend (root) | [MIGRATION_database_base.md](./MIGRATION_database_base.md) | Released |
+| DBS-MIGR-002 | Database System Migration Guide | [advanced/MIGRATION.md](./advanced/MIGRATION.md) | Released |
+| DBS-MIGR-003 | thread_system Migration Guide | [advanced/THREAD_SYSTEM_MIGRATION.md](./advanced/THREAD_SYSTEM_MIGRATION.md) | Released |
 
 ### Integration (1)
 
 | doc_id | Topic | Document | Status |
 |--------|-------|----------|--------|
-| DBS-INTR-001 | Integration Guide - Database System | [INTEGRATION.md](./guides/INTEGRATION.md) | Released |
+| DBS-INTR-001 | Integration Guide - Database System | [guides/INTEGRATION.md](./guides/INTEGRATION.md) | Released |
 
 ### Quality (3)
 
@@ -174,22 +211,24 @@ Total documents: **59**
 
 | doc_id | Topic | Document | Status |
 |--------|-------|----------|--------|
-| DBS-ADR-001 | ADR-001: Multi-Backend Database Abstraction | [ADR-001-multi-backend-abstraction.md](./adr/ADR-001-multi-backend-abstraction.md) | Accepted |
-| DBS-ADR-002 | ADR-002: Connection Pool Architecture | [ADR-002-connection-pool-architecture.md](./adr/ADR-002-connection-pool-architecture.md) | Accepted |
+| DBS-ADR-001 | ADR-001: Multi-Backend Database Abstraction | [adr/ADR-001-multi-backend-abstraction.md](./adr/ADR-001-multi-backend-abstraction.md) | Accepted |
+| DBS-ADR-002 | ADR-002: Connection Pool Architecture | [adr/ADR-002-connection-pool-architecture.md](./adr/ADR-002-connection-pool-architecture.md) | Superseded (Phase 4.3) |
 
 ### Project (8)
 
 | doc_id | Topic | Document | Status |
 |--------|-------|----------|--------|
-| DBS-PROJ-001 | 📜 Database System - 개발 히스토리 | [CHANGELOG.kr.md](./CHANGELOG.kr.md) | Released |
-| DBS-PROJ-002 | 📜 Database System - Development History | [CHANGELOG.md](./CHANGELOG.md) | Released |
+| DBS-PROJ-001 | Database System - 개발 히스토리 | [CHANGELOG.kr.md](./CHANGELOG.kr.md) | Released |
+| DBS-PROJ-002 | Database System - Development History | [CHANGELOG.md](./CHANGELOG.md) | Released |
 | DBS-PROJ-003 | Database System 프로젝트 구조 | [PROJECT_STRUCTURE.kr.md](./PROJECT_STRUCTURE.kr.md) | Released |
 | DBS-PROJ-004 | Database System Project Structure | [PROJECT_STRUCTURE.md](./PROJECT_STRUCTURE.md) | Released |
 | DBS-PROJ-005 | SOUP List &mdash; database_system | [SOUP.md](./SOUP.md) | Released |
-| DBS-PROJ-006 | Thread Adapter 통합 평가 | [THREAD_ADAPTER_EVALUATION.kr.md](./advanced/THREAD_ADAPTER_EVALUATION.kr.md) | Released |
-| DBS-PROJ-007 | Thread Adapter Integration Evaluation | [THREAD_ADAPTER_EVALUATION.md](./advanced/THREAD_ADAPTER_EVALUATION.md) | Released |
-| DBS-PROJ-008 | Contributing to Database System | [CONTRIBUTING.md](./contributing/CONTRIBUTING.md) | Released |
+| DBS-PROJ-006 | Thread Adapter 통합 평가 | [advanced/THREAD_ADAPTER_EVALUATION.kr.md](./advanced/THREAD_ADAPTER_EVALUATION.kr.md) | Released |
+| DBS-PROJ-007 | Thread Adapter Integration Evaluation | [advanced/THREAD_ADAPTER_EVALUATION.md](./advanced/THREAD_ADAPTER_EVALUATION.md) | Released |
+| DBS-PROJ-008 | Contributing to Database System | [contributing/CONTRIBUTING.md](./contributing/CONTRIBUTING.md) | Released |
 
 ---
 
-*Registry generated for issue [#563](https://github.com/kcenon/database_system/issues/563).*
+*Registry regenerated 2026-04-15: total Markdown documents enumerated across the repo (80); docs/ subtree (66). Adds missing entries for `FEATURES_BACKENDS.md`, `FEATURES_ORM_QUERY.md`, `FEATURES_POOLING_SECURITY.md`, `API_QUICK_REFERENCE.md`, `ECOSYSTEM.md`, `GETTING_STARTED.md` and an out-of-tree table covering README, CHANGELOG, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, CLAUDE.md, DOC_REVIEW_REPORT.md, and sub-project / .github templates.*
+
+*Original registry issue: [#563](https://github.com/kcenon/database_system/issues/563).*

--- a/docs/SOUP.md
+++ b/docs/SOUP.md
@@ -40,8 +40,8 @@ category: "PROJ"
 | ID | Name | Manufacturer | Version | License | Usage | Safety Class | Linking | Known Anomalies |
 |----|------|-------------|---------|---------|-------|-------------|---------|-----------------|
 | SOUP-002 | [libpq](https://www.postgresql.org/) | PostgreSQL Global Development Group | 16.2 | PostgreSQL | PostgreSQL C client library (`postgresql` feature) | B | Dynamic | None |
-| SOUP-003 | [libpqxx](https://pqxx.org/) | Jeroen T. Vermeulen | 7.9.0 | BSD-3-Clause | PostgreSQL C++ wrapper (`postgresql` feature) | B | Dynamic | None |
-| SOUP-004 | [OpenSSL](https://www.openssl.org/) | OpenSSL Software Foundation | 3.3.0 | Apache-2.0 | TLS encryption for PostgreSQL connections (`postgresql` feature) | C | Dynamic | None known at pinned version |
+| SOUP-003 | [libpqxx](https://pqxx.org/) | Jeroen T. Vermeulen | 7.9.2 | BSD-3-Clause | PostgreSQL C++ wrapper (`postgresql` feature) | B | Dynamic | None |
+| SOUP-004 | [OpenSSL](https://www.openssl.org/) | OpenSSL Software Foundation | 3.4.1 | Apache-2.0 | TLS encryption for PostgreSQL connections (`postgresql` feature) | C | Dynamic | None known at pinned version |
 | SOUP-006 | [SQLite](https://www.sqlite.org/) | D. Richard Hipp | 3.45.3 | Public Domain | Embedded SQL database (`sqlite` feature) | B | Static or dynamic | None |
 | SOUP-007 | [MongoDB C++ Driver](https://github.com/mongodb/mongo-cxx-driver) | MongoDB, Inc. | 3.10.1 | Apache-2.0 | MongoDB database connectivity (`mongodb` feature, experimental) | B | Dynamic | None |
 | SOUP-008 | [Hiredis](https://github.com/redis/hiredis) | Redis Ltd. | 1.2.0 | BSD-3-Clause | Redis client library (`redis` feature, experimental) | A | Dynamic | None |
@@ -81,9 +81,9 @@ All SOUP versions are pinned in `vcpkg.json` via the `overrides` field:
 {
   "overrides": [
     { "name": "asio", "version": "1.30.2" },
-    { "name": "openssl", "version": "3.3.0" },
+    { "name": "openssl", "version": "3.4.1" },
     { "name": "libpq", "version": "16.2" },
-    { "name": "libpqxx", "version": "7.9.0" },
+    { "name": "libpqxx", "version": "7.9.2" },
     { "name": "sqlite3", "version": "3.45.3" },
     { "name": "mongo-cxx-driver", "version": "3.10.1" },
     { "name": "hiredis", "version": "1.2.0" },

--- a/docs/adr/ADR-002-connection-pool-architecture.md
+++ b/docs/adr/ADR-002-connection-pool-architecture.md
@@ -1,20 +1,22 @@
 ---
 doc_id: "DBS-ADR-002"
 doc_title: "ADR-002: Connection Pool Architecture"
-doc_version: "1.0.0"
-doc_date: "2026-04-04"
-doc_status: "Accepted"
+doc_version: "1.1.0"
+doc_date: "2026-04-15"
+doc_status: "Superseded"
 project: "database_system"
 category: "ADR"
 ---
 
 # ADR-002: Connection Pool Architecture
 
-> **SSOT**: This document is the single source of truth for **ADR-002: Connection Pool Architecture**.
+> **SUPERSEDED (Phase 4.3, 2025-12-09)**: The local connection pool described in this ADR has been **removed**. Production pooling is now handled server-side via ProxyMode / `database_server` middleware. This ADR is retained for historical context only. See [CHANGELOG](../CHANGELOG.md) and the discussion in [README](../../README.md#overview). <!-- TODO: ADR-003 superseding this decision -->
+
+> **SSOT**: This document is the single source of truth for **ADR-002: Connection Pool Architecture** (historical).
 
 | Field | Value |
 |-------|-------|
-| Status | Accepted |
+| Status | Superseded (Phase 4.3, 2025-12-09) |
 | Date | 2025-04-01 |
 | Decision Makers | kcenon ecosystem maintainers |
 

--- a/docs/advanced/ARCHITECTURE.md
+++ b/docs/advanced/ARCHITECTURE.md
@@ -10,11 +10,12 @@ category: "ARCH"
 
 # Database System Architecture
 
-> **SSOT**: This document is the single source of truth for **Database System Architecture**.
+> **Deferred to**: The canonical SSOT for **Database System Architecture** is [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md). This advanced document covers implementation-detail aspects (multi-backend internals, connection pooling strategy, query builder patterns). Where facts conflict, `docs/ARCHITECTURE.md` wins.
 
 > **Version:** 0.1.0.0
 > **Last Updated:** 2025-10-22
 > **Language:** English
+> **See also**: [docs/ARCHITECTURE.md](../ARCHITECTURE.md) (canonical SSOT)
 
 ## Table of Contents
 

--- a/docs/advanced/ARCHITECTURE_ISSUES.md
+++ b/docs/advanced/ARCHITECTURE_ISSUES.md
@@ -29,8 +29,8 @@ This document catalogs known architectural issues in database_system identified 
 
 ## Key Issues
 
-### ARC-001: MySQL/SQLite Backend Testing (P0, Phase 1)
-- Enable and validate MySQL and SQLite backends
+### ARC-001: SQLite/MongoDB/Redis Backend Testing (P0, Phase 1)
+- Enable and validate SQLite, MongoDB, and Redis backends (MongoDB and Redis are experimental)
 
 ### ARC-002: Test Coverage (P0, Phase 5)
 - Improve from ~65% to 80%+
@@ -38,8 +38,8 @@ This document catalogs known architectural issues in database_system identified 
 ### ARC-003: Performance Benchmarks (P1, Phase 2)
 - Create comprehensive benchmark suite
 
-### ARC-004: Connection Pool Optimization (P1, Phase 2)
-- Optimize connection pooling performance
+### ARC-004: ProxyMode Integration (P1, Phase 2)
+- Integrate with `database_server` middleware (local connection pool removed in Phase 4.3; see [CHANGELOG](../CHANGELOG.md))
 
 ---
 

--- a/docs/advanced/CURRENT_STATE.md
+++ b/docs/advanced/CURRENT_STATE.md
@@ -27,31 +27,31 @@ This document captures the current state of the `database_system` at the beginni
 
 ## System Overview
 
-**Purpose**: Database system provides multi-backend database abstraction with PostgreSQL, MySQL, SQLite support.
+**Purpose**: Database system provides multi-backend database abstraction with PostgreSQL, SQLite, MongoDB, and Redis support.
 
 **Key Components**:
-- Connection pooling
-- Query builder
+- Query builder (immutable, thread-safe)
 - Transaction management
-- Multiple backend support (PostgreSQL, MySQL, SQLite)
-- IDatabase interface implementation
+- Multiple backend support (PostgreSQL, SQLite, MongoDB, Redis)
+- IDatabase / `database_backend` interface implementation
+- ProxyMode entry point (local connection pooling removed in Phase 4.3 — see [CHANGELOG](../CHANGELOG.md))
 
-**Architecture**: Modular backend abstraction layer with pluggable database drivers.
+**Architecture**: Modular backend abstraction layer with pluggable backends.
 
 ---
 
 ## Build Configuration
 
 ### Supported Platforms
-- ✅ Ubuntu 22.04 (GCC 12, Clang 15)
-- ✅ macOS 13 (Apple Clang)
-- ✅ Windows Server 2022 (MSVC 2022)
+- ✅ Ubuntu 22.04+ (GCC 13+, Clang 17+)
+- ✅ macOS 13+ (Apple Clang 14+)
+- ✅ Windows Server 2022 (MSVC 2022+)
 
 ### Dependencies
-- C++20 compiler
-- common_system (optional): IDatabase interface, Result<T>
+- C++20 compiler (see `README.md` for authoritative compiler baseline)
+- common_system (required): IDatabase interface, Result<T>
 - container_system (optional): Query results
-- Database drivers (PostgreSQL, MySQL, SQLite)
+- Database backends (PostgreSQL, SQLite, MongoDB, Redis)
 
 ---
 
@@ -71,20 +71,21 @@ This document captures the current state of the `database_system` at the beginni
 
 #### High Priority (P0)
 - [ ] Test coverage at ~65%, needs improvement
-- [ ] MySQL and SQLite backends need more testing
+- [ ] SQLite, MongoDB, Redis backends need more testing
 
 #### Medium Priority (P1)
 - [ ] Performance benchmarks missing
-- [ ] Connection pool optimization
+- [ ] ProxyMode integration (local connection pool removed in Phase 4.3)
 
 ---
 
 ## Next Steps (Phase 1)
 
-1. Enable and test MySQL backend
-2. Enable and test SQLite backend
-3. Add performance benchmarks
-4. Improve test coverage to 80%+
+1. Enable and test SQLite backend
+2. Enable and test MongoDB backend
+3. Enable and test Redis backend
+4. Add performance benchmarks
+5. Improve test coverage to 80%+
 
 ---
 

--- a/docs/advanced/MIGRATION.md
+++ b/docs/advanced/MIGRATION.md
@@ -391,7 +391,7 @@ std::optional<User> get_user(int64_t user_id) {
 }
 ```
 
-> **Note**: For production deployments with multiple database types, use ProxyMode with `database_server` middleware for centralized connection management. See [docs/migration/proxy-mode.md](../migration/proxy-mode.md).
+> **Note**: For production deployments with multiple database types, use ProxyMode with `database_server` middleware for centralized connection management. See [migration/database_base.md](../migration/database_base.md). <!-- TODO: dedicated proxy-mode.md -->
 
 ---
 
@@ -866,8 +866,8 @@ Database migrations are critical operations that require careful planning, testi
 
 - [ARCHITECTURE.md](ARCHITECTURE.md) - System architecture overview
 - [STRUCTURE.md](STRUCTURE.md) - Project directory structure
-- [docs/API_REFERENCE.md](docs/API_REFERENCE.md) - Complete API documentation
-- [samples/](samples/) - Example migrations and usage patterns
+- [API_REFERENCE.md](../API_REFERENCE.md) - Complete API documentation
+- [samples/](../../samples/) - Example migrations and usage patterns
 
 ---
 

--- a/docs/advanced/STRUCTURE.md
+++ b/docs/advanced/STRUCTURE.md
@@ -10,11 +10,12 @@ category: "ARCH"
 
 # Database System Project Structure
 
-> **SSOT**: This document is the single source of truth for **Database System Project Structure**.
+> **Deferred to**: The canonical SSOT for **Database System Project Structure** is [`docs/PROJECT_STRUCTURE.md`](../PROJECT_STRUCTURE.md). Where facts conflict, `docs/PROJECT_STRUCTURE.md` wins.
 
 > **Version:** 0.1.0.0
 > **Last Updated:** 2025-10-22
 > **Language:** English
+> **See also**: [docs/PROJECT_STRUCTURE.md](../PROJECT_STRUCTURE.md) (canonical SSOT)
 
 ## Table of Contents
 

--- a/docs/advanced/THREAD_SYSTEM_MIGRATION.md
+++ b/docs/advanced/THREAD_SYSTEM_MIGRATION.md
@@ -395,8 +395,8 @@ if constexpr (database::async::using_thread_system) {
 
 - [thread_system Repository](https://github.com/kcenon/thread_system)
 - [thread_system Documentation](https://github.com/kcenon/thread_system/tree/main/docs)
-- [database_system Integration Guide](./INTEGRATION.md)
-- [API Reference](./API_REFERENCE.md)
+- [database_system Integration Guide](../guides/INTEGRATION.md)
+- [API Reference](../API_REFERENCE.md)
 
 ## Contact
 

--- a/docs/advanced/TYPE_SYSTEM.md
+++ b/docs/advanced/TYPE_SYSTEM.md
@@ -431,10 +431,10 @@ if (auto it = row.find("optional_field"); it != row.end()) {
 
 ## 📚 Related Documentation
 
-- [API Reference](API_REFERENCE.md)
-- [Query Builder Guide](../database/query_builder.h)
-- [ORM Guide](ORM.md)
-- [Backend Integration](BACKEND_INTEGRATION.md)
+- [API Reference](../API_REFERENCE.md)
+- [Query Builder Guide](../../database/query_builder.h)
+- [ORM Guide](../ORM_GUIDE.md)
+- [Backend Integration](../BACKENDS.md)
 
 ---
 

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -77,8 +77,8 @@ New to open source? Start here:
 2. **Read the documentation**:
    - [Architecture Guide](../ARCHITECTURE.md)
    - [API Reference](../API_REFERENCE.md)
-   - [Build Guide](../BUILD_GUIDE.md)
-   - [Improvement Plan](../../IMPROVEMENT_PLAN.md)
+   - [Build Guide](../guides/BUILD_GUIDE.md)
+   - Improvement Plan <!-- TODO: IMPROVEMENT_PLAN.md -->
 
 3. **Join discussions**:
    - [GitHub Discussions](https://github.com/kcenon/database_system/discussions)
@@ -905,10 +905,10 @@ Follows [Semantic Versioning](https://semver.org/):
 
 - **Documentation**: [docs/](../)
 - **Examples**: [samples/](../../samples/)
-- **Build Guide**: [docs/BUILD_GUIDE.md](../BUILD_GUIDE.md)
+- **Build Guide**: [docs/guides/BUILD_GUIDE.md](../guides/BUILD_GUIDE.md)
 - **Architecture**: [docs/ARCHITECTURE.md](../ARCHITECTURE.md)
 - **API Reference**: [docs/API_REFERENCE.md](../API_REFERENCE.md)
-- **Improvement Plan**: [IMPROVEMENT_PLAN.md](../../IMPROVEMENT_PLAN.md)
+- **Improvement Plan**: Improvement Plan <!-- TODO: IMPROVEMENT_PLAN.md -->
 
 ### Communication
 

--- a/docs/guides/ASYNC_OPERATIONS.md
+++ b/docs/guides/ASYNC_OPERATIONS.md
@@ -12,7 +12,7 @@ category: "GUID"
 
 > **SSOT**: This document is the single source of truth for **Async Database Operations Guide**.
 
-> **Language:** **English** | [한국어](ASYNC_OPERATIONS.kr.md)
+> **Language:** **English** | 한국어 <!-- TODO: ASYNC_OPERATIONS.kr.md translation -->
 
 ## Table of Contents
 

--- a/docs/guides/FAQ.md
+++ b/docs/guides/FAQ.md
@@ -168,7 +168,7 @@ int main() {
 }
 ```
 
-For more details, see [Quick Start Guide](../BUILD_GUIDE.md).
+For more details, see [Quick Start Guide](QUICK_START.md) or [Build Guide](BUILD_GUIDE.md).
 
 ### Q: What are the most common use cases?
 
@@ -792,7 +792,7 @@ auto result = db->create_query_builder(database_types::postgres)
 - **95%+ pool efficiency** under load
 - **1.16M ops/s** with thread_system integration
 
-See [Performance Benchmarks](../PERFORMANCE_BENCHMARKS.md) for detailed results.
+See [Performance Benchmarks](../BENCHMARKS.md) for detailed results.
 
 ### Q: How can I optimize performance?
 
@@ -925,7 +925,7 @@ for (auto& t : threads) {
    set(CMAKE_CXX_STANDARD_REQUIRED ON)
    ```
 
-If issue persists, see [Build Guide](../BUILD_GUIDE.md) and [Troubleshooting Guide](TROUBLESHOOTING.md).
+If issue persists, see [Build Guide](BUILD_GUIDE.md) and [Troubleshooting Guide](TROUBLESHOOTING.md).
 
 ### Q: Runtime crash with segmentation fault. What should I check?
 
@@ -1123,7 +1123,7 @@ auto summary = perf_monitor->get_performance_summary();
 exporter.export_metrics(summary);
 ```
 
-See [Integration Guide](../INTEGRATION.md) for detailed examples.
+See [Integration Guide](INTEGRATION.md) for detailed examples.
 
 ### Q: Can I use database_system without other KCENON systems?
 
@@ -1374,7 +1374,7 @@ auto perf_mon = context->get_performance_monitor();
 - Thread-safe by design (no global state)
 - Better separation of concerns
 
-See [IMPROVEMENT_PLAN.md](../../IMPROVEMENT_PLAN.md) for migration guide.
+See [Migration Guide](../advanced/MIGRATION.md) for migration details. <!-- TODO: IMPROVEMENT_PLAN.md -->
 
 ---
 
@@ -1487,12 +1487,12 @@ Code:
 
 - [README](../../README.md) - Project overview and features
 - [Architecture](../ARCHITECTURE.md) - System architecture and design patterns
-- [Build Guide](../BUILD_GUIDE.md) - Comprehensive build instructions
+- [Build Guide](BUILD_GUIDE.md) - Comprehensive build instructions
 - [API Reference](../API_REFERENCE.md) - Complete API documentation
 - [Troubleshooting](TROUBLESHOOTING.md) - Detailed troubleshooting guide
-- [Integration](../INTEGRATION.md) - Integration with KCENON ecosystem
-- [Performance Benchmarks](../PERFORMANCE_BENCHMARKS.md) - Detailed performance metrics
-- [Improvement Plan](../../IMPROVEMENT_PLAN.md) - Roadmap and recent improvements
+- [Integration](INTEGRATION.md) - Integration with KCENON ecosystem
+- [Performance Benchmarks](../BENCHMARKS.md) - Detailed performance metrics
+- Improvement Plan <!-- TODO: IMPROVEMENT_PLAN.md -->
 
 ---
 

--- a/docs/guides/INTEGRATION.md
+++ b/docs/guides/INTEGRATION.md
@@ -12,7 +12,7 @@ category: "INTR"
 
 > **SSOT**: This document is the single source of truth for **Integration Guide - Database System**.
 
-> **Language:** **English** | [한국어](INTEGRATION.kr.md)
+> **Language:** **English** | 한국어 <!-- TODO: INTEGRATION.kr.md translation -->
 
 ## Overview
 
@@ -1072,9 +1072,9 @@ make
 
 ## Support
 
-- **Documentation**: [docs/](docs/)
-- **API Reference**: [docs/API_REFERENCE.md](docs/API_REFERENCE.md)
-- **Build Guide**: [docs/BUILD_GUIDE.md](docs/BUILD_GUIDE.md)
+- **Documentation**: [docs/](../)
+- **API Reference**: [API_REFERENCE.md](../API_REFERENCE.md)
+- **Build Guide**: [BUILD_GUIDE.md](BUILD_GUIDE.md)
 - **Issues**: [GitHub Issues](https://github.com/kcenon/database_system/issues)
 - **Email**: kcenon@naver.com
 

--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -156,7 +156,7 @@ if (result.is_ok()) {
 
 - [API Reference](../API_REFERENCE.md) - Comprehensive API documentation
 - [Architecture Guide](../ARCHITECTURE.md) - System design and patterns
-- [Integration Guide](../../INTEGRATION.md) - Advanced integration scenarios
+- [Integration Guide](./INTEGRATION.md) - Advanced integration scenarios
 - [FAQ](./FAQ.md) - Frequently asked questions
 - [Examples](../../samples/) - Complete sample applications
 

--- a/docs/guides/SAMPLES_GUIDE.md
+++ b/docs/guides/SAMPLES_GUIDE.md
@@ -794,7 +794,7 @@ void performance_optimization()
 
 ---
 
-These samples provide comprehensive examples of using the Database System in various scenarios. For more advanced use cases and specific database features, refer to the [API Reference](API_REFERENCE.md) and individual database documentation.
+These samples provide comprehensive examples of using the Database System in various scenarios. For more advanced use cases and specific database features, refer to the [API Reference](../API_REFERENCE.md) and individual database documentation.
 ---
 
 *Last Updated: 2025-10-20*

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -912,7 +912,7 @@ Include:
 ### Additional Resources
 
 - **GitHub Issues**: [database_system issues](https://github.com/kcenon/database_system/issues)
-- **Documentation**: See [BUILD_GUIDE.md](../BUILD_GUIDE.md) and [API_REFERENCE.md](../API_REFERENCE.md)
+- **Documentation**: See [BUILD_GUIDE.md](BUILD_GUIDE.md) and [API_REFERENCE.md](../API_REFERENCE.md)
 - **FAQ**: Check [FAQ.md](FAQ.md) for common questions
 - **Examples**: See `samples/` directory for working examples
 

--- a/docs/guides/UNIFIED_SYSTEM.md
+++ b/docs/guides/UNIFIED_SYSTEM.md
@@ -12,7 +12,7 @@ category: "GUID"
 
 > **SSOT**: This document is the single source of truth for **Unified Database System Guide**.
 
-> **Language:** **English** | [한국어](UNIFIED_SYSTEM.kr.md)
+> **Language:** **English** | 한국어 <!-- TODO: UNIFIED_SYSTEM.kr.md translation -->
 
 ## Table of Contents
 

--- a/docs/integration/README.md
+++ b/docs/integration/README.md
@@ -18,11 +18,14 @@ This directory contains integration guides for using database_system with other 
 
 ## Integration Guides
 
-- [With Common System](with-common-system.md) - Foundation interfaces and error handling
-- [With Logger System](with-logger.md) - Database query and error logging
-- [With Monitoring System](with-monitoring.md) - Database metrics and performance monitoring
-- [With Thread System](with-thread-system.md) - Connection pooling and async queries
-- [With Network System](with-network-system.md) - Network-based database protocols
+<!-- TODO: sub-guides below are not yet written; see docs/guides/INTEGRATION.md for the current consolidated guide -->
+- With Common System - Foundation interfaces and error handling
+- With Logger System - Database query and error logging
+- With Monitoring System - Database metrics and performance monitoring
+- With Thread System - Connection pooling and async queries
+- With Network System - Network-based database protocols
+
+Until the per-system guides are split out, see the consolidated [Integration Guide](../guides/INTEGRATION.md).
 
 ## Quick Start
 
@@ -219,8 +222,8 @@ TRY(transaction->commit());
 
 - [Database System API Reference](../API_REFERENCE.md)
 - [Database System Architecture](../ARCHITECTURE.md)
-- [Ecosystem Integration Guide](../../../ECOSYSTEM.md)
-- [Example Applications](../../../examples/database/)
+- [Ecosystem Integration Guide](../ECOSYSTEM.md)
+- [Example Applications](../../examples/)
 
 ## Support
 

--- a/docs/migration/database_base.md
+++ b/docs/migration/database_base.md
@@ -11,6 +11,9 @@ category: "GUID"
 # database_base Migration Guide
 
 > **SSOT**: This document is the single source of truth for **database_base Migration Guide**.
+>
+> **Related**: [../MIGRATION_database_base.md](../MIGRATION_database_base.md) also covers this topic from a `MIGR` perspective. Canonical has not yet been chosen; treat both as authoritative and keep them in sync. <!-- TODO: name one canonical SSOT -->
+
 
 ## Overview
 
@@ -313,7 +316,7 @@ error: cannot convert 'Result<uint64_t>' to 'unsigned int'
 
 - [API Reference](../API_REFERENCE.md)
 - [Architecture Overview](../ARCHITECTURE.md)
-- [Backend Registry Guide](../guides/backend_registry.md)
+- Backend Registry Guide <!-- TODO: docs/guides/backend_registry.md -->
 
 ---
 

--- a/docs/performance/BENCHMARKS.md
+++ b/docs/performance/BENCHMARKS.md
@@ -10,11 +10,12 @@ category: "PERF"
 
 # Database System Performance Benchmarks
 
-> **SSOT**: This document is the single source of truth for **Database System Performance Benchmarks**.
+> **Deferred to**: The canonical SSOT for **Database System Performance Benchmarks** is [`docs/BENCHMARKS.md`](../BENCHMARKS.md). This document is retained as the performance-folder mirror. Where facts conflict, `docs/BENCHMARKS.md` wins.
 
-> **Language:** **English** | [한국어](PERFORMANCE_BENCHMARKS.kr.md)
+> **Language:** **English** | [한국어](BENCHMARKS.kr.md)
+> **See also**: [docs/BENCHMARKS.md](../BENCHMARKS.md) (canonical SSOT)
 
-Comprehensive performance analysis and benchmarks for the Database System with multi-backend support, connection pooling, and query builders.
+Comprehensive performance analysis and benchmarks for the Database System with multi-backend support and query builders.
 
 ## Table of Contents
 

--- a/docs/performance/TUNING_GUIDE.md
+++ b/docs/performance/TUNING_GUIDE.md
@@ -130,6 +130,6 @@ checkpoint_completion_target = 0.9
 
 ## See Also
 
-- [POSTGRESQL_TUNING.md](POSTGRESQL_TUNING.md) - PostgreSQL specific tuning
-- [SQLITE_TUNING.md](SQLITE_TUNING.md) - SQLite specific tuning
+- POSTGRESQL_TUNING.md <!-- TODO: PostgreSQL specific tuning -->
+- SQLITE_TUNING.md <!-- TODO: SQLite specific tuning -->
 - [BENCHMARKS.md](BENCHMARKS.md) - Performance benchmark results

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -282,4 +282,4 @@ When adding new integration tests:
 - [Google Test Documentation](https://google.github.io/googletest/)
 - [SQLite Documentation](https://www.sqlite.org/docs.html)
 - [database_system API Documentation](../docs/)
-- [Performance Tuning Guide](../docs/performance.md)
+- [Performance Tuning Guide](../docs/performance/TUNING_GUIDE.md)

--- a/samples/README.md
+++ b/samples/README.md
@@ -209,8 +209,8 @@ task async_database_operation() {
 ## Building the Samples
 
 ### Prerequisites
-- C++20 compatible compiler (GCC 10+, Clang 12+, MSVC 2019+)
-- CMake 3.16 or later
+- C++20 compatible compiler (GCC 13+, Clang 17+, MSVC 2022+, Apple Clang 14+)
+- CMake 3.20 or later
 - Database System library
 - PostgreSQL client library (libpq)
 - PostgreSQL server (for actual database operations)

--- a/samples/integrated/async_queries.cpp
+++ b/samples/integrated/async_queries.cpp
@@ -221,17 +221,18 @@ int main(int argc, char* argv[]) {
     // Create database instance
     std::cout << "Creating database instance with async support...\n";
 
-    auto db = unified_database_system::create_builder()
+    auto db_result = unified_database_system::create_builder()
         .enable_logging(db_log_level::info, "./logs")
         .enable_monitoring(true)
         .enable_async(8)  // 8 async worker threads
         .set_pool_size(2, 10)
         .build();
 
-    if (!db) {
-        std::cerr << "❌ Failed to create database instance\n";
+    if (db_result.is_err()) {
+        std::cerr << "Failed to create database instance: " << db_result.error().message << "\n";
         return 1;
     }
+    auto db = std::move(db_result.value());
 
     std::cout << "✅ Database instance created with async support\n";
 

--- a/samples/integrated/basic_usage.cpp
+++ b/samples/integrated/basic_usage.cpp
@@ -89,16 +89,17 @@ int main(int argc, char* argv[]) {
     // Step 1: Create database instance with zero-config
     std::cout << "Step 1: Creating database instance...\n";
 
-    auto db = unified_database_system::create_builder()
+    auto db_result = unified_database_system::create_builder()
         .enable_logging(db_log_level::info, "./logs")
         .enable_monitoring(true)
         .set_pool_size(2, 10)
         .build();
 
-    if (!db) {
-        std::cerr << "❌ Failed to create database instance\n";
+    if (db_result.is_err()) {
+        std::cerr << "Failed to create database instance: " << db_result.error().message << "\n";
         return 1;
     }
+    auto db = std::move(db_result.value());
 
     std::cout << "✅ Database instance created\n";
 

--- a/samples/integrated/migration_from_legacy.cpp
+++ b/samples/integrated/migration_from_legacy.cpp
@@ -51,14 +51,15 @@ int main() {
     std::cout << "  - Result<T> for explicit error handling\n\n";
 
     std::cout << "Example:\n";
-    auto db = unified_database_system::create_builder()
+    auto db_result = unified_database_system::create_builder()
         .enable_logging(db_log_level::info, "./logs")
         .enable_monitoring(true)
         .set_pool_size(2, 10)
         .build();
 
-    if (db) {
-        std::cout << "✅ Database instance created with integrated API\n";
+    if (db_result.is_ok()) {
+        auto db = std::move(db_result.value());
+        std::cout << "Database instance created with integrated API\n";
     }
 
     // ========================================

--- a/samples/integrated/migration_from_legacy.cpp
+++ b/samples/integrated/migration_from_legacy.cpp
@@ -57,8 +57,9 @@ int main() {
         .set_pool_size(2, 10)
         .build();
 
+    std::unique_ptr<unified_database_system> db;
     if (db_result.is_ok()) {
-        auto db = std::move(db_result.value());
+        db = std::move(db_result.value());
         std::cout << "Database instance created with integrated API\n";
     }
 

--- a/samples/integrated/monitoring.cpp
+++ b/samples/integrated/monitoring.cpp
@@ -315,7 +315,7 @@ int main(int argc, char* argv[]) {
     // Create database instance with monitoring enabled
     std::cout << "Creating database instance with monitoring...\n";
 
-    auto db = unified_database_system::create_builder()
+    auto db_result = unified_database_system::create_builder()
         .enable_logging(db_log_level::info, "./logs")
         .enable_monitoring(true)
         .enable_async(4)
@@ -323,10 +323,11 @@ int main(int argc, char* argv[]) {
         .set_slow_query_threshold(milliseconds(100))
         .build();
 
-    if (!db) {
-        std::cerr << "❌ Failed to create database instance\n";
+    if (db_result.is_err()) {
+        std::cerr << "Failed to create database instance: " << db_result.error().message << "\n";
         return 1;
     }
+    auto db = std::move(db_result.value());
 
     std::cout << "✅ Database instance created\n";
 

--- a/tests/integrated/test_unified_database_system.cpp
+++ b/tests/integrated/test_unified_database_system.cpp
@@ -155,8 +155,10 @@ bool test_builder_default() {
     TEST_START("Builder Pattern - Default Configuration");
 
     auto builder = unified_database_system::create_builder();
-    auto db = builder.build();
+    auto db_result = builder.build();
 
+    ASSERT_TRUE(db_result.is_ok(), "Builder should succeed");
+    auto db = std::move(db_result.value());
     ASSERT_TRUE(db != nullptr, "Builder should create database instance");
 
     TEST_END();
@@ -169,27 +171,23 @@ bool test_builder_default() {
 bool test_builder_custom() {
     TEST_START("Builder Pattern - Custom Configuration");
 
-    try {
-        auto db = unified_database_system::create_builder()
-            .set_backend(backend_type::postgres)
-            .set_connection_string("host=localhost dbname=test")
-            .set_pool_size(5, 20)
-            .enable_logging(db_log_level::debug, "./test_logs")
-            .enable_monitoring(true)
-            .enable_async(8)
-            .set_slow_query_threshold(std::chrono::milliseconds(500))
-            .build();
+    auto db_result = unified_database_system::create_builder()
+        .set_backend(backend_type::postgres)
+        .set_connection_string("host=localhost dbname=test")
+        .set_pool_size(5, 20)
+        .enable_logging(db_log_level::debug, "./test_logs")
+        .enable_monitoring(true)
+        .enable_async(8)
+        .set_slow_query_threshold(std::chrono::milliseconds(500))
+        .build();
 
-        ASSERT_TRUE(db != nullptr, "Builder with custom config should create instance");
-
-        // Note: Connection is not established yet, just configuration
-        // Actual connection would happen on connect() or first query
-
-    } catch (const std::exception& e) {
+    if (db_result.is_err()) {
         // If PostgreSQL is not available or not compiled in, that's acceptable
         // This test is just verifying the builder API works
-        std::cout << "  ℹ️  Note: Database connection not available: " << e.what() << "\n";
-        std::cout << "  ℹ️  Builder API test passed (connection test skipped)\n";
+        std::cout << "  Note: Database connection not available: " << db_result.error().message << "\n";
+        std::cout << "  Builder API test passed (connection test skipped)\n";
+    } else {
+        ASSERT_TRUE(db_result.value() != nullptr, "Builder with custom config should create instance");
     }
 
     TEST_END();
@@ -239,10 +237,12 @@ bool test_config_construction() {
 bool test_move_semantics() {
     TEST_START("Move Semantics");
 
-    auto db1 = unified_database_system::create_builder()
+    auto db1_result = unified_database_system::create_builder()
         .set_backend(backend_type::postgres)
         .build();
 
+    ASSERT_TRUE(db1_result.is_ok(), "Builder should succeed");
+    auto db1 = std::move(db1_result.value());
     ASSERT_TRUE(db1 != nullptr, "Original instance should be valid");
 
     // Move construction
@@ -250,7 +250,9 @@ bool test_move_semantics() {
     ASSERT_TRUE(db2 != nullptr, "Moved instance should be valid");
 
     // Move assignment
-    auto db3 = unified_database_system::create_builder().build();
+    auto db3_result = unified_database_system::create_builder().build();
+    ASSERT_TRUE(db3_result.is_ok(), "Builder should succeed");
+    auto db3 = std::move(db3_result.value());
     db3 = std::move(db2);
     ASSERT_TRUE(db3 != nullptr, "Move-assigned instance should be valid");
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "kcenon-database-system",
-  "version-semver": "0.1.0",
-  "port-version": 6,
+  "version-semver": "1.0.0",
+  "port-version": 0,
   "description": "Advanced C++20 Database System with Multi-Backend Support",
   "homepage": "https://github.com/kcenon/database_system",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
## Summary
- Release database_system v1.0.0 — first stable release
- All v1.0 readiness checklist items from #564 are complete
- All blocking dependencies resolved (common_system, thread_system, logger_system v1.0)

## What
### Change Type
- [x] Feature (new functionality)
- [x] Refactor (no functional changes)
- [x] Documentation

### Key Changes Since v0.1.0
- **BREAKING**: `builder::build()` returns `Result<unique_ptr<>>` instead of throwing
- **BREAKING**: CMake package name unified to `database_system`
- Synchronous public APIs use `Result<T>` — no-throw guarantee enforced
- Credential encryption and audit log persistence
- PostgreSQL batch transaction mode
- Doxygen modernization

## Why
### Related Issues
- Closes #564 (Prepare database_system for v1.0 release)
- Part of kcenon/common_system#639 (Ecosystem v1.0)

### Motivation
All Tier 0-2 dependencies have released v1.0. database_system (Tier 3) is the next
in the ecosystem release chain.

## How
### Test Plan
- [ ] Full CI suite passes (multi-platform: Ubuntu, macOS, Windows)
- [ ] Integration tests pass
- [ ] All PR checks green before merge

### Post-Merge Steps
- Tag `v1.0.0` on the merge commit
- Delete `develop` branch and recreate from `main`
- Close epic #564
- Check parent epic kcenon/common_system#639