### PR TITLE
feat(postgres): keep pqxx::work across calls

### DIFF
--- a/database/backends/postgresql_backend.cpp
+++ b/database/backends/postgresql_backend.cpp
@@ -15,6 +15,8 @@
 #include <iomanip>
 #include <variant>
 #include <iostream>
+#include <cctype>
+#include <cstring>
 
 #include "../utils/backend_logger.h"
 
@@ -28,6 +30,33 @@ constexpr unsigned int PG_INT8OID = 20;
 constexpr unsigned int PG_FLOAT4OID = 700;
 constexpr unsigned int PG_FLOAT8OID = 701;
 constexpr unsigned int PG_BOOLOID = 16;
+
+// Case-insensitive check: does `query` begin with `keyword` (surrounded by
+// whitespace/EOS/semicolon)? Used to detect BEGIN / COMMIT / ROLLBACK /
+// ROLLBACK TO ... transaction-control statements in execute_query so the
+// persistent pqxx::work can be opened, committed, or aborted across calls.
+bool query_starts_with(const std::string& query, const char* keyword) {
+	const std::size_t n = std::strlen(keyword);
+	std::size_t i = 0;
+	while (i < query.size() &&
+	       std::isspace(static_cast<unsigned char>(query[i]))) {
+		++i;
+	}
+	if (query.size() - i < n) {
+		return false;
+	}
+	for (std::size_t k = 0; k < n; ++k) {
+		if (std::tolower(static_cast<unsigned char>(query[i + k])) !=
+		    std::tolower(static_cast<unsigned char>(keyword[k]))) {
+			return false;
+		}
+	}
+	if (i + n == query.size()) {
+		return true;
+	}
+	const char c = query[i + n];
+	return std::isspace(static_cast<unsigned char>(c)) || c == ';';
+}
 }
 
 namespace database
@@ -96,6 +125,21 @@ kcenon::common::VoidResult postgresql_backend::do_shutdown()
 	}
 
 #ifdef USE_POSTGRESQL
+	// Safety: if rollback_transaction() couldn't reach the connection for
+	// any reason, drop the active pqxx::work* here before the connection
+	// underneath it is deleted.
+	if (active_txn_ != nullptr) {
+		try {
+			auto* txn = static_cast<pqxx::work*>(active_txn_);
+			txn->abort();
+			delete txn;
+		} catch (...) {
+			// Swallow — the connection teardown below is the recovery path.
+		}
+		active_txn_ = nullptr;
+		in_transaction_ = false;
+	}
+
 	try {
 		delete static_cast<pqxx::connection*>(connection_);
 		connection_ = nullptr;
@@ -329,12 +373,63 @@ kcenon::common::VoidResult postgresql_backend::execute_query(const std::string& 
 			};
 		}
 
