### PR TITLE
chore(release): verify SHA512 against actual archive (#588)

### DIFF
--- a/.github/workflows/on-release-sync-registry.yml
+++ b/.github/workflows/on-release-sync-registry.yml
@@ -5,7 +5,66 @@ on:
     types: [published]
 
 jobs:
+  # Defense-in-depth: independently verify the published GitHub release archive
+  # is fetchable and produces a stable SHA512 BEFORE delegating to the shared
+  # sync workflow that will write the SHA into portfile.cmake.
+  #
+  # The downstream reusable workflow
+  # (kcenon/common_system/.github/workflows/sync-vcpkg-registry.yml) was
+  # hardened in kcenon/common_system#676 to compare its computed SHA against
+  # the actual archive. This job adds a second, independent check in this
+  # repo so a release that produces an unfetchable or empty archive fails
+  # fast in this repo's release run, with a clear log line, before the sync
+  # workflow ever runs.
+  #
+  # See kcenon/database_system#588 (parent EPIC kcenon/common_system#674)
+  # and microsoft/vcpkg#51511.
+  verify-archive:
+    name: Verify release archive is fetchable
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify SHA512 against actual GitHub archive
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          ARCHIVE_URL="https://github.com/kcenon/database_system/archive/refs/tags/${TAG}.tar.gz"
+          VERIFY_FILE="/tmp/verify-archive.tar.gz"
+
+          echo "Re-fetching ${ARCHIVE_URL} for independent verification..."
+          # Use --fail so curl returns non-zero on HTTP errors; download to a
+          # file (rather than piping into sha512sum) so a fetch failure cannot
+          # silently produce the empty-input hash cf83e1357eefb8bdf...
+          if ! curl -fsSL --retry 3 --retry-delay 2 -o "${VERIFY_FILE}" "${ARCHIVE_URL}"; then
+            echo "::error::Failed to download release archive for verification: ${ARCHIVE_URL}"
+            exit 1
+          fi
+
+          # Guard against the empty-input hash by requiring a non-empty file.
+          if [[ ! -s "${VERIFY_FILE}" ]]; then
+            echo "::error::Release archive is empty: ${ARCHIVE_URL}"
+            rm -f "${VERIFY_FILE}"
+            exit 1
+          fi
+
+          ACTUAL_SHA=$(sha512sum "${VERIFY_FILE}" | awk '{print $1}')
+          ARCHIVE_SIZE=$(stat -c%s "${VERIFY_FILE}")
+          rm -f "${VERIFY_FILE}"
+
+          # Reject the well-known SHA-512 of empty input as a final safety net.
+          EMPTY_SHA="cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+          if [[ "${ACTUAL_SHA}" == "${EMPTY_SHA}" ]]; then
+            echo "::error::Release archive hashed to the empty-input SHA512; refusing to proceed."
+            exit 1
+          fi
+
+          echo "Release archive verified at ${ARCHIVE_URL}"
+          echo "  size:   ${ARCHIVE_SIZE} bytes"
+          echo "  sha512: ${ACTUAL_SHA}"
+
   sync:
+    needs: verify-archive
     uses: kcenon/common_system/.github/workflows/sync-vcpkg-registry.yml@main
     with:
       port-name: kcenon-database-system


### PR DESCRIPTION
Closes #588

Part of kcenon/common_system#674.

## What

Adds a defense-in-depth `verify-archive` pre-job to `.github/workflows/on-release-sync-registry.yml` that downloads the published GitHub release archive and computes its SHA512 before delegating to the shared sync workflow that writes the SHA into `portfile.cmake`. On any fetch failure, empty archive, or empty-input hash, the job exits 1 with a clear error annotation before the sync workflow runs.

## Why

Detected via [microsoft/vcpkg#51511](https://github.com/microsoft/vcpkg/issues/51511) and [kcenon/vcpkg-registry#87](https://github.com/kcenon/vcpkg-registry/issues/87) - every kcenon port shipped a mismatched SHA512 because the release automation never compared its computed value against the actual archive. Cold-cache vcpkg consumers (new CI runners, fresh users) hit 100% install failure when the SHA in `vcpkg-registry/ports/kcenon-database-system/portfile.cmake` does not match the bytes at `https://github.com/kcenon/database_system/archive/refs/tags/v<version>.tar.gz`.

The downstream reusable workflow (`kcenon/common_system/.github/workflows/sync-vcpkg-registry.yml`) was hardened in [kcenon/common_system#676](https://github.com/kcenon/common_system/pull/676) to compare its computed SHA against the actual archive. This PR adds an independent check in this repo so a release whose archive is unfetchable or empty fails fast in this repo's release run, with a clear log line, before the sync workflow is ever called.

## Where

| File | Change |
|------|--------|
| `.github/workflows/on-release-sync-registry.yml` | New pre-job `verify-archive` and `needs: verify-archive` on the existing `sync` job |

### Audit summary (other workflows considered)

| Workflow | Touches portfile SHA? | Action |
|----------|----------------------|--------|
| `on-release-sync-registry.yml` | Calls reusable SHA-computing workflow in `common_system` | **Hardened (this PR)** - adds independent pre-verification |
| `release.yml` | No (builds and publishes platform artifacts) | No change needed |
| `vcpkg-overlay.yml` | No (local overlay-port build/test, no SHA write) | No change needed |
| `ci.yml`, `sanitizers.yml`, `coverage.yml`, `integration*.yml`, `cve-scan.yml`, `osv-scanner.yml`, `static-analysis.yml`, `sbom.yml`, `benchmarks.yml`, `build-Doxygen.yaml`, `doc-audit.yml` | No portfile SHA computation | No change needed |

The actual SHA computation step lives in `common_system`'s reusable workflow (already hardened by #676). The sensible local addition is a pre-flight verification job in this repo's caller, so a bad release fails fast before delegating.

## How

The new `verify-archive` job runs before the existing `sync` job (declared via `needs: verify-archive`). It re-fetches the archive with `curl -fsSL --retry 3` to a file (not piped) so a 404 cannot silently produce the empty-input SHA512 `cf83e1357eefb8bdf...`. It additionally rejects:

1. Any HTTP error from `curl` (`-fsSL` ensures non-zero exit).
2. An empty archive file (`! -s "${VERIFY_FILE}"`).
3. The empty-input SHA512 constant explicitly, as a belt-and-braces final safety net.

Runtime: ~1-2 s on a typical `database_system` archive (~670 KB).

## Test Plan

### How a reviewer can validate the new job fires

1. Cut a release tag (`v0.x.y`) - the existing `Sync Registry on Release` workflow triggers `verify-archive`, then on success delegates to the `sync` reusable workflow.
2. Inspect the run log for the new job. On a healthy release, the step prints:
   ```
   Re-fetching https://github.com/kcenon/database_system/archive/refs/tags/v0.x.y.tar.gz for independent verification...
   Release archive verified at https://github.com/kcenon/database_system/archive/refs/tags/v0.x.y.tar.gz
     size:   <bytes>
     sha512: <128-char hex digest>
   ```

### Locally executed and confirmed before push

- **Match path** (real `v0.1.1` archive): `curl -fsSL` returns 0, file size 669807 bytes, SHA512 `989aeb716da9e79f...` (non-empty hash).
- **Bad URL path** (nonexistent tag `v999.999.999`): `curl -fsSL` returns 22 (404), the `if !` branch fires `exit 1` with `Failed to download release archive for verification: <URL>`.
- **Empty file path**: rejected by `[[ ! -s ... ]]` check.
- **Empty-input SHA path**: rejected by explicit comparison against the known constant.

The download-to-file pattern (rather than a pipe) is required to make these failure modes detectable - piping into `sha512sum` would otherwise mask the curl failure with the empty-input hash.

YAML structure validated with `js-yaml` (`jobs: verify-archive, sync`; `sync.needs: verify-archive`).

## Breaking Changes

None. The new job is additive; on a successful release it adds ~1-2 s and a few log lines before the existing sync runs. On a SHA mismatch or unfetchable archive (the failure modes this PR is designed to detect) it short-circuits the existing run before the sync workflow is invoked, which is the desired behavior.
