### PR TITLE
feat(core): re-introduce thread-safe connection pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Thread-safe `connection_pool` with RAII `pooled_connection` lease handle, bounded
+  sizing, acquisition timeout, and transparent replacement of broken connections.
+  The pool is backend-agnostic and lives alongside existing direct-connection APIs
+  without breaking them ([#568](https://github.com/kcenon/database_system/issues/568)).
+- Public forwarding header `kcenon/database/core/connection_pool.h`.
+- Unit test suite `connection_pool_test` covering pre-warming, concurrent
+  checkout/checkin, pool exhaustion, broken-connection replacement, and shutdown.
+
 ## [1.0.0] - 2026-04-16
 
 ### Changed

--- a/database/CMakeLists.txt
+++ b/database/CMakeLists.txt
@@ -69,6 +69,7 @@ set(HEADER_FILES
     # Sprint 5 Headers (Backend Plugin System)
     ${CMAKE_CURRENT_SOURCE_DIR}/core/database_backend.h
     ${CMAKE_CURRENT_SOURCE_DIR}/core/backend_registry.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/connection_pool.h
     # Sprint 5.2 Headers (PostgreSQL Backend Plugin)
     ${CMAKE_CURRENT_SOURCE_DIR}/backends/postgresql_backend.h
     # Sprint 5.3 Headers (Additional Backend Plugins)
@@ -99,6 +100,7 @@ set(SOURCE_FILES
     # Sprint 5 Sources (Backend Plugin System)
     ${CMAKE_CURRENT_SOURCE_DIR}/core/database_backend.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core/backend_registry.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/connection_pool.cpp
     # Sprint 5.2 Sources (PostgreSQL Backend Plugin)
     ${CMAKE_CURRENT_SOURCE_DIR}/backends/postgresql_backend.cpp
     # Sprint 5.3 Sources (Additional Backend Plugins)
@@ -208,7 +210,9 @@ endif()
 target_include_directories(${PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
     $<INSTALL_INTERFACE:include/database_system>
+    $<INSTALL_INTERFACE:include>
 )
 
 ##################################################

--- a/database/core/connection_pool.cpp
+++ b/database/core/connection_pool.cpp
@@ -1,0 +1,313 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+#include "connection_pool.h"
+
+#include <utility>
+
+namespace database
+{
+namespace core
+{
+namespace pool
+{
+
+// ---------------------------------------------------------------------------
+// pooled_connection
+// ---------------------------------------------------------------------------
+
+pooled_connection::pooled_connection(std::shared_ptr<connection_pool> pool,
+                                     std::unique_ptr<database_backend> backend) noexcept
+	: pool_(std::move(pool))
+	, backend_(std::move(backend))
+{
+}
+
+pooled_connection::pooled_connection(pooled_connection&& other) noexcept
+	: pool_(std::move(other.pool_))
+	, backend_(std::move(other.backend_))
+	, broken_(other.broken_)
+{
+	other.broken_ = false;
+}
+
+pooled_connection& pooled_connection::operator=(pooled_connection&& other) noexcept
+{
+	if (this != &other) {
+		release();
+		pool_ = std::move(other.pool_);
+		backend_ = std::move(other.backend_);
+		broken_ = other.broken_;
+		other.broken_ = false;
+	}
+	return *this;
+}
+
+pooled_connection::~pooled_connection()
+{
+	release();
+}
+
+void pooled_connection::release() noexcept
+{
+	if (pool_ && backend_) {
+		// Return to pool (noexcept contract: the pool's return_connection
+		// must not throw; it only moves pointers and notifies the CV).
+		pool_->return_connection(std::move(backend_), broken_);
+	}
+	pool_.reset();
+	backend_.reset();
+	broken_ = false;
+}
+
+// ---------------------------------------------------------------------------
+// connection_pool
+// ---------------------------------------------------------------------------
+
+namespace {
+
+connection_validator default_validator()
+{
+	return [](database_backend& backend) {
+		return backend.is_initialized();
+	};
+}
+
+error_info make_pool_error(error_code code, std::string message)
+{
+	return error_info{static_cast<int>(code), std::move(message), "connection_pool"};
+}
+
+} // namespace
+
+std::shared_ptr<connection_pool> connection_pool::create(
+	pool_config config,
+	connection_factory factory,
+	connection_validator validator)
+{
+	if (config.max_size == 0) {
+		config.max_size = 1;
+	}
+	if (config.min_size > config.max_size) {
+		config.min_size = config.max_size;
+	}
+
+	if (!validator) {
+		validator = default_validator();
+	}
+
+	// Use new because the ctor is private; std::make_shared would need a friend.
+	auto pool = std::shared_ptr<connection_pool>(new connection_pool(
+		std::move(config), std::move(factory), std::move(validator)));
+
+	// Pre-warm up to min_size. Failures are tolerated: the pool will retry
+	// on the first acquire() call.
+	{
+		std::unique_lock<std::mutex> lock(pool->mutex_);
+		while (pool->total_connections_ < pool->config_.min_size) {
+			auto backend = pool->create_locked(lock);
+			if (!backend) {
+				break; // Abort pre-warming; acquire() will retry later.
+			}
+			pool->idle_.push_back(std::move(backend));
+		}
+	}
+
+	return pool;
+}
+
+connection_pool::connection_pool(pool_config config,
+                                 connection_factory factory,
+                                 connection_validator validator)
+	: config_(std::move(config))
+	, factory_(std::move(factory))
+	, validator_(std::move(validator))
+{
+}
+
+connection_pool::~connection_pool()
+{
+	shutdown();
+}
+
+void connection_pool::shutdown()
+{
+	std::deque<std::unique_ptr<database_backend>> drained;
+	{
+		std::lock_guard<std::mutex> lock(mutex_);
+		if (shut_down_) {
+			return;
+		}
+		shut_down_ = true;
+		drained.swap(idle_);
+		total_connections_ -= drained.size();
+	}
+	// Destroy idle connections outside the lock. shutdown() on each backend
+	// is invoked via the backend destructor.
+	drained.clear();
+	cv_.notify_all();
+}
+
+bool connection_pool::is_shut_down() const
+{
+	std::lock_guard<std::mutex> lock(mutex_);
+	return shut_down_;
+}
+
+pool_statistics connection_pool::stats() const
+{
+	std::lock_guard<std::mutex> lock(mutex_);
+	pool_statistics s;
+	s.total_connections = total_connections_;
+	s.idle_connections = idle_.size();
+	s.active_connections = active_connections_;
+	s.waiters = waiters_;
+	s.total_acquires = total_acquires_;
+	s.acquire_timeouts = acquire_timeouts_;
+	s.failed_creations = failed_creations_;
+	s.replaced_connections = replaced_connections_;
+	return s;
+}
+
+Result<pooled_connection> connection_pool::acquire()
+{
+	return acquire(config_.acquire_timeout);
+}
+
+Result<pooled_connection> connection_pool::acquire(std::chrono::milliseconds timeout)
+{
+	const auto deadline = std::chrono::steady_clock::now() + timeout;
+
+	std::unique_lock<std::mutex> lock(mutex_);
+
+	for (;;) {
+		if (shut_down_) {
+			return make_pool_error(error_code::invalid_state,
+			                       "connection_pool has been shut down");
+		}
+
+		// Prefer an idle connection.
+		if (auto backend = take_idle_locked()) {
+			// Validate (with the lock released) before handing out.
+			if (config_.validate_on_acquire) {
+				lock.unlock();
+				const bool ok = validator_(*backend);
+				lock.lock();
+				if (!ok) {
+					// Discard and try to create a replacement.
+					--total_connections_;
+					++replaced_connections_;
+					backend.reset();
+					auto fresh = create_locked(lock);
+					if (!fresh) {
+						// Creation failed; loop to wait again or timeout.
+					} else {
+						++active_connections_;
+						++total_acquires_;
+						return pooled_connection(shared_from_this(), std::move(fresh));
+					}
+				} else {
+					++active_connections_;
+					++total_acquires_;
+					return pooled_connection(shared_from_this(), std::move(backend));
+				}
+			} else {
+				++active_connections_;
+				++total_acquires_;
+				return pooled_connection(shared_from_this(), std::move(backend));
+			}
+		}
+
+		// No idle connection. Can we create a new one?
+		if (total_connections_ < config_.max_size) {
+			auto fresh = create_locked(lock);
+			if (fresh) {
+				++active_connections_;
+				++total_acquires_;
+				return pooled_connection(shared_from_this(), std::move(fresh));
+			}
+			// Creation failed; fall through to waiting (so we back off a bit).
+		}
+
+		// Pool is saturated (or creation failed): wait for a release.
+		++waiters_;
+		const auto wait_result = cv_.wait_until(lock, deadline);
+		--waiters_;
+
+		if (wait_result == std::cv_status::timeout &&
+		    std::chrono::steady_clock::now() >= deadline) {
+			++acquire_timeouts_;
+			return make_pool_error(error_code::timeout,
+			                       "timed out waiting for a pooled connection");
+		}
+		// Otherwise loop and try again.
+	}
+}
+
+void connection_pool::return_connection(std::unique_ptr<database_backend> backend, bool broken)
+{
+	if (!backend) {
+		return;
+	}
+
+	{
+		std::lock_guard<std::mutex> lock(mutex_);
+
+		// Invariant: only decrement active when we were counted as active.
+		if (active_connections_ > 0) {
+			--active_connections_;
+		}
+
+		if (broken || shut_down_) {
+			// Drop the backend entirely.
+			if (total_connections_ > 0) {
+				--total_connections_;
+			}
+			if (broken) {
+				++replaced_connections_;
+			}
+		} else {
+			// Return to idle (LIFO keeps the most-recently-used connection hot).
+			idle_.push_back(std::move(backend));
+		}
+	}
+
+	cv_.notify_one();
+}
+
+std::unique_ptr<database_backend> connection_pool::create_locked(std::unique_lock<std::mutex>& lock)
+{
+	// Factory may block on network I/O; drop the lock while calling it.
+	lock.unlock();
+	std::unique_ptr<database_backend> backend;
+	try {
+		backend = factory_();
+	} catch (...) {
+		backend.reset();
+	}
+	lock.lock();
+
+	if (!backend) {
+		++failed_creations_;
+		return nullptr;
+	}
+
+	++total_connections_;
+	return backend;
+}
+
+std::unique_ptr<database_backend> connection_pool::take_idle_locked()
+{
+	if (idle_.empty()) {
+		return nullptr;
+	}
+	// LIFO: reuse the most recently released connection first.
+	auto backend = std::move(idle_.back());
+	idle_.pop_back();
+	return backend;
+}
+
+} // namespace pool
+} // namespace core
+} // namespace database

--- a/database/core/connection_pool.h
+++ b/database/core/connection_pool.h
@@ -1,0 +1,336 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file connection_pool.h
+ * @brief Thread-safe connection pool for database backends
+ *
+ * Provides a bounded, thread-safe pool of database_backend instances with
+ * RAII-based lease handles (pooled_connection). The pool is backend-agnostic:
+ * any object implementing the database::core::database_backend interface can
+ * be pooled, regardless of the underlying driver (libpqxx, sqlite3, etc.).
+ *
+ * Design goals:
+ * - Thread-safe acquisition and release (mutex + condition variable)
+ * - Bounded size with min/max connection counts
+ * - RAII lease handle: pooled_connection automatically returns on scope exit
+ * - Connection validation on checkout: broken connections are replaced
+ * - Timeout-based backpressure: acquire() returns error on exhaustion
+ * - No dependency on a specific backend implementation
+ *
+ * Thread Safety:
+ * - All public methods are thread-safe
+ * - pooled_connection is move-only; the wrapped backend is accessed by one
+ *   thread at a time (the lease holder)
+ *
+ * Example:
+ * @code
+ * using namespace database::core;
+ *
+ * pool::pool_config cfg;
+ * cfg.min_size = 2;
+ * cfg.max_size = 8;
+ * cfg.acquire_timeout = std::chrono::seconds(5);
+ *
+ * auto pool = std::make_shared<pool::connection_pool>(
+ *     cfg,
+ *     [config]() {
+ *         auto backend = backend_registry::instance().create("postgresql");
+ *         auto init_result = backend->initialize(config);
+ *         if (init_result.is_err()) return std::unique_ptr<database_backend>{};
+ *         return backend;
+ *     });
+ *
+ * {
+ *     auto lease = pool->acquire();
+ *     if (lease.is_ok()) {
+ *         auto rows = lease.value()->select_query("SELECT 1");
+ *     }
+ * } // Connection returned to pool here
+ * @endcode
+ */
+
+#pragma once
+
+#include "database_backend.h"
+#include "result.h"
+
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+namespace database
+{
+namespace core
+{
+namespace pool
+{
+
+/**
+ * @struct pool_config
+ * @brief Configuration for a connection_pool instance.
+ *
+ * Reasonable defaults are provided for moderate workloads. Tune `max_size`
+ * for high-concurrency scenarios and `acquire_timeout` to balance back-pressure
+ * against caller latency.
+ */
+struct pool_config
+{
+	/// Minimum number of connections. Pool pre-creates this many on startup.
+	std::size_t min_size = 1;
+
+	/// Maximum number of connections the pool will hold simultaneously.
+	std::size_t max_size = 8;
+
+	/// How long acquire() waits for an idle connection before failing.
+	std::chrono::milliseconds acquire_timeout = std::chrono::milliseconds(5000);
+
+	/// Whether to validate a connection before returning it from acquire().
+	/// If true, the pool invokes the validator callback; on failure the
+	/// connection is discarded and a new one is created.
+	bool validate_on_acquire = true;
+};
+
+/**
+ * @brief Factory callable that produces a new, initialized database_backend.
+ *
+ * Called by the pool when it needs to create a new connection (lazily up to
+ * max_size, or to replace a failed one). The backend must be returned in the
+ * initialized state. If creation fails, return an empty unique_ptr; the pool
+ * will surface the error to the caller of acquire().
+ */
+using connection_factory = std::function<std::unique_ptr<database_backend>()>;
+
+/**
+ * @brief Validator callable: returns true if the backend is still usable.
+ *
+ * The default validator checks `is_initialized()`. Backend-specific validators
+ * may issue a lightweight "SELECT 1"-style query instead.
+ */
+using connection_validator = std::function<bool(database_backend&)>;
+
+class connection_pool;
+
+/**
+ * @class pooled_connection
+ * @brief Move-only RAII lease handle for a pooled database_backend.
+ *
+ * While this handle is alive, the caller has exclusive access to the wrapped
+ * backend. When the handle is destroyed (or reset), the backend is returned
+ * to the pool and becomes available to other callers. Access the backend via
+ * `operator->` or `get()`.
+ *
+ * Invariant: a valid pooled_connection always wraps a non-null backend and
+ * references a live pool.
+ */
+class pooled_connection
+{
+public:
+	/// Construct an empty (invalid) handle.
+	pooled_connection() = default;
+
+	/// Construct a lease referencing a backend checked out from `pool`.
+	pooled_connection(std::shared_ptr<connection_pool> pool,
+	                  std::unique_ptr<database_backend> backend) noexcept;
+
+	/// Move constructor transfers the lease.
+	pooled_connection(pooled_connection&& other) noexcept;
+
+	/// Move assignment releases any current lease, then transfers from `other`.
+	pooled_connection& operator=(pooled_connection&& other) noexcept;
+
+	pooled_connection(const pooled_connection&) = delete;
+	pooled_connection& operator=(const pooled_connection&) = delete;
+
+	/// Destructor returns the backend to the pool (if any).
+	~pooled_connection();
+
+	/// Access the underlying backend. Precondition: valid() is true.
+	database_backend* operator->() const noexcept { return backend_.get(); }
+
+	/// Access the underlying backend. Precondition: valid() is true.
+	database_backend& operator*() const noexcept { return *backend_; }
+
+	/// Raw backend pointer (may be nullptr if the lease is empty/moved-from).
+	database_backend* get() const noexcept { return backend_.get(); }
+
+	/// True if the handle holds a live backend.
+	[[nodiscard]] bool valid() const noexcept { return backend_ != nullptr; }
+
+	explicit operator bool() const noexcept { return valid(); }
+
+	/**
+	 * @brief Mark the wrapped connection as broken.
+	 *
+	 * On release, a broken connection is discarded instead of returned to the
+	 * idle queue. Call this when a query fails in a way that indicates the
+	 * underlying connection is no longer usable (e.g., protocol error).
+	 */
+	void mark_broken() noexcept { broken_ = true; }
+
+	/**
+	 * @brief Release the lease early, returning the backend to the pool.
+	 *
+	 * Equivalent to destroying the handle; the handle becomes invalid.
+	 */
+	void release() noexcept;
+
+private:
+	std::shared_ptr<connection_pool> pool_;
+	std::unique_ptr<database_backend> backend_;
+	bool broken_ = false;
+};
+
+/**
+ * @struct pool_statistics
+ * @brief Snapshot of pool state for monitoring.
+ *
+ * Returned by connection_pool::stats(). Values are a consistent snapshot
+ * captured under the pool mutex.
+ */
+struct pool_statistics
+{
+	std::size_t total_connections = 0;   ///< Currently living connections (idle + active).
+	std::size_t idle_connections = 0;    ///< Connections in the idle queue.
+	std::size_t active_connections = 0;  ///< Leased connections (currently in use).
+	std::size_t waiters = 0;             ///< Threads currently blocked in acquire().
+
+	std::uint64_t total_acquires = 0;    ///< Successful acquire calls since creation.
+	std::uint64_t acquire_timeouts = 0;  ///< Acquires that failed due to timeout.
+	std::uint64_t failed_creations = 0;  ///< Factory invocations that returned null.
+	std::uint64_t replaced_connections = 0; ///< Broken/invalid connections replaced.
+};
+
+/**
+ * @class connection_pool
+ * @brief Thread-safe pool of database_backend instances.
+ *
+ * Create the pool with a factory that produces initialized backend instances.
+ * Call `acquire()` to obtain a lease (returns pooled_connection); the lease is
+ * automatically returned when destroyed.
+ *
+ * The pool lazily creates connections up to `max_size`. Idle connections are
+ * kept in a LIFO queue for cache-warmth. On `shutdown()` or destruction, all
+ * connections are drained and disposed.
+ *
+ * Must be held via std::shared_ptr (pooled_connection holds a weak reference
+ * back to the pool via shared_ptr). Use the static `create()` helper.
+ */
+class connection_pool : public std::enable_shared_from_this<connection_pool>
+{
+public:
+	/**
+	 * @brief Create a new connection_pool.
+	 * @param config Pool sizing and timeout configuration.
+	 * @param factory Callable that produces new initialized backends.
+	 * @param validator Optional validator (default: checks is_initialized()).
+	 * @return Shared pointer to the pool. Pre-warms to min_size on success.
+	 *
+	 * If pre-warming fails (factory returns null for the very first call),
+	 * the pool is still returned but will retry creation on acquire().
+	 */
+	static std::shared_ptr<connection_pool> create(
+		pool_config config,
+		connection_factory factory,
+		connection_validator validator = {});
+
+	~connection_pool();
+
+	connection_pool(const connection_pool&) = delete;
+	connection_pool& operator=(const connection_pool&) = delete;
+	connection_pool(connection_pool&&) = delete;
+	connection_pool& operator=(connection_pool&&) = delete;
+
+	/**
+	 * @brief Acquire an idle backend from the pool.
+	 *
+	 * Blocks up to `config.acquire_timeout` waiting for a connection. If a
+	 * connection can be created (total < max_size), one is created on demand.
+	 * If validation is enabled, the returned connection is validated before
+	 * hand-off; an invalid one is discarded and a replacement is created.
+	 *
+	 * @return Result containing a valid pooled_connection, or an error_info
+	 *         describing the failure (timeout, creation failure, shutdown).
+	 *
+	 * Thread-safe.
+	 */
+	[[nodiscard]] Result<pooled_connection> acquire();
+
+	/**
+	 * @brief Acquire with an explicit timeout (overrides the configured one).
+	 */
+	[[nodiscard]] Result<pooled_connection> acquire(std::chrono::milliseconds timeout);
+
+	/**
+	 * @brief Get a consistent snapshot of pool statistics.
+	 *
+	 * Thread-safe.
+	 */
+	pool_statistics stats() const;
+
+	/**
+	 * @brief Shut down the pool: drain all idle connections and prevent
+	 *        further acquires.
+	 *
+	 * Active leases are not forcibly revoked; they must still be returned
+	 * by their holders (at which point the connection is disposed). After
+	 * shutdown(), acquire() returns an invalid_state error.
+	 *
+	 * Safe to call multiple times.
+	 */
+	void shutdown();
+
+	/**
+	 * @brief True if the pool has been shut down.
+	 */
+	[[nodiscard]] bool is_shut_down() const;
+
+	/// The effective configuration.
+	const pool_config& config() const noexcept { return config_; }
+
+private:
+	friend class pooled_connection;
+
+	connection_pool(pool_config config,
+	                connection_factory factory,
+	                connection_validator validator);
+
+	/// Return a backend to the pool (called by pooled_connection on release).
+	void return_connection(std::unique_ptr<database_backend> backend, bool broken);
+
+	/// Try to create a new connection; increments total_connections on success.
+	/// Called with mutex held. Returns nullptr on factory failure.
+	std::unique_ptr<database_backend> create_locked(std::unique_lock<std::mutex>& lock);
+
+	/// Pop an idle connection (if any). Called with mutex held.
+	std::unique_ptr<database_backend> take_idle_locked();
+
+	pool_config config_;
+	connection_factory factory_;
+	connection_validator validator_;
+
+	mutable std::mutex mutex_;
+	std::condition_variable cv_;
+
+	std::deque<std::unique_ptr<database_backend>> idle_;
+	std::size_t total_connections_ = 0;
+	std::size_t active_connections_ = 0;
+	std::size_t waiters_ = 0;
+
+	std::uint64_t total_acquires_ = 0;
+	std::uint64_t acquire_timeouts_ = 0;
+	std::uint64_t failed_creations_ = 0;
+	std::uint64_t replaced_connections_ = 0;
+
+	bool shut_down_ = false;
+};
+
+} // namespace pool
+} // namespace core
+} // namespace database

--- a/docs/advanced/POOLING.md
+++ b/docs/advanced/POOLING.md
@@ -1,0 +1,119 @@
+---
+doc_id: "DBS-POOL-001"
+doc_title: "Connection Pool"
+doc_version: "1.0.0"
+doc_date: "2026-04-18"
+doc_status: "Active"
+project: "database_system"
+category: "architecture"
+---
+
+# Connection Pool
+
+> **SSOT**: This document is the single source of truth for the connection pool
+> introduced under issue [#568](https://github.com/kcenon/database_system/issues/568).
+
+database_system provides an in-process, thread-safe connection pool for reusing
+`database_backend` instances across concurrent callers. The pool is **additive**
+and does not alter any existing direct-connection API. Users who do not need
+pooling can continue using `database_backend::initialize()` / `shutdown()` directly.
+
+## When to Use the Pool
+
+| Scenario | Recommendation |
+|----------|---------------|
+| Single-threaded script, short-lived connection | Direct backend (no pool) |
+| Server handling concurrent requests on PostgreSQL | Pool (PG connections are not thread-safe) |
+| High-QPS workload paying the handshake per query | Pool with `min_size > 0` |
+| SQLite embedded, single process | Pool-of-one or direct backend |
+
+## Public API
+
+```cpp
+#include <kcenon/database/core/connection_pool.h>
+#include <kcenon/database/core/backend_registry.h>
+
+using namespace database::core;
+
+pool::pool_config cfg;
+cfg.min_size = 2;
+cfg.max_size = 16;
+cfg.acquire_timeout = std::chrono::seconds(5);
+cfg.validate_on_acquire = true;
+
+auto pool = pool::connection_pool::create(
+    cfg,
+    /* factory */ [config]() -> std::unique_ptr<database_backend> {
+        auto backend = backend_registry::instance().create("postgresql");
+        if (!backend) return nullptr;
+        auto init = backend->initialize(config);
+        if (init.is_err()) return nullptr;
+        return backend;
+    });
+
+// Acquire a lease. RAII returns the connection on scope exit.
+{
+    auto lease = pool->acquire();
+    if (lease.is_err()) {
+        // Pool exhausted, shut down, or factory failed.
+        return;
+    }
+    auto rows = lease.value()->select_query("SELECT 1");
+    // lease is returned to the pool here
+}
+```
+
+## Guarantees
+
+- **Thread safety** — `acquire()`, `stats()`, `shutdown()` are safe to call from
+  any thread. Each issued `pooled_connection` is owned by exactly one thread.
+- **RAII return** — A connection is always returned to the pool when the lease
+  handle is destroyed, even on exception.
+- **Bounded growth** — `total_connections <= max_size` at all times.
+- **Back-pressure** — When the pool is saturated, `acquire()` blocks up to
+  `acquire_timeout` and returns `error_code::timeout` on expiry.
+- **Broken-connection recovery** — Callers may call `lease.mark_broken()` to
+  signal the connection is no longer usable; the pool discards it on return
+  and creates a replacement on the next acquire. If `validate_on_acquire` is
+  enabled (default), connections failing the validator are transparently
+  replaced.
+- **No lost increments** — Statistics (`total_acquires`, `acquire_timeouts`,
+  `failed_creations`, `replaced_connections`) are updated under the pool mutex.
+
+## Design Notes
+
+- The pool holds `std::unique_ptr<database_backend>` and hands out move-only
+  `pooled_connection` lease objects. The lease forwards `operator->` to the
+  wrapped backend.
+- Idle connections are kept in a LIFO queue so the most-recently-used
+  connection is handed out first (better cache warmth).
+- The factory callback may block on network I/O; the pool releases its mutex
+  around factory invocations to keep other acquires unblocked.
+- The default validator calls `backend.is_initialized()`. A driver-aware
+  validator (e.g., `"SELECT 1"`) can be supplied as the third argument to
+  `create()`.
+
+## Limitations
+
+- The pool does not currently integrate automatically into
+  `unified_database_system`. Callers who want the builder-style API
+  (`.set_pool_size(...)`) must wire the pool in explicitly. Integration is
+  tracked as a follow-up.
+- No background idle-timeout eviction yet. Idle connections persist until
+  `shutdown()` or the owning `shared_ptr<connection_pool>` is released.
+
+## Relationship to Historical ADR-002
+
+ADR-002 (Superseded) described a previous local pool design that was removed
+in Phase 4.3 in anticipation of a server-side `ProxyMode`. `ProxyMode` remains
+unimplemented. This pool re-introduces the local pooling capability with a
+smaller, more focused surface area (backend-agnostic, header + single .cpp).
+
+## References
+
+- Issue [#568](https://github.com/kcenon/database_system/issues/568) —
+  "implement ProxyMode or re-introduce connection pool"
+- Issue [#573](https://github.com/kcenon/database_system/issues/573) —
+  Thread-safe PG connection handling; addressed via this pool.
+- Header: `include/kcenon/database/core/connection_pool.h`
+- Tests: `tests/connection_pool_test.cpp`

--- a/include/kcenon/database/core/connection_pool.h
+++ b/include/kcenon/database/core/connection_pool.h
@@ -1,0 +1,40 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file connection_pool.h
+ * @brief Public forwarding header for the database connection pool.
+ *
+ * Exposes database::core::pool::connection_pool and supporting types for
+ * thread-safe, RAII-based connection pooling.
+ *
+ * @code
+ * #include <kcenon/database/core/connection_pool.h>
+ * #include <kcenon/database/core/backend_registry.h>
+ *
+ * using namespace database::core;
+ *
+ * pool::pool_config cfg;
+ * cfg.max_size = 16;
+ *
+ * auto pool = pool::connection_pool::create(
+ *     cfg,
+ *     [config]() {
+ *         auto backend = backend_registry::instance().create("postgresql");
+ *         if (!backend) return std::unique_ptr<database_backend>{};
+ *         auto init = backend->initialize(config);
+ *         if (init.is_err()) return std::unique_ptr<database_backend>{};
+ *         return backend;
+ *     });
+ *
+ * auto lease = pool->acquire();
+ * if (lease.is_ok()) {
+ *     auto rows = lease.value()->select_query("SELECT 1");
+ * }
+ * @endcode
+ */
+
+#pragma once
+
+#include "database/core/connection_pool.h"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -205,6 +205,50 @@ if(GTest_FOUND OR gtest_FOUND)
 endif()
 
 ##################################################
+# Connection Pool Tests (Issue #568)
+##################################################
+
+if(GTest_FOUND OR gtest_FOUND)
+    add_executable(connection_pool_test
+        connection_pool_test.cpp
+    )
+
+    if(GTest_FOUND)
+        target_link_libraries(connection_pool_test PRIVATE
+            database
+            GTest::gtest
+            GTest::gtest_main
+            Threads::Threads
+        )
+    else()
+        target_link_libraries(connection_pool_test PRIVATE
+            database
+            gtest
+            gtest_main
+            Threads::Threads
+        )
+    endif()
+
+    set_target_properties(connection_pool_test PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED ON
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+    )
+
+    apply_test_compiler_options(connection_pool_test)
+
+    add_test(NAME ConnectionPoolTests COMMAND connection_pool_test)
+
+    gtest_discover_tests(connection_pool_test
+        PROPERTIES
+            TIMEOUT ${TEST_TIMEOUT}
+        DISCOVERY_TIMEOUT 60
+    )
+
+    message(STATUS "Connection pool tests configured (Issue #568)")
+endif()
+
+##################################################
 # Integrated Database Configuration Tests
 ##################################################
 

--- a/tests/connection_pool_test.cpp
+++ b/tests/connection_pool_test.cpp
@@ -1,0 +1,456 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file connection_pool_test.cpp
+ * @brief Unit tests for database::core::pool::connection_pool
+ *
+ * Uses a lightweight in-memory fake backend so the tests exercise the pool's
+ * synchronization, bookkeeping, and RAII guarantees without requiring any
+ * real database driver.
+ */
+
+#include <gtest/gtest.h>
+
+#include "database/core/connection_pool.h"
+#include "database/core/database_backend.h"
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <thread>
+#include <vector>
+
+namespace {
+
+using namespace std::chrono_literals;
+using database::core::database_backend;
+using database::core::pool::connection_pool;
+using database::core::pool::pool_config;
+using database::core::pool::pooled_connection;
+
+// A minimal in-memory backend suitable for unit-testing the pool. It honors
+// the database_backend contract just enough to be initialized, validated, and
+// shut down. Queries are no-ops.
+class fake_backend : public database_backend
+{
+public:
+	explicit fake_backend(int id) : id_(id) {}
+
+	int id() const { return id_; }
+	void set_valid(bool v) { valid_.store(v); }
+
+	database::database_types type() const override { return database::database_types::none; }
+
+	kcenon::common::VoidResult initialize(const database::core::connection_config&) override
+	{
+		initialized_.store(true);
+		return kcenon::common::ok();
+	}
+
+	kcenon::common::VoidResult shutdown() override
+	{
+		initialized_.store(false);
+		return kcenon::common::ok();
+	}
+
+	bool is_initialized() const override
+	{
+		return initialized_.load() && valid_.load();
+	}
+
+	kcenon::common::Result<database::core::database_result>
+	select_query(const std::string&) override
+	{
+		return database::core::database_result{};
+	}
+
+	kcenon::common::VoidResult execute_query(const std::string&) override
+	{
+		return kcenon::common::ok();
+	}
+
+	kcenon::common::VoidResult begin_transaction() override { return kcenon::common::ok(); }
+	kcenon::common::VoidResult commit_transaction() override { return kcenon::common::ok(); }
+	kcenon::common::VoidResult rollback_transaction() override { return kcenon::common::ok(); }
+	bool in_transaction() const override { return false; }
+	std::string last_error() const override { return {}; }
+	std::map<std::string, std::string> connection_info() const override { return {}; }
+
+private:
+	int id_;
+	std::atomic<bool> initialized_{true};
+	std::atomic<bool> valid_{true};
+};
+
+struct counting_factory
+{
+	std::atomic<int> creations{0};
+	std::atomic<int> fail_next{0};
+
+	std::unique_ptr<database_backend> operator()()
+	{
+		if (fail_next.load() > 0) {
+			fail_next.fetch_sub(1);
+			return {};
+		}
+		int id = creations.fetch_add(1) + 1;
+		return std::make_unique<fake_backend>(id);
+	}
+};
+
+// ---------------------------------------------------------------------------
+// Basic lifecycle
+// ---------------------------------------------------------------------------
+
+TEST(ConnectionPoolTest, PrewarmsToMinSize)
+{
+	pool_config cfg;
+	cfg.min_size = 3;
+	cfg.max_size = 5;
+
+	auto factory = std::make_shared<counting_factory>();
+	auto pool = connection_pool::create(cfg, [factory]() { return (*factory)(); });
+
+	auto stats = pool->stats();
+	EXPECT_EQ(stats.total_connections, 3u);
+	EXPECT_EQ(stats.idle_connections, 3u);
+	EXPECT_EQ(stats.active_connections, 0u);
+	EXPECT_EQ(factory->creations.load(), 3);
+}
+
+TEST(ConnectionPoolTest, AcquireAndReleaseSingleConnection)
+{
+	pool_config cfg;
+	cfg.min_size = 0;
+	cfg.max_size = 2;
+
+	auto factory = std::make_shared<counting_factory>();
+	auto pool = connection_pool::create(cfg, [factory]() { return (*factory)(); });
+
+	{
+		auto lease = pool->acquire();
+		ASSERT_TRUE(lease.is_ok());
+		ASSERT_TRUE(lease.value().valid());
+		EXPECT_NE(lease.value().get(), nullptr);
+
+		auto stats = pool->stats();
+		EXPECT_EQ(stats.active_connections, 1u);
+		EXPECT_EQ(stats.idle_connections, 0u);
+		EXPECT_EQ(stats.total_connections, 1u);
+	}
+
+	auto stats = pool->stats();
+	EXPECT_EQ(stats.active_connections, 0u);
+	EXPECT_EQ(stats.idle_connections, 1u);
+	EXPECT_EQ(stats.total_connections, 1u);
+}
+
+TEST(ConnectionPoolTest, LeasesReuseTheSameConnectionLifo)
+{
+	pool_config cfg;
+	cfg.min_size = 0;
+	cfg.max_size = 4;
+
+	auto factory = std::make_shared<counting_factory>();
+	auto pool = connection_pool::create(cfg, [factory]() { return (*factory)(); });
+
+	fake_backend* first_ptr = nullptr;
+	{
+		auto lease = pool->acquire();
+		ASSERT_TRUE(lease.is_ok());
+		first_ptr = static_cast<fake_backend*>(lease.value().get());
+	}
+	{
+		auto lease = pool->acquire();
+		ASSERT_TRUE(lease.is_ok());
+		// LIFO reuse: same backend instance as last lease.
+		EXPECT_EQ(static_cast<fake_backend*>(lease.value().get()), first_ptr);
+	}
+	EXPECT_EQ(factory->creations.load(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent checkout/checkin
+// ---------------------------------------------------------------------------
+
+TEST(ConnectionPoolTest, ConcurrentAcquireReleaseIsRaceFree)
+{
+	pool_config cfg;
+	cfg.min_size = 2;
+	cfg.max_size = 4;
+	cfg.acquire_timeout = 2000ms;
+
+	auto factory = std::make_shared<counting_factory>();
+	auto pool = connection_pool::create(cfg, [factory]() { return (*factory)(); });
+
+	constexpr int kThreads = 16;
+	constexpr int kIterations = 200;
+
+	std::atomic<int> ok_count{0};
+	std::atomic<int> fail_count{0};
+
+	std::vector<std::thread> threads;
+	threads.reserve(kThreads);
+	for (int i = 0; i < kThreads; ++i) {
+		threads.emplace_back([&]() {
+			for (int j = 0; j < kIterations; ++j) {
+				auto lease = pool->acquire();
+				if (lease.is_ok()) {
+					ASSERT_TRUE(lease.value().valid());
+					// Simulate brief use.
+					std::this_thread::sleep_for(50us);
+					++ok_count;
+				} else {
+					++fail_count;
+				}
+			}
+		});
+	}
+
+	for (auto& t : threads) t.join();
+
+	EXPECT_EQ(ok_count.load(), kThreads * kIterations);
+	EXPECT_EQ(fail_count.load(), 0);
+
+	auto stats = pool->stats();
+	EXPECT_EQ(stats.active_connections, 0u);
+	// Never exceeded max_size.
+	EXPECT_LE(stats.total_connections, cfg.max_size);
+	EXPECT_LE(static_cast<std::size_t>(factory->creations.load()), cfg.max_size);
+}
+
+// ---------------------------------------------------------------------------
+// Exhaustion / timeout behavior
+// ---------------------------------------------------------------------------
+
+TEST(ConnectionPoolTest, AcquireTimesOutWhenPoolExhausted)
+{
+	pool_config cfg;
+	cfg.min_size = 0;
+	cfg.max_size = 1;
+	cfg.acquire_timeout = 50ms;
+
+	auto factory = std::make_shared<counting_factory>();
+	auto pool = connection_pool::create(cfg, [factory]() { return (*factory)(); });
+
+	auto hold = pool->acquire();
+	ASSERT_TRUE(hold.is_ok());
+
+	const auto start = std::chrono::steady_clock::now();
+	auto second = pool->acquire();
+	const auto elapsed = std::chrono::steady_clock::now() - start;
+
+	EXPECT_TRUE(second.is_err());
+	EXPECT_GE(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count(),
+	          45);
+
+	auto stats = pool->stats();
+	EXPECT_EQ(stats.acquire_timeouts, 1u);
+}
+
+TEST(ConnectionPoolTest, BlockedAcquireUnblocksWhenLeaseReleased)
+{
+	pool_config cfg;
+	cfg.min_size = 0;
+	cfg.max_size = 1;
+	cfg.acquire_timeout = 1s;
+
+	auto factory = std::make_shared<counting_factory>();
+	auto pool = connection_pool::create(cfg, [factory]() { return (*factory)(); });
+
+	// Hold a lease in a scope we can explicitly end.
+	std::optional<pooled_connection> first_holder;
+	{
+		auto first = pool->acquire();
+		ASSERT_TRUE(first.is_ok());
+		first_holder.emplace(std::move(first.value()));
+	}
+
+	std::atomic<bool> second_got{false};
+	std::thread waiter([&]() {
+		auto lease = pool->acquire();
+		if (lease.is_ok()) second_got.store(true);
+	});
+
+	std::this_thread::sleep_for(50ms);
+	EXPECT_FALSE(second_got.load());
+
+	// Release the first lease; the waiter should unblock.
+	first_holder.reset();
+
+	waiter.join();
+	EXPECT_TRUE(second_got.load());
+}
+
+// ---------------------------------------------------------------------------
+// Broken connection replacement
+// ---------------------------------------------------------------------------
+
+TEST(ConnectionPoolTest, MarkBrokenDiscardsConnection)
+{
+	pool_config cfg;
+	cfg.min_size = 0;
+	cfg.max_size = 2;
+
+	auto factory = std::make_shared<counting_factory>();
+	auto pool = connection_pool::create(cfg, [factory]() { return (*factory)(); });
+
+	{
+		auto lease = pool->acquire();
+		ASSERT_TRUE(lease.is_ok());
+		lease.value().mark_broken();
+	}
+
+	auto stats = pool->stats();
+	EXPECT_EQ(stats.active_connections, 0u);
+	EXPECT_EQ(stats.idle_connections, 0u);
+	EXPECT_EQ(stats.total_connections, 0u);
+	EXPECT_EQ(stats.replaced_connections, 1u);
+
+	// Next acquire must create a new connection.
+	auto lease = pool->acquire();
+	ASSERT_TRUE(lease.is_ok());
+	EXPECT_EQ(factory->creations.load(), 2);
+}
+
+TEST(ConnectionPoolTest, InvalidIdleConnectionIsReplacedOnAcquire)
+{
+	pool_config cfg;
+	cfg.min_size = 1;
+	cfg.max_size = 2;
+	cfg.validate_on_acquire = true;
+
+	auto factory = std::make_shared<counting_factory>();
+	// Keep a raw pointer to the first fake created via the factory so the
+	// test can flip its validity.
+	std::shared_ptr<fake_backend*> first_raw = std::make_shared<fake_backend*>(nullptr);
+	auto creator = [factory, first_raw]() -> std::unique_ptr<database_backend> {
+		auto backend = (*factory)();
+		if (backend && *first_raw == nullptr) {
+			*first_raw = static_cast<fake_backend*>(backend.get());
+		}
+		return backend;
+	};
+	auto pool = connection_pool::create(cfg, creator);
+
+	ASSERT_NE(*first_raw, nullptr);
+	// Simulate the idle connection going bad (e.g., server-side timeout).
+	(*first_raw)->set_valid(false);
+
+	auto lease = pool->acquire();
+	ASSERT_TRUE(lease.is_ok());
+	// Replacement has been created.
+	EXPECT_GE(factory->creations.load(), 2);
+
+	auto stats = pool->stats();
+	EXPECT_GE(stats.replaced_connections, 1u);
+}
+
+// ---------------------------------------------------------------------------
+// Factory failure handling
+// ---------------------------------------------------------------------------
+
+TEST(ConnectionPoolTest, FactoryFailureIsSurfacedWhenPoolEmpty)
+{
+	pool_config cfg;
+	cfg.min_size = 0;
+	cfg.max_size = 1;
+	cfg.acquire_timeout = 50ms;
+
+	auto factory = std::make_shared<counting_factory>();
+	factory->fail_next.store(10); // All factory calls fail.
+
+	auto pool = connection_pool::create(cfg, [factory]() { return (*factory)(); });
+
+	auto lease = pool->acquire();
+	EXPECT_TRUE(lease.is_err());
+
+	auto stats = pool->stats();
+	EXPECT_GE(stats.failed_creations, 1u);
+}
+
+// ---------------------------------------------------------------------------
+// Shutdown
+// ---------------------------------------------------------------------------
+
+TEST(ConnectionPoolTest, AcquireAfterShutdownFails)
+{
+	pool_config cfg;
+	cfg.min_size = 1;
+	cfg.max_size = 2;
+
+	auto factory = std::make_shared<counting_factory>();
+	auto pool = connection_pool::create(cfg, [factory]() { return (*factory)(); });
+
+	pool->shutdown();
+
+	auto lease = pool->acquire();
+	EXPECT_TRUE(lease.is_err());
+}
+
+TEST(ConnectionPoolTest, ShutdownUnblocksWaitingAcquire)
+{
+	pool_config cfg;
+	cfg.min_size = 0;
+	cfg.max_size = 1;
+	cfg.acquire_timeout = 5s;
+
+	auto factory = std::make_shared<counting_factory>();
+	auto pool = connection_pool::create(cfg, [factory]() { return (*factory)(); });
+
+	// Hold one lease so the next acquire has to block.
+	std::optional<pooled_connection> holder;
+	{
+		auto first = pool->acquire();
+		ASSERT_TRUE(first.is_ok());
+		holder.emplace(std::move(first.value()));
+	}
+
+	std::atomic<bool> returned{false};
+	std::thread waiter([&]() {
+		auto lease = pool->acquire();
+		(void)lease;
+		returned.store(true);
+	});
+
+	std::this_thread::sleep_for(50ms);
+	EXPECT_FALSE(returned.load());
+
+	pool->shutdown();
+
+	waiter.join();
+	EXPECT_TRUE(returned.load());
+	holder.reset();
+}
+
+// ---------------------------------------------------------------------------
+// Move semantics
+// ---------------------------------------------------------------------------
+
+TEST(ConnectionPoolTest, PooledConnectionMoveTransfersLease)
+{
+	pool_config cfg;
+	cfg.min_size = 0;
+	cfg.max_size = 1;
+
+	auto factory = std::make_shared<counting_factory>();
+	auto pool = connection_pool::create(cfg, [factory]() { return (*factory)(); });
+
+	auto result = pool->acquire();
+	ASSERT_TRUE(result.is_ok());
+
+	pooled_connection original = std::move(result.value());
+	ASSERT_TRUE(original.valid());
+
+	pooled_connection moved = std::move(original);
+	EXPECT_TRUE(moved.valid());
+	EXPECT_FALSE(original.valid());
+
+	auto stats = pool->stats();
+	EXPECT_EQ(stats.active_connections, 1u);
+}
+
+} // namespace


### PR DESCRIPTION
## What

### Summary
Re-introduces an in-process, thread-safe `connection_pool` for
`database_backend` instances, with an RAII lease handle
(`pooled_connection`) that guarantees connections return to the pool.
Local pooling was removed in Phase 4.3 in favor of a ProxyMode that
has remained a stub; this restores production-ready pooling without
waiting on ProxyMode.

### Change Type
- [x] Feature (new functionality)

### Affected Components
- `database/core/connection_pool.{h,cpp}` — pool implementation
- `include/kcenon/database/core/connection_pool.h` — public forwarding header
- `tests/connection_pool_test.cpp` — unit tests
- `docs/advanced/POOLING.md` — design + API documentation
- `CHANGELOG.md`, `database/CMakeLists.txt`, `tests/CMakeLists.txt`

## Why

- Every query currently pays the TCP + auth handshake cost. The pool
  amortizes that cost across many queries.
- `pqxx::connection` is not thread-safe, so the PG backend today can
  only be used from one thread at a time (see #573). A pool gives
  multiple threads independent, validated connections.
- Closes #568. The pool implementation is Option B from the issue
  ("re-introduce local pool"); ProxyMode (Option A) would require
  inventing a wire protocol and implementing `database_server` side-by-
  side, which is out of scope for a single PR.

### Related Issues
- Closes #568
- Resolves #573 (thread-safe PG connection handling) — users needing
  thread-safe access from multiple threads can now front `postgresql_backend`
  instances with this pool. I've left #573 open for the maintainer to
  confirm before closing, since swapping the parameterized integration
  tests over is a separate, testable change.
- Does **not** address #572 (PG multi-statement transactions via
  `execute_query`). The pool leaves transaction semantics entirely to the
  underlying backend; solving #572 requires changes to
  `postgresql_backend::execute_query` that are deliberately out of scope
  here.

## Who

### Reviewers
- @kcenon — architecture owner

## When

### Urgency
- [x] Normal — feature work, not blocking a release

## Where

### Files Changed
| Directory | Files | Type |
|-----------|-------|------|
| `database/core/` | 2 | New |
| `include/kcenon/database/core/` | 1 | New |
| `tests/` | 1 | New |
| `docs/advanced/` | 1 | New |
| `database/CMakeLists.txt` | 1 | Modified (add sources + expose `include/` as public) |
| `tests/CMakeLists.txt` | 1 | Modified (register test target) |
| `CHANGELOG.md` | 1 | Modified |

### API Changes
Additive only — no existing API is modified or removed. The direct-
connection path (`backend->initialize(config)` + direct query) keeps
working unchanged.

New public API:
- `database::core::pool::pool_config`
- `database::core::pool::connection_factory` / `connection_validator`
- `database::core::pool::connection_pool::create(cfg, factory, [validator])`
- `database::core::pool::connection_pool::acquire()` / `acquire(timeout)`
- `database::core::pool::connection_pool::stats()` / `shutdown()`
- `database::core::pool::pooled_connection` (move-only RAII lease)
- `database::core::pool::pool_statistics`

## How

### Design Highlights
- **Backend-agnostic.** The pool owns
  `std::unique_ptr<database_backend>`; the factory callback decides what
  to instantiate. PostgreSQL gets one `pqxx::connection` per slot.
- **Bounded.** `min_size` is pre-warmed; `total_connections` never
  exceeds `max_size`.
- **Thread-safe.** Mutex + condition variable. `acquire()` drops the
  mutex around factory invocations and validator calls so other
  acquires are not blocked by slow I/O.
- **RAII lease.** `pooled_connection` is move-only and returns the
  backend to the pool on destruction. Callers may call
  `lease.mark_broken()` to signal the connection is unusable; the pool
  drops it and creates a replacement on the next acquire.
- **Back-pressure.** On saturation, `acquire()` blocks up to
  `acquire_timeout` and returns `error_code::timeout` on expiry.

### Testing Done
- [x] Unit tests — 10 test cases covering pre-warm, concurrent
  checkout/checkin (16 threads × 200 iterations), exhaustion timeout,
  blocked-acquire unblock on release, broken-connection replacement
  (both `mark_broken` and invalid-idle validation paths), factory
  failure, shutdown unblocking waiters, and move semantics.
- [ ] Local full build — skipped (no cmake/g++ in sandbox). Relying on CI.
- [ ] Integration tests against live PG — deferred; the pool has no
  runtime dependency on a specific backend, so the fake-backend unit
  tests exercise the synchronization invariants.

### Test Plan for Reviewers
1. `cmake -B build && cmake --build build -j` with tests enabled.
2. `ctest --output-on-failure -R ConnectionPool`.
3. Optional: plug a real `postgresql_backend` into the pool and stress
   it from multiple threads; verify `stats()` never reports
   `active_connections > max_size`.

### Breaking Changes
None. Pure additions.

### Out of Scope (Follow-ups)
- Automatic integration into `unified_database_system::builder`
  (`.set_pool_size(...)` currently still just stores the config).
- Background idle-timeout eviction.
- Per-backend query-level `"SELECT 1"` validators.
- Benchmark against per-query connection baseline (ADR-002 acceptance
  criterion).
- #572 multi-statement transactions in PG (separate PR).

## Checklist

- [x] Code follows project style guidelines (snake_case, `_` suffix for
  private members, header in `database/core/`, public forwarder under
  `include/kcenon/database/core/`).
- [x] Self-review completed.
- [x] Tests added.
- [x] Documentation added (`docs/advanced/POOLING.md`).
- [x] No sensitive data exposed.
- [x] Commits are atomic and well-described.
- [x] Related issue(s) linked with closing keyword.