### PR TITLE
feat(headers): add deprecation forwarding shims at legacy <database/...> paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unit test suite `connection_pool_test` covering pre-warming, concurrent
   checkout/checkin, pool exhaustion, broken-connection replacement, and shutdown.
 
+### Deprecated
+
+- Header path `<database/...>` is deprecated; use `<kcenon/database/...>`.
+  Forwarding stubs at the legacy paths emit `#pragma message` warnings and
+  include the canonical headers. Set `DATABASE_DISABLE_LEGACY_HEADERS=ON` to
+  opt out. Stubs will be removed in the next minor release
+  ([#582](https://github.com/kcenon/database_system/issues/582),
+  part of [#577](https://github.com/kcenon/database_system/issues/577)).
+
 ## [1.0.0] - 2026-04-16
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,13 @@ option(BUILD_INTEGRATED_DATABASE "Build integrated database system with adapter 
 option(DATABASE_BUILD_BENCHMARKS "Build database system benchmarks" OFF)
 option(DATABASE_BUILD_INTEGRATION_TESTS "Build database system integration tests" ON)
 option(ENABLE_COVERAGE "Enable code coverage reporting" OFF)
+# Legacy <database/...> include path support (issue #582).
+# When ON (default), forwarding shims under legacy_include/database/ are exposed
+# in the build interface and installed at <prefix>/include/database/. They emit
+# a #pragma message redirecting consumers to the canonical <kcenon/database/...>
+# path. Set OFF for consumers that have already migrated; the shims are
+# scheduled for removal in the next minor release.
+option(DATABASE_DISABLE_LEGACY_HEADERS "Skip installing forwarding shims at legacy <database/...> paths" OFF)
 
 # Coverage Configuration (DB-006)
 if(ENABLE_COVERAGE)
@@ -452,6 +459,17 @@ if(BUILD_DATABASE)
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
     )
+
+    # Legacy forwarding shims (issue #582). Mirror every public header at
+    # <prefix>/include/database/<rest>.h so external consumers using the
+    # pre-#577 <database/...> form keep building, with a deprecation
+    # #pragma message redirecting them to <kcenon/database/...>.
+    if(NOT DATABASE_DISABLE_LEGACY_HEADERS)
+        install(DIRECTORY legacy_include/database
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+            FILES_MATCHING PATTERN "*.h"
+        )
+    endif()
 
     # --- Tier 2+3: Targets + conditional export --------------------------
     if(_DB_CAN_EXPORT)

--- a/legacy_include/database/adapters/common_system_database_adapter.h
+++ b/legacy_include/database/adapters/common_system_database_adapter.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/adapters/common_system_database_adapter.h
+//
+// External consumers using <database/adapters/common_system_database_adapter.h> should migrate to
+// <kcenon/database/adapters/common_system_database_adapter.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/adapters/common_system_database_adapter.h> is deprecated; use <kcenon/database/adapters/common_system_database_adapter.h>")
+#include <kcenon/database/adapters/common_system_database_adapter.h>

--- a/legacy_include/database/adapters/thread_pool_adapter.h
+++ b/legacy_include/database/adapters/thread_pool_adapter.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/adapters/thread_pool_adapter.h
+//
+// External consumers using <database/adapters/thread_pool_adapter.h> should migrate to
+// <kcenon/database/adapters/thread_pool_adapter.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/adapters/thread_pool_adapter.h> is deprecated; use <kcenon/database/adapters/thread_pool_adapter.h>")
+#include <kcenon/database/adapters/thread_pool_adapter.h>

--- a/legacy_include/database/async/async_operations.h
+++ b/legacy_include/database/async/async_operations.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/async/async_operations.h
+//
+// External consumers using <database/async/async_operations.h> should migrate to
+// <kcenon/database/async/async_operations.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/async/async_operations.h> is deprecated; use <kcenon/database/async/async_operations.h>")
+#include <kcenon/database/async/async_operations.h>

--- a/legacy_include/database/backends/mongodb_backend.h
+++ b/legacy_include/database/backends/mongodb_backend.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/backends/mongodb_backend.h
+//
+// External consumers using <database/backends/mongodb_backend.h> should migrate to
+// <kcenon/database/backends/mongodb_backend.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/backends/mongodb_backend.h> is deprecated; use <kcenon/database/backends/mongodb_backend.h>")
+#include <kcenon/database/backends/mongodb_backend.h>

--- a/legacy_include/database/backends/postgresql_backend.h
+++ b/legacy_include/database/backends/postgresql_backend.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/backends/postgresql_backend.h
+//
+// External consumers using <database/backends/postgresql_backend.h> should migrate to
+// <kcenon/database/backends/postgresql_backend.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/backends/postgresql_backend.h> is deprecated; use <kcenon/database/backends/postgresql_backend.h>")
+#include <kcenon/database/backends/postgresql_backend.h>

--- a/legacy_include/database/backends/redis_backend.h
+++ b/legacy_include/database/backends/redis_backend.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/backends/redis_backend.h
+//
+// External consumers using <database/backends/redis_backend.h> should migrate to
+// <kcenon/database/backends/redis_backend.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/backends/redis_backend.h> is deprecated; use <kcenon/database/backends/redis_backend.h>")
+#include <kcenon/database/backends/redis_backend.h>

--- a/legacy_include/database/backends/sqlite_backend.h
+++ b/legacy_include/database/backends/sqlite_backend.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/backends/sqlite_backend.h
+//
+// External consumers using <database/backends/sqlite_backend.h> should migrate to
+// <kcenon/database/backends/sqlite_backend.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/backends/sqlite_backend.h> is deprecated; use <kcenon/database/backends/sqlite_backend.h>")
+#include <kcenon/database/backends/sqlite_backend.h>

--- a/legacy_include/database/config/feature_flags.h
+++ b/legacy_include/database/config/feature_flags.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/config/feature_flags.h
+//
+// External consumers using <database/config/feature_flags.h> should migrate to
+// <kcenon/database/config/feature_flags.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/config/feature_flags.h> is deprecated; use <kcenon/database/config/feature_flags.h>")
+#include <kcenon/database/config/feature_flags.h>

--- a/legacy_include/database/core/backend_base.h
+++ b/legacy_include/database/core/backend_base.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/core/backend_base.h
+//
+// External consumers using <database/core/backend_base.h> should migrate to
+// <kcenon/database/core/backend_base.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/core/backend_base.h> is deprecated; use <kcenon/database/core/backend_base.h>")
+#include <kcenon/database/core/backend_base.h>

--- a/legacy_include/database/core/backend_registry.h
+++ b/legacy_include/database/core/backend_registry.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/core/backend_registry.h
+//
+// External consumers using <database/core/backend_registry.h> should migrate to
+// <kcenon/database/core/backend_registry.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/core/backend_registry.h> is deprecated; use <kcenon/database/core/backend_registry.h>")
+#include <kcenon/database/core/backend_registry.h>

--- a/legacy_include/database/core/concepts.h
+++ b/legacy_include/database/core/concepts.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/core/concepts.h
+//
+// External consumers using <database/core/concepts.h> should migrate to
+// <kcenon/database/core/concepts.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/core/concepts.h> is deprecated; use <kcenon/database/core/concepts.h>")
+#include <kcenon/database/core/concepts.h>

--- a/legacy_include/database/core/connection_pool.h
+++ b/legacy_include/database/core/connection_pool.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/core/connection_pool.h
+//
+// External consumers using <database/core/connection_pool.h> should migrate to
+// <kcenon/database/core/connection_pool.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/core/connection_pool.h> is deprecated; use <kcenon/database/core/connection_pool.h>")
+#include <kcenon/database/core/connection_pool.h>

--- a/legacy_include/database/core/database_backend.h
+++ b/legacy_include/database/core/database_backend.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/core/database_backend.h
+//
+// External consumers using <database/core/database_backend.h> should migrate to
+// <kcenon/database/core/database_backend.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/core/database_backend.h> is deprecated; use <kcenon/database/core/database_backend.h>")
+#include <kcenon/database/core/database_backend.h>

--- a/legacy_include/database/core/database_context.h
+++ b/legacy_include/database/core/database_context.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/core/database_context.h
+//
+// External consumers using <database/core/database_context.h> should migrate to
+// <kcenon/database/core/database_context.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/core/database_context.h> is deprecated; use <kcenon/database/core/database_context.h>")
+#include <kcenon/database/core/database_context.h>

--- a/legacy_include/database/core/result.h
+++ b/legacy_include/database/core/result.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/core/result.h
+//
+// External consumers using <database/core/result.h> should migrate to
+// <kcenon/database/core/result.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/core/result.h> is deprecated; use <kcenon/database/core/result.h>")
+#include <kcenon/database/core/result.h>

--- a/legacy_include/database/database_manager.h
+++ b/legacy_include/database/database_manager.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/database_manager.h
+//
+// External consumers using <database/database_manager.h> should migrate to
+// <kcenon/database/database_manager.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/database_manager.h> is deprecated; use <kcenon/database/database_manager.h>")
+#include <kcenon/database/database_manager.h>

--- a/legacy_include/database/database_types.h
+++ b/legacy_include/database/database_types.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/database_types.h
+//
+// External consumers using <database/database_types.h> should migrate to
+// <kcenon/database/database_types.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/database_types.h> is deprecated; use <kcenon/database/database_types.h>")
+#include <kcenon/database/database_types.h>

--- a/legacy_include/database/di/service_registration.h
+++ b/legacy_include/database/di/service_registration.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/di/service_registration.h
+//
+// External consumers using <database/di/service_registration.h> should migrate to
+// <kcenon/database/di/service_registration.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/di/service_registration.h> is deprecated; use <kcenon/database/di/service_registration.h>")
+#include <kcenon/database/di/service_registration.h>

--- a/legacy_include/database/forward.h
+++ b/legacy_include/database/forward.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/forward.h
+//
+// External consumers using <database/forward.h> should migrate to
+// <kcenon/database/forward.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/forward.h> is deprecated; use <kcenon/database/forward.h>")
+#include <kcenon/database/forward.h>

--- a/legacy_include/database/integrated/adapters/backends/common_logger_backend.h
+++ b/legacy_include/database/integrated/adapters/backends/common_logger_backend.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/integrated/adapters/backends/common_logger_backend.h
+//
+// External consumers using <database/integrated/adapters/backends/common_logger_backend.h> should migrate to
+// <kcenon/database/integrated/adapters/backends/common_logger_backend.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/integrated/adapters/backends/common_logger_backend.h> is deprecated; use <kcenon/database/integrated/adapters/backends/common_logger_backend.h>")
+#include <kcenon/database/integrated/adapters/backends/common_logger_backend.h>

--- a/legacy_include/database/integrated/adapters/backends/fallback_logger_backend.h
+++ b/legacy_include/database/integrated/adapters/backends/fallback_logger_backend.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/integrated/adapters/backends/fallback_logger_backend.h
+//
+// External consumers using <database/integrated/adapters/backends/fallback_logger_backend.h> should migrate to
+// <kcenon/database/integrated/adapters/backends/fallback_logger_backend.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/integrated/adapters/backends/fallback_logger_backend.h> is deprecated; use <kcenon/database/integrated/adapters/backends/fallback_logger_backend.h>")
+#include <kcenon/database/integrated/adapters/backends/fallback_logger_backend.h>

--- a/legacy_include/database/integrated/adapters/backends/fallback_monitoring_backend.h
+++ b/legacy_include/database/integrated/adapters/backends/fallback_monitoring_backend.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/integrated/adapters/backends/fallback_monitoring_backend.h
+//
+// External consumers using <database/integrated/adapters/backends/fallback_monitoring_backend.h> should migrate to
+// <kcenon/database/integrated/adapters/backends/fallback_monitoring_backend.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/integrated/adapters/backends/fallback_monitoring_backend.h> is deprecated; use <kcenon/database/integrated/adapters/backends/fallback_monitoring_backend.h>")
+#include <kcenon/database/integrated/adapters/backends/fallback_monitoring_backend.h>

--- a/legacy_include/database/integrated/adapters/backends/fallback_thread_backend.h
+++ b/legacy_include/database/integrated/adapters/backends/fallback_thread_backend.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/integrated/adapters/backends/fallback_thread_backend.h
+//
+// External consumers using <database/integrated/adapters/backends/fallback_thread_backend.h> should migrate to
+// <kcenon/database/integrated/adapters/backends/fallback_thread_backend.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/integrated/adapters/backends/fallback_thread_backend.h> is deprecated; use <kcenon/database/integrated/adapters/backends/fallback_thread_backend.h>")
+#include <kcenon/database/integrated/adapters/backends/fallback_thread_backend.h>

--- a/legacy_include/database/integrated/adapters/backends/logger_backend.h
+++ b/legacy_include/database/integrated/adapters/backends/logger_backend.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/integrated/adapters/backends/logger_backend.h
+//
+// External consumers using <database/integrated/adapters/backends/logger_backend.h> should migrate to
+// <kcenon/database/integrated/adapters/backends/logger_backend.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/integrated/adapters/backends/logger_backend.h> is deprecated; use <kcenon/database/integrated/adapters/backends/logger_backend.h>")
+#include <kcenon/database/integrated/adapters/backends/logger_backend.h>

--- a/legacy_include/database/integrated/adapters/backends/monitoring_backend.h
+++ b/legacy_include/database/integrated/adapters/backends/monitoring_backend.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/integrated/adapters/backends/monitoring_backend.h
+//
+// External consumers using <database/integrated/adapters/backends/monitoring_backend.h> should migrate to
+// <kcenon/database/integrated/adapters/backends/monitoring_backend.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/integrated/adapters/backends/monitoring_backend.h> is deprecated; use <kcenon/database/integrated/adapters/backends/monitoring_backend.h>")
+#include <kcenon/database/integrated/adapters/backends/monitoring_backend.h>

--- a/legacy_include/database/integrated/adapters/backends/null_logger_backend.h
+++ b/legacy_include/database/integrated/adapters/backends/null_logger_backend.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/integrated/adapters/backends/null_logger_backend.h
+//
+// External consumers using <database/integrated/adapters/backends/null_logger_backend.h> should migrate to
+// <kcenon/database/integrated/adapters/backends/null_logger_backend.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/integrated/adapters/backends/null_logger_backend.h> is deprecated; use <kcenon/database/integrated/adapters/backends/null_logger_backend.h>")
+#include <kcenon/database/integrated/adapters/backends/null_logger_backend.h>

--- a/legacy_include/database/integrated/adapters/backends/null_monitoring_backend.h
+++ b/legacy_include/database/integrated/adapters/backends/null_monitoring_backend.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/integrated/adapters/backends/null_monitoring_backend.h
+//
+// External consumers using <database/integrated/adapters/backends/null_monitoring_backend.h> should migrate to
+// <kcenon/database/integrated/adapters/backends/null_monitoring_backend.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/integrated/adapters/backends/null_monitoring_backend.h> is deprecated; use <kcenon/database/integrated/adapters/backends/null_monitoring_backend.h>")
+#include <kcenon/database/integrated/adapters/backends/null_monitoring_backend.h>

--- a/legacy_include/database/integrated/adapters/backends/null_thread_backend.h
+++ b/legacy_include/database/integrated/adapters/backends/null_thread_backend.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/integrated/adapters/backends/null_thread_backend.h
+//
+// External consumers using <database/integrated/adapters/backends/null_thread_backend.h> should migrate to
+// <kcenon/database/integrated/adapters/backends/null_thread_backend.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/integrated/adapters/backends/null_thread_backend.h> is deprecated; use <kcenon/database/integrated/adapters/backends/null_thread_backend.h>")
+#include <kcenon/database/integrated/adapters/backends/null_thread_backend.h>

--- a/legacy_include/database/integrated/adapters/backends/system_monitoring_backend.h
+++ b/legacy_include/database/integrated/adapters/backends/system_monitoring_backend.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/integrated/adapters/backends/system_monitoring_backend.h
+//
+// External consumers using <database/integrated/adapters/backends/system_monitoring_backend.h> should migrate to
+// <kcenon/database/integrated/adapters/backends/system_monitoring_backend.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/integrated/adapters/backends/system_monitoring_backend.h> is deprecated; use <kcenon/database/integrated/adapters/backends/system_monitoring_backend.h>")
+#include <kcenon/database/integrated/adapters/backends/system_monitoring_backend.h>

--- a/legacy_include/database/integrated/adapters/backends/thread_backend.h
+++ b/legacy_include/database/integrated/adapters/backends/thread_backend.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/integrated/adapters/backends/thread_backend.h
+//
+// External consumers using <database/integrated/adapters/backends/thread_backend.h> should migrate to
+// <kcenon/database/integrated/adapters/backends/thread_backend.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/integrated/adapters/backends/thread_backend.h> is deprecated; use <kcenon/database/integrated/adapters/backends/thread_backend.h>")
+#include <kcenon/database/integrated/adapters/backends/thread_backend.h>

--- a/legacy_include/database/integrated/adapters/logger_adapter.h
+++ b/legacy_include/database/integrated/adapters/logger_adapter.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/integrated/adapters/logger_adapter.h
+//
+// External consumers using <database/integrated/adapters/logger_adapter.h> should migrate to
+// <kcenon/database/integrated/adapters/logger_adapter.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/integrated/adapters/logger_adapter.h> is deprecated; use <kcenon/database/integrated/adapters/logger_adapter.h>")
+#include <kcenon/database/integrated/adapters/logger_adapter.h>

--- a/legacy_include/database/integrated/adapters/monitoring_adapter.h
+++ b/legacy_include/database/integrated/adapters/monitoring_adapter.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/integrated/adapters/monitoring_adapter.h
+//
+// External consumers using <database/integrated/adapters/monitoring_adapter.h> should migrate to
+// <kcenon/database/integrated/adapters/monitoring_adapter.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/integrated/adapters/monitoring_adapter.h> is deprecated; use <kcenon/database/integrated/adapters/monitoring_adapter.h>")
+#include <kcenon/database/integrated/adapters/monitoring_adapter.h>

--- a/legacy_include/database/integrated/adapters/thread_adapter.h
+++ b/legacy_include/database/integrated/adapters/thread_adapter.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/integrated/adapters/thread_adapter.h
+//
+// External consumers using <database/integrated/adapters/thread_adapter.h> should migrate to
+// <kcenon/database/integrated/adapters/thread_adapter.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/integrated/adapters/thread_adapter.h> is deprecated; use <kcenon/database/integrated/adapters/thread_adapter.h>")
+#include <kcenon/database/integrated/adapters/thread_adapter.h>

--- a/legacy_include/database/integrated/connection_string_builder.h
+++ b/legacy_include/database/integrated/connection_string_builder.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/integrated/connection_string_builder.h
+//
+// External consumers using <database/integrated/connection_string_builder.h> should migrate to
+// <kcenon/database/integrated/connection_string_builder.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/integrated/connection_string_builder.h> is deprecated; use <kcenon/database/integrated/connection_string_builder.h>")
+#include <kcenon/database/integrated/connection_string_builder.h>

--- a/legacy_include/database/integrated/core/common_result.h
+++ b/legacy_include/database/integrated/core/common_result.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/integrated/core/common_result.h
+//
+// External consumers using <database/integrated/core/common_result.h> should migrate to
+// <kcenon/database/integrated/core/common_result.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/integrated/core/common_result.h> is deprecated; use <kcenon/database/integrated/core/common_result.h>")
+#include <kcenon/database/integrated/core/common_result.h>

--- a/legacy_include/database/integrated/core/configuration.h
+++ b/legacy_include/database/integrated/core/configuration.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/integrated/core/configuration.h
+//
+// External consumers using <database/integrated/core/configuration.h> should migrate to
+// <kcenon/database/integrated/core/configuration.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/integrated/core/configuration.h> is deprecated; use <kcenon/database/integrated/core/configuration.h>")
+#include <kcenon/database/integrated/core/configuration.h>

--- a/legacy_include/database/integrated/core/database_coordinator.h
+++ b/legacy_include/database/integrated/core/database_coordinator.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/integrated/core/database_coordinator.h
+//
+// External consumers using <database/integrated/core/database_coordinator.h> should migrate to
+// <kcenon/database/integrated/core/database_coordinator.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/integrated/core/database_coordinator.h> is deprecated; use <kcenon/database/integrated/core/database_coordinator.h>")
+#include <kcenon/database/integrated/core/database_coordinator.h>

--- a/legacy_include/database/integrated/unified_database_system.h
+++ b/legacy_include/database/integrated/unified_database_system.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/integrated/unified_database_system.h
+//
+// External consumers using <database/integrated/unified_database_system.h> should migrate to
+// <kcenon/database/integrated/unified_database_system.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/integrated/unified_database_system.h> is deprecated; use <kcenon/database/integrated/unified_database_system.h>")
+#include <kcenon/database/integrated/unified_database_system.h>

--- a/legacy_include/database/monitoring/performance_monitor.h
+++ b/legacy_include/database/monitoring/performance_monitor.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/monitoring/performance_monitor.h
+//
+// External consumers using <database/monitoring/performance_monitor.h> should migrate to
+// <kcenon/database/monitoring/performance_monitor.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/monitoring/performance_monitor.h> is deprecated; use <kcenon/database/monitoring/performance_monitor.h>")
+#include <kcenon/database/monitoring/performance_monitor.h>

--- a/legacy_include/database/monitoring/pool_metrics.h
+++ b/legacy_include/database/monitoring/pool_metrics.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/monitoring/pool_metrics.h
+//
+// External consumers using <database/monitoring/pool_metrics.h> should migrate to
+// <kcenon/database/monitoring/pool_metrics.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/monitoring/pool_metrics.h> is deprecated; use <kcenon/database/monitoring/pool_metrics.h>")
+#include <kcenon/database/monitoring/pool_metrics.h>

--- a/legacy_include/database/orm/entity.h
+++ b/legacy_include/database/orm/entity.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/orm/entity.h
+//
+// External consumers using <database/orm/entity.h> should migrate to
+// <kcenon/database/orm/entity.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/orm/entity.h> is deprecated; use <kcenon/database/orm/entity.h>")
+#include <kcenon/database/orm/entity.h>

--- a/legacy_include/database/postgres_manager.h
+++ b/legacy_include/database/postgres_manager.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/postgres_manager.h
+//
+// External consumers using <database/postgres_manager.h> should migrate to
+// <kcenon/database/postgres_manager.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/postgres_manager.h> is deprecated; use <kcenon/database/postgres_manager.h>")
+#include <kcenon/database/postgres_manager.h>

--- a/legacy_include/database/protocol/database_protocol.h
+++ b/legacy_include/database/protocol/database_protocol.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/protocol/database_protocol.h
+//
+// External consumers using <database/protocol/database_protocol.h> should migrate to
+// <kcenon/database/protocol/database_protocol.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/protocol/database_protocol.h> is deprecated; use <kcenon/database/protocol/database_protocol.h>")
+#include <kcenon/database/protocol/database_protocol.h>

--- a/legacy_include/database/protocol/database_protocol_container.h
+++ b/legacy_include/database/protocol/database_protocol_container.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/protocol/database_protocol_container.h
+//
+// External consumers using <database/protocol/database_protocol_container.h> should migrate to
+// <kcenon/database/protocol/database_protocol_container.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/protocol/database_protocol_container.h> is deprecated; use <kcenon/database/protocol/database_protocol_container.h>")
+#include <kcenon/database/protocol/database_protocol_container.h>

--- a/legacy_include/database/query/immutable_query_builder.h
+++ b/legacy_include/database/query/immutable_query_builder.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/query/immutable_query_builder.h
+//
+// External consumers using <database/query/immutable_query_builder.h> should migrate to
+// <kcenon/database/query/immutable_query_builder.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/query/immutable_query_builder.h> is deprecated; use <kcenon/database/query/immutable_query_builder.h>")
+#include <kcenon/database/query/immutable_query_builder.h>

--- a/legacy_include/database/query_builder.h
+++ b/legacy_include/database/query_builder.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/query_builder.h
+//
+// External consumers using <database/query_builder.h> should migrate to
+// <kcenon/database/query_builder.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/query_builder.h> is deprecated; use <kcenon/database/query_builder.h>")
+#include <kcenon/database/query_builder.h>

--- a/legacy_include/database/query_builder/condition_builder.h
+++ b/legacy_include/database/query_builder/condition_builder.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/query_builder/condition_builder.h
+//
+// External consumers using <database/query_builder/condition_builder.h> should migrate to
+// <kcenon/database/query_builder/condition_builder.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/query_builder/condition_builder.h> is deprecated; use <kcenon/database/query_builder/condition_builder.h>")
+#include <kcenon/database/query_builder/condition_builder.h>

--- a/legacy_include/database/query_builder/join_builder.h
+++ b/legacy_include/database/query_builder/join_builder.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/query_builder/join_builder.h
+//
+// External consumers using <database/query_builder/join_builder.h> should migrate to
+// <kcenon/database/query_builder/join_builder.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/query_builder/join_builder.h> is deprecated; use <kcenon/database/query_builder/join_builder.h>")
+#include <kcenon/database/query_builder/join_builder.h>

--- a/legacy_include/database/query_builder/sql_dialect.h
+++ b/legacy_include/database/query_builder/sql_dialect.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/query_builder/sql_dialect.h
+//
+// External consumers using <database/query_builder/sql_dialect.h> should migrate to
+// <kcenon/database/query_builder/sql_dialect.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/query_builder/sql_dialect.h> is deprecated; use <kcenon/database/query_builder/sql_dialect.h>")
+#include <kcenon/database/query_builder/sql_dialect.h>

--- a/legacy_include/database/query_builder/value_formatter.h
+++ b/legacy_include/database/query_builder/value_formatter.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/query_builder/value_formatter.h
+//
+// External consumers using <database/query_builder/value_formatter.h> should migrate to
+// <kcenon/database/query_builder/value_formatter.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/query_builder/value_formatter.h> is deprecated; use <kcenon/database/query_builder/value_formatter.h>")
+#include <kcenon/database/query_builder/value_formatter.h>

--- a/legacy_include/database/query_dialect.h
+++ b/legacy_include/database/query_dialect.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/query_dialect.h
+//
+// External consumers using <database/query_dialect.h> should migrate to
+// <kcenon/database/query_dialect.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/query_dialect.h> is deprecated; use <kcenon/database/query_dialect.h>")
+#include <kcenon/database/query_dialect.h>

--- a/legacy_include/database/security/secure_connection.h
+++ b/legacy_include/database/security/secure_connection.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/security/secure_connection.h
+//
+// External consumers using <database/security/secure_connection.h> should migrate to
+// <kcenon/database/security/secure_connection.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/security/secure_connection.h> is deprecated; use <kcenon/database/security/secure_connection.h>")
+#include <kcenon/database/security/secure_connection.h>

--- a/legacy_include/database/utils/backend_logger.h
+++ b/legacy_include/database/utils/backend_logger.h
@@ -1,0 +1,12 @@
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+//
+// DEPRECATED FORWARDING HEADER - DO NOT EDIT
+// Generated from include/kcenon/database/utils/backend_logger.h
+//
+// External consumers using <database/utils/backend_logger.h> should migrate to
+// <kcenon/database/utils/backend_logger.h>. This stub will be removed in the next minor release.
+#pragma once
+#pragma message("Header <database/utils/backend_logger.h> is deprecated; use <kcenon/database/utils/backend_logger.h>")
+#include <kcenon/database/utils/backend_logger.h>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -223,6 +223,15 @@ target_include_directories(${PROJECT_NAME} PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
 )
 
+# Legacy forwarding shims (issue #582). Expose them on the build interface so
+# in-tree consumers that still resolve <database/...> keep compiling. The
+# corresponding install rule lives in the top-level CMakeLists.txt.
+if(NOT DATABASE_DISABLE_LEGACY_HEADERS)
+    target_include_directories(${PROJECT_NAME} INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../legacy_include>
+    )
+endif()
+
 ##################################################
 # Dependencies
 ##################################################


### PR DESCRIPTION
## What

Add 53 deprecation forwarding shims under `legacy_include/database/` that mirror every public header in `include/kcenon/database/`, install them at `<prefix>/include/database/...` matching the pre-EPIC layout, and add `DATABASE_DISABLE_LEGACY_HEADERS` CMake option for consumers that have already migrated.

Closes #582.
Part of #577.

## Why

D1 (#578) moved public headers to `include/kcenon/database/`, but external consumers (notably `pacs_system` and any unknown third parties) still use the legacy `#include <database/...>` form. A hard break would force every consumer to update simultaneously, violating the project's "no flag day" policy. Forwarding shims keep their builds green for one release cycle while emitting visible `#pragma message` warnings that direct them to the new path.

## How

- Each shim file is a 12-line stub with: BSD-3 header, deprecation comment, `#pragma once`, `#pragma message("...")`, and `#include <kcenon/database/...>`.
- File layout under `legacy_include/database/` is a byte-equivalent mirror of `include/kcenon/database/`. Every subdirectory and feature path is replicated.
- CMake additions:
  - Top-level `CMakeLists.txt`: `option(DATABASE_DISABLE_LEGACY_HEADERS ...)` and `install(DIRECTORY legacy_include/database ...)` guarded by the option.
  - `src/CMakeLists.txt`: when option is OFF, expose `legacy_include/` via `target_include_directories(database INTERFACE $<BUILD_INTERFACE:...>)` so an in-tree consumer that still uses `<database/...>` resolves it through the shims (with deprecation warning).
- `CHANGELOG.md`: added `### Deprecated` entry under Unreleased documenting the deprecation, the opt-out flag, and the removal target.

### Static-file vs generator decision

Picked static files over a CMake configure-time generator. Rationale:
- Reviewers can see exactly what gets shipped without running CMake.
- Repository state is self-documenting: `find legacy_include -name "*.h"` lists everything.
- No build-time generation step adds CMake complexity or non-determinism.
- Trade-off: 53 stub files in the repo. Each is 12 lines, machine-generated, identical structure. The generator script was used once and discarded (not committed) per sub-agent guidance.

## Where

| Area | Change |
|------|--------|
| `legacy_include/database/**.h` | New: 53 shim files (1:1 mirror of `include/kcenon/database/`) |
| `CMakeLists.txt` | Added option + install rule |
| `src/CMakeLists.txt` | Added BUILD_INTERFACE include path (option-guarded) |
| `CHANGELOG.md` | Added `### Deprecated` entry under Unreleased |

## Test Plan

- Local cmake/g++ unavailable in sub-agent environment; relied on CI for build verification.
- CI's multi-platform builds will exercise both the canonical includes (in source) and the install step that copies shims.
- Acceptance verification:
  - `find legacy_include -name "*.h" | wc -l` → 53 ✓
  - `find include/kcenon/database -name "*.h" | wc -l` → 53 ✓ (1:1 mirror)
  - Sample shim content inspected (database_manager.h, integrated/.../null_thread_backend.h, query_builder/sql_dialect.h)

## Notes for Reviewers

- **Default behavior**: `DATABASE_DISABLE_LEGACY_HEADERS=OFF` (default) installs the shims at `<prefix>/include/database/...`. Consumers using `<database/...>` see deprecation warnings but still build.
- **Opt-out**: `-DDATABASE_DISABLE_LEGACY_HEADERS=ON` skips installing the shims and skips the BUILD_INTERFACE exposure. Useful for consumers (or CI for `pacs_system` after D6) that want to verify they have completed migration.
- **Removal target**: documented in CHANGELOG under "next minor release". Specific milestone TBD.
- **D4 (CMake decomposition) impact**: this PR adds CMake rules to two files. D4 may consolidate them into a `cmake/legacy_headers.cmake` module. No conflict expected; just refactor location.
- **D6 (pacs downstream) interaction**: pacs will use the new `<kcenon/database/...>` path directly, never going through these shims. The shims protect any other consumer the kcenon org doesn't directly control.

## Rollback

`git revert` of this single squash-merge commit removes all shims, the CMake option, and the CHANGELOG entry. No data, no schema, no behavior change for code that already uses the canonical path.