-		pqxx::work txn{*static_cast<pqxx::connection*>(connection_)};
-		txn.exec(query_string);
-		txn.commit();
+		auto* conn = static_cast<pqxx::connection*>(connection_);
+
+		// Route through a persistent pqxx::work when a multi-statement txn
+		// is open, so BEGIN / INSERT / COMMIT issued as separate
+		// execute_query calls compose into a single transaction. Without
+		// this, each call would open-and-commit its own pqxx::work,
+		// silently auto-committing every statement and breaking
+		// ROLLBACK / SAVEPOINT / isolation semantics (#572).
+		if (active_txn_ != nullptr) {
+			auto* txn = static_cast<pqxx::work*>(active_txn_);
+			if (query_starts_with(query_string, "COMMIT") ||
+			    query_starts_with(query_string, "END")) {
+				txn->commit();
+				delete txn;
+				active_txn_ = nullptr;
+				in_transaction_ = false;
+			} else if (query_starts_with(query_string, "ROLLBACK") &&
+			           !query_starts_with(query_string, "ROLLBACK TO")) {
+				txn->abort();
+				delete txn;
+				active_txn_ = nullptr;
+				in_transaction_ = false;
+			} else {
+				// SAVEPOINT, RELEASE SAVEPOINT, ROLLBACK TO SAVEPOINT,
+				// and all DML execute within the active txn.
+				txn->exec(query_string);
+			}
+		} else {
+			if (query_starts_with(query_string, "BEGIN") ||
+			    query_starts_with(query_string, "START")) {
+				// Open a persistent txn. pqxx::work's ctor issues BEGIN
+				// internally, so we do not forward the BEGIN query text.
+				active_txn_ = new pqxx::work{*conn};
+				in_transaction_ = true;
+			} else {
+				// Transient auto-transaction (previous behavior).
+				pqxx::work txn{*conn};
+				txn.exec(query_string);
+				txn.commit();
+			}
+		}
+
 		last_error_.clear();
 		return kcenon::common::ok();
 	} catch (const std::exception& e) {
+		// If the active txn is now in a poisoned state (pqxx throws on
+		// committed-or-aborted work, or on a failed exec), drop it so the
+		// next BEGIN can open a fresh one.
+		if (active_txn_ != nullptr) {
+			try {
+				delete static_cast<pqxx::work*>(active_txn_);
+			} catch (...) {
+				// Swallow secondary teardown error; we report the primary.
+			}
+			active_txn_ = nullptr;
+			in_transaction_ = false;
+		}
 		last_error_ = std::string("Execute error: ") + e.what();
 		logger_.error("execute_query", last_error_);
 		return kcenon::common::error_info{

--- a/database/backends/postgresql_backend.h
+++ b/database/backends/postgresql_backend.h
@@ -171,7 +171,8 @@ private:
 	unsigned int execute_modification_query(const std::string& query_string);
 
 	void* connection_{nullptr};                 ///< PostgreSQL connection (PGconn* or pqxx::connection*)
-	std::atomic<bool> in_transaction_{false};   ///< Transaction state
+	std::atomic<bool> in_transaction_{false};   ///< Transaction state (mirrors active_txn_ under USE_POSTGRESQL)
+	void* active_txn_{nullptr};                 ///< Active pqxx::work* when a multi-statement txn is open (USE_POSTGRESQL only; nullptr otherwise)
 	mutable std::string last_error_;            ///< Last error message
 	core::connection_config connection_config_; ///< Cached connection config
 };

--- a/integration_tests/scenarios/parameterized_backend_test.cpp
+++ b/integration_tests/scenarios/parameterized_backend_test.cpp
@@ -106,16 +106,7 @@ TEST_P(BackendParam, TransactionCommitPersists) {
 }
 
 // Scenario 7: BEGIN + INSERT + ROLLBACK leaves no residue.
-//
-// The current PostgreSQL backend wraps each execute_query call in its own
-// pqxx::work that auto-commits, so raw BEGIN/ROLLBACK issued as SQL do not
-// span subsequent statements. Tracked as a backend limitation; skipped on
-// PG to keep the SQLite-side contract under test.
 TEST_P(BackendParam, TransactionRollbackDiscardsWrites) {
-  if (kind() == BackendKind::PostgreSQL) {
-    GTEST_SKIP() << "PG backend auto-commits each statement; multi-statement "
-                    "rollback not supported by current implementation.";
-  }
   ASSERT_TRUE(Create("BEGIN"));
   ASSERT_TRUE(Execute("INSERT INTO " + TableName() +
                       " (name, email, age) VALUES "
@@ -125,15 +116,7 @@ TEST_P(BackendParam, TransactionRollbackDiscardsWrites) {
 }
 
 // Scenario 8: savepoint rollback preserves outer transaction writes.
-//
-// Savepoints require a surrounding transaction, which the PG backend does
-// not currently maintain across execute_query calls (see scenario 7).
-// Skipped on PG until the backend supports explicit transaction scopes.
 TEST_P(BackendParam, NestedSavepointRollbackKeepsOuterWrites) {
-  if (kind() == BackendKind::PostgreSQL) {
-    GTEST_SKIP() << "PG backend does not retain a txn across execute_query "
-                    "calls; SAVEPOINT/ROLLBACK TO SAVEPOINT unsupported.";
-  }
   ASSERT_TRUE(Create("BEGIN"));
   ASSERT_TRUE(Execute("INSERT INTO " + TableName() +
                       " (name, email, age) VALUES "
@@ -153,16 +136,7 @@ TEST_P(BackendParam, NestedSavepointRollbackKeepsOuterWrites) {
 // -----------------------------------------------------------------------------
 
 // Scenario 9: a second session cannot observe uncommitted writes of the first.
-//
-// Requires holding an open transaction across a second-session read. The
-// current PG backend auto-commits each statement so "uncommitted" writes
-// become visible immediately; the scenario is therefore SQLite-only until
-// the backend supports explicit transaction scopes.
 TEST_P(BackendParam, ReadCommittedIsolation) {
-  if (kind() == BackendKind::PostgreSQL) {
-    GTEST_SKIP() << "PG backend auto-commits per statement; cannot hold an "
-                    "uncommitted write across a second-session read.";
-  }
   auto second_ctx = std::make_shared<database_context>();
   auto second = std::make_shared<database_manager>(second_ctx);
   if (kind() == BackendKind::SQLite) {


### PR DESCRIPTION
## What

The PostgreSQL backend's `execute_query` previously wrapped every call in a
fresh `pqxx::work` that committed on scope exit, so raw `BEGIN` / `INSERT` /
`ROLLBACK` issued as separate `execute_query` calls each auto-committed —
multi-statement transactions, savepoints, and read-committed isolation all
silently degraded.

### Change Type
- [x] Feature (brings PG backend in line with SQLite transaction semantics)

### Affected Components
- `database/backends/postgresql_backend.cpp` — transaction routing in `execute_query`, cleanup in `do_shutdown`
- `database/backends/postgresql_backend.h` — adds `void* active_txn_` member
- `integration_tests/scenarios/parameterized_backend_test.cpp` — un-skip 3 scenarios

## Why

Closes #572. Integration tests added under #570 (PR #571) documented the gap
by guarding three PG-specific scenarios with `GTEST_SKIP`. Transactional
semantics are core to any database backend; users who rely on
cross-statement transactions cannot use the PG backend reliably without this.

## Where

- `execute_query` (USE_POSTGRESQL path): route through a persistent
  `pqxx::work` when a multi-statement transaction is open. Detect
  `BEGIN` / `START` to open the work, `COMMIT` / `END` to commit it,
  bare `ROLLBACK` to abort it; `SAVEPOINT` / `RELEASE` /
  `ROLLBACK TO SAVEPOINT` execute within the held work.
- `do_shutdown`: drop any surviving `pqxx::work*` before the connection
  underneath it is destroyed.
- 3 `GTEST_SKIP` guards in `parameterized_backend_test.cpp` removed.

The `HAVE_LIBPQ` (raw libpq) and mock paths are unchanged — `PQexec`
already forwards transaction-control SQL verbatim, so they never had this
bug.

## How

### Implementation highlights

```cpp
if (active_txn_ != nullptr) {
    auto* txn = static_cast<pqxx::work*>(active_txn_);
    if (query_starts_with(q, \"COMMIT\") || query_starts_with(q, \"END\")) {
        txn->commit(); delete txn; active_txn_ = nullptr; in_transaction_ = false;
    } else if (query_starts_with(q, \"ROLLBACK\") && !query_starts_with(q, \"ROLLBACK TO\")) {
        txn->abort();  delete txn; active_txn_ = nullptr; in_transaction_ = false;
    } else {
        txn->exec(q);   // SAVEPOINT/RELEASE/ROLLBACK TO/DML stay inside the txn
    }
} else if (query_starts_with(q, \"BEGIN\") || query_starts_with(q, \"START\")) {
    active_txn_ = new pqxx::work{*conn};  // pqxx::work issues BEGIN internally
    in_transaction_ = true;
} else {
    pqxx::work txn{*conn}; txn.exec(q); txn.commit();  // transient auto-tx
}
```

On exception the active work is dropped so the next `BEGIN` opens a fresh
transaction. A helper `query_starts_with` does case-insensitive keyword
detection with word-boundary awareness so `ROLLBACK TO SAVEPOINT` is not
confused with plain `ROLLBACK`.

### Acceptance Criteria (from #572)
- [x] Raw `BEGIN` / `COMMIT` / `ROLLBACK` / `SAVEPOINT` span multiple
      `execute_query` calls on the same connection
- [x] The three `GTEST_SKIP` guards in `parameterized_backend_test.cpp`
      are removed (scenarios 7, 8, 9)
- [x] No regression on SQLite backend (changes are `#ifdef USE_POSTGRESQL`)
- [x] No regression on existing PG paths: the transient `pqxx::work`
      auto-tx branch is preserved for non-transactional callers

### Test Plan
- CI: integration tests on ubuntu-24.04 / macos-14 / windows-2022 must pass,
  including the three newly-un-skipped scenarios against PostgreSQL
- CI: SQLite scenarios continue to pass unchanged

Local build not performed — ecosystem toolchain unavailable; relying on CI.

### Out of Scope
- The two `GTEST_SKIP` scenarios about concurrent reads/writes
  (`ConcurrentReadsAgreeOnRowCount`, `ConcurrentWritesDistinctRows`)
  remain skipped — those are about libpqxx thread-safety, not
  cross-statement transactions (see #572 \"Relates to\").

### Rollback
Revert of a single commit. No schema migration, no ABI break
(`active_txn_` is a new private member, only visible through internal API).