### PR TITLE
refactor(api): align database namespace with kcenon/database path and deprecate legacy_include

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Public forwarding header `kcenon/database/core/connection_pool.h`.
 - Unit test suite `connection_pool_test` covering pre-warming, concurrent
   checkout/checkin, pool exhaustion, broken-connection replacement, and shutdown.
+- Compatibility header `kcenon/database/compat.h` declaring the global namespace
+  alias `namespace database = kcenon::database;`. Pulled in by the foundation
+  headers so pre-#591 source using `database::` (or `::database::`) keeps
+  compiling. Define `DATABASE_DISABLE_LEGACY_NAMESPACE` to build without the
+  alias ([#591](https://github.com/kcenon/database_system/issues/591)).
+
+### Changed
+
+- Internal namespace migrated from `database::` to `kcenon::database::` so the
+  namespace matches the canonical `kcenon/database/...` include path. All in-tree
+  namespace definitions (headers, sources, and C++20 module partitions) now open
+  `kcenon::database`; a tracked backward-compatibility alias keeps the legacy
+  `database::` spelling working for existing consumers
+  ([#591](https://github.com/kcenon/database_system/issues/591)).
+- Relocated the loose `*_manager` / query translation units out of the `src` root
+  into their domain folders: `database_manager.cpp` -> `core/`,
+  `postgres_manager.cpp` -> `backends/`, `query_builder.cpp` and
+  `query_dialect.cpp` -> `query_builder/`. Public include paths are unchanged
+  ([#591](https://github.com/kcenon/database_system/issues/591)).
 
 ### Deprecated
 
 - Header path `<database/...>` is deprecated; use `<kcenon/database/...>`.
   Forwarding stubs at the legacy paths emit `#pragma message` warnings and
   include the canonical headers. Set `DATABASE_DISABLE_LEGACY_HEADERS=ON` to
-  opt out. Stubs will be removed in the next minor release
+  opt out. **Stubs will be removed in version 2.0.0** (removing a public include
+  path is a breaking change, hence a major bump)
   ([#582](https://github.com/kcenon/database_system/issues/582),
   part of [#577](https://github.com/kcenon/database_system/issues/577)).
+- Namespace `database::` is deprecated; use `kcenon::database::`. The compat
+  alias in `kcenon/database/compat.h` keeps the old spelling working. **The alias
+  will be removed in version 2.0.0**, in the same breaking-change window as the
+  legacy `<database/...>` include shims, so consumers migrate include path and
+  namespace together ([#591](https://github.com/kcenon/database_system/issues/591)).
 
 ## [1.0.0] - 2026-04-16
 

--- a/benchmarks/query_execution_bench.cpp
+++ b/benchmarks/query_execution_bench.cpp
@@ -13,7 +13,7 @@
 #include <kcenon/database/database_types.h>
 #include <memory>
 
-using namespace database;
+using namespace kcenon::database;
 
 // Benchmark query builder creation
 static void BM_QueryBuilder_Create(benchmark::State& state) {

--- a/benchmarks/sqlite_io_bench.cpp
+++ b/benchmarks/sqlite_io_bench.cpp
@@ -25,7 +25,7 @@
 #include <memory>
 #include <string>
 
-using namespace database;
+using namespace kcenon::database;
 
 namespace {
 

--- a/benchmarks/transaction_bench.cpp
+++ b/benchmarks/transaction_bench.cpp
@@ -15,7 +15,7 @@
 #include <memory>
 #include <vector>
 
-using namespace database;
+using namespace kcenon::database;
 
 // Mock database for benchmarking
 class mock_transaction_database : public core::database_backend {

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -41,7 +41,7 @@ option(ENABLE_COVERAGE "Enable code coverage reporting" OFF)
 # in the build interface and installed at <prefix>/include/database/. They emit
 # a #pragma message redirecting consumers to the canonical <kcenon/database/...>
 # path. Set OFF for consumers that have already migrated; the shims are
-# scheduled for removal in the next minor release.
+# scheduled for removal in version 2.0.0.
 option(DATABASE_DISABLE_LEGACY_HEADERS "Skip installing forwarding shims at legacy <database/...> paths" OFF)
 
 # Experimental backend warnings

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -850,7 +850,10 @@ db.insert_query(
 ### Code Organization Best Practices
 
 1. **One class per file**: Each class has separate `.h` and `.cpp`
-2. **Namespace organization**: All code in `database` namespace
+2. **Namespace organization**: All code in the `kcenon::database` namespace
+   (matching the canonical `kcenon/database/...` include path). The legacy
+   `database::` spelling remains available via the deprecated alias in
+   `kcenon/database/compat.h` until version 2.0.0 (see CHANGELOG, issue #591).
 3. **Include guards**: Use `#pragma once` for all headers
 4. **Forward declarations**: Minimize header dependencies
 5. **PIMPL idiom**: Hide implementation details where appropriate
@@ -869,11 +872,11 @@ db.insert_query(
 
 **Template**:
 ```cpp
-// include/database/backends/newdb/newdb_manager.h
+// include/kcenon/database/backends/newdb/newdb_manager.h
 #pragma once
 #include <kcenon/database/core/database_base.h>
 
-namespace database {
+namespace kcenon::database {
 
 class newdb_manager : public database_base {
 public:
@@ -885,7 +888,7 @@ public:
     // ... other methods
 };
 
-} // namespace database
+} // namespace kcenon::database
 ```
 
 ---

--- a/examples/basic_connection.cpp
+++ b/examples/basic_connection.cpp
@@ -27,7 +27,7 @@
 #include <kcenon/database/database_manager.h>
 #include <kcenon/database/core/database_context.h>
 
-using namespace database;
+using namespace kcenon::database;
 
 int main()
 {

--- a/examples/connection_pool_demo.cpp
+++ b/examples/connection_pool_demo.cpp
@@ -34,7 +34,7 @@
 #include <kcenon/database/database_manager.h>
 #include <kcenon/database/core/database_context.h>
 
-using namespace database;
+using namespace kcenon::database;
 
 static std::mutex cout_mutex;
 

--- a/examples/error_handling.cpp
+++ b/examples/error_handling.cpp
@@ -27,7 +27,7 @@
 #include <kcenon/database/database_manager.h>
 #include <kcenon/database/core/database_context.h>
 
-using namespace database;
+using namespace kcenon::database;
 
 /**
  * @brief Helper to print a Result error.

--- a/examples/orm_entity_demo.cpp
+++ b/examples/orm_entity_demo.cpp
@@ -27,8 +27,8 @@
 #include <kcenon/database/orm/entity.h>
 #include <kcenon/database/database_types.h>
 
-using namespace database;
-using namespace database::orm;
+using namespace kcenon::database;
+using namespace kcenon::database::orm;
 
 // -------------------------------------------------------
 // Define a User entity

--- a/examples/query_builder_usage.cpp
+++ b/examples/query_builder_usage.cpp
@@ -27,7 +27,7 @@
 #include <kcenon/database/query_builder.h>
 #include <kcenon/database/database_types.h>
 
-using namespace database;
+using namespace kcenon::database;
 
 int main()
 {

--- a/examples/transaction_management.cpp
+++ b/examples/transaction_management.cpp
@@ -25,7 +25,7 @@
 #include <kcenon/database/database_manager.h>
 #include <kcenon/database/core/database_context.h>
 
-using namespace database;
+using namespace kcenon::database;
 
 /**
  * @brief RAII transaction guard that rolls back on destruction unless committed.

--- a/include/kcenon/database/adapters/thread_pool_adapter.h
+++ b/include/kcenon/database/adapters/thread_pool_adapter.h
@@ -38,7 +38,7 @@
     #include <kcenon/common/interfaces/logger_interface.h>
     #include <kcenon/common/interfaces/monitoring_interface.h>
 
-    namespace database::async {
+    namespace kcenon::database::async {
         /**
          * @brief Type alias for thread pool implementation
          * Uses kcenon::thread::thread_pool when thread_system is available
@@ -98,7 +98,7 @@
          */
         constexpr bool using_thread_system = true;
 
-    } // namespace database::async
+    } // namespace kcenon::database::async
 
 #else
     // Fallback to standard library threading
@@ -112,7 +112,7 @@
     #include <variant>
     #include <string>
 
-    namespace database::async {
+    namespace kcenon::database::async {
         /**
          * @brief Fallback thread context (empty implementation)
          * Provides a no-op context when thread_system is not available
@@ -215,6 +215,6 @@
          */
         constexpr bool using_thread_system = false;
 
-    } // namespace database::async
+    } // namespace kcenon::database::async
 
 #endif // USE_THREAD_SYSTEM

--- a/include/kcenon/database/async/async_operations.h
+++ b/include/kcenon/database/async/async_operations.h
@@ -32,7 +32,7 @@
     #include <kcenon/thread/core/error_handling.h>
 #endif
 
-namespace database::async
+namespace kcenon::database::async
 {
 #ifdef USE_THREAD_SYSTEM
 	/**
@@ -1284,4 +1284,4 @@ namespace database::async
 	}
 #endif // HAS_COROUTINES
 
-} // namespace database::async
+} // namespace kcenon::database::async

--- a/include/kcenon/database/backends/mongodb_backend.h
+++ b/include/kcenon/database/backends/mongodb_backend.h
@@ -27,7 +27,7 @@
 #include <atomic>
 #include <mutex>
 
-namespace database
+namespace kcenon::database
 {
 namespace backends
 {
@@ -154,4 +154,4 @@ private:
 };
 
 } // namespace backends
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/backends/postgresql_backend.h
+++ b/include/kcenon/database/backends/postgresql_backend.h
@@ -27,7 +27,7 @@
 #include <vector>
 #include <atomic>
 
-namespace database
+namespace kcenon::database
 {
 namespace backends
 {
@@ -178,4 +178,4 @@ private:
 };
 
 } // namespace backends
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/backends/redis_backend.h
+++ b/include/kcenon/database/backends/redis_backend.h
@@ -27,7 +27,7 @@
 #include <atomic>
 #include <mutex>
 
-namespace database
+namespace kcenon::database
 {
 namespace backends
 {
@@ -141,4 +141,4 @@ private:
 };
 
 } // namespace backends
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/backends/sqlite_backend.h
+++ b/include/kcenon/database/backends/sqlite_backend.h
@@ -27,7 +27,7 @@
 #include <atomic>
 #include <mutex>
 
-namespace database
+namespace kcenon::database
 {
 namespace backends
 {
@@ -150,4 +150,4 @@ private:
 };
 
 } // namespace backends
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/compat.h
+++ b/include/kcenon/database/compat.h
@@ -1,0 +1,47 @@
+// BSD 3-Clause License
+// Copyright (c) 2021-2025
+// See the LICENSE file in the project root for full license information.
+
+#pragma once
+
+/**
+ * @file compat.h
+ * @brief Backward-compatibility namespace alias for the legacy ::database namespace.
+ *
+ * The public include path is `kcenon/database/...` and, as of issue #591, the
+ * internal namespace is `kcenon::database`. Prior to that migration the library
+ * defined its symbols in the top-level `database` namespace, and external
+ * consumers (as well as some in-tree adapters) reference them as `database::...`
+ * or `::database::...`.
+ *
+ * This header declares a global-scope namespace alias
+ *
+ *     namespace database = kcenon::database;
+ *
+ * so that pre-#591 source keeps compiling without changes. The alias is a thin,
+ * zero-cost compatibility shim — it introduces no new symbols, only a second
+ * spelling for `kcenon::database`.
+ *
+ * @deprecated The `database::` spelling is deprecated. Migrate to
+ *             `kcenon::database::`. The alias is scheduled for removal in
+ *             version 2.0.0 (see CHANGELOG.md and docs/MIGRATION.md). This is
+ *             the same lifecycle window as the `<database/...>` legacy include
+ *             shims (issue #582), so consumers can migrate path and namespace
+ *             together.
+ *
+ * Define `DATABASE_DISABLE_LEGACY_NAMESPACE` before including any database_system
+ * header to compile without the alias and surface every remaining `database::`
+ * reference at build time.
+ *
+ * @see https://github.com/kcenon/database_system/issues/591
+ */
+
+#ifndef DATABASE_DISABLE_LEGACY_NAMESPACE
+// Ensure the alias target exists even when this header is included before any
+// other database_system header has opened the namespace. A namespace alias
+// requires its target to be declared.
+namespace kcenon { namespace database {} }
+
+/// @brief Deprecated alias for kcenon::database. Use kcenon::database directly.
+namespace database = kcenon::database;
+#endif

--- a/include/kcenon/database/core/backend_base.h
+++ b/include/kcenon/database/core/backend_base.h
@@ -44,7 +44,7 @@
 #include <memory>
 #include <atomic>
 
-namespace database
+namespace kcenon::database
 {
 namespace core
 {
@@ -173,4 +173,4 @@ protected:
 };
 
 } // namespace core
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/core/backend_registry.h
+++ b/include/kcenon/database/core/backend_registry.h
@@ -50,7 +50,7 @@
 #include <functional>
 #include <mutex>
 
-namespace database
+namespace kcenon::database
 {
 namespace core
 {
@@ -250,4 +250,4 @@ inline std::vector<std::string> available_backends()
 }
 
 } // namespace core
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/core/concepts.h
+++ b/include/kcenon/database/core/concepts.h
@@ -29,7 +29,7 @@
  * @code
  * #include <kcenon/database/core/concepts.h>
  *
- * using namespace database::concepts;
+ * using namespace kcenon::database::concepts;
  *
  * // Use callable concepts for async operations
  * template<Invocable F>
@@ -55,15 +55,15 @@
 #include <future>
 
 // Forward declarations
-namespace database {
+namespace kcenon::database {
 class database_base;
 namespace core {
 class database_backend;
 // database_row is a type alias defined in database_backend.h, not forward-declarable
 } // namespace core
-} // namespace database
+} // namespace kcenon::database
 
-namespace database::concepts {
+namespace kcenon::database::concepts {
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Callable Concepts (adapted from common_system for database_system)
@@ -343,4 +343,4 @@ template<typename F, typename... Args>
 concept VoidTask = VoidCallable<F, Args...> &&
     std::move_constructible<std::decay_t<F>>;
 
-} // namespace database::concepts
+} // namespace kcenon::database::concepts

--- a/include/kcenon/database/core/connection_pool.h
+++ b/include/kcenon/database/core/connection_pool.h
@@ -26,7 +26,7 @@
  *
  * Example:
  * @code
- * using namespace database::core;
+ * using namespace kcenon::database::core;
  *
  * pool::pool_config cfg;
  * cfg.min_size = 2;
@@ -65,7 +65,7 @@
 #include <mutex>
 #include <vector>
 
-namespace database
+namespace kcenon::database
 {
 namespace core
 {
@@ -333,4 +333,4 @@ private:
 
 } // namespace pool
 } // namespace core
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/core/database_backend.h
+++ b/include/kcenon/database/core/database_backend.h
@@ -30,7 +30,7 @@
 #include <map>
 #include <variant>
 
-namespace database
+namespace kcenon::database
 {
 namespace core
 {
@@ -307,4 +307,4 @@ private:
 using backend_factory_fn = std::unique_ptr<database_backend> (*)();
 
 } // namespace core
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/core/database_context.h
+++ b/include/kcenon/database/core/database_context.h
@@ -36,7 +36,7 @@
  * @endcode
  */
 
-namespace database
+namespace kcenon::database
 {
 
 // Forward declarations
@@ -236,4 +236,4 @@ private:
     mutable std::mutex mutex_;
 };
 
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/core/result.h
+++ b/include/kcenon/database/core/result.h
@@ -19,7 +19,9 @@
 
 #include <kcenon/common/patterns/result.h>
 
-namespace database {
+#include <kcenon/database/compat.h>
+
+namespace kcenon::database {
 
 // =============================================================================
 // Primary types - imported from common_system
@@ -51,15 +53,15 @@ enum class error_code {
 	timeout = -7
 };
 
-} // namespace database
+} // namespace kcenon::database
 
 // =============================================================================
 // Integrated namespace for compatibility
 // =============================================================================
 
-namespace database::integrated {
+namespace kcenon::database::integrated {
 	using database::Result;
 	using database::VoidResult;
 	using database::error_info;
 	using database::error_code;
-} // namespace database::integrated
+} // namespace kcenon::database::integrated

--- a/include/kcenon/database/database_manager.h
+++ b/include/kcenon/database/database_manager.h
@@ -15,8 +15,10 @@
 
 #include <kcenon/database/query_builder.h>
 
+#include <kcenon/database/compat.h>
 
-namespace database
+
+namespace kcenon::database
 {
 	/**
 	 * @class database_manager
@@ -176,4 +178,4 @@ namespace database
 		std::string connect_string_; ///< Cached connection string for initialization
 
 	};
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/database_types.h
+++ b/include/kcenon/database/database_types.h
@@ -11,7 +11,9 @@
 
 #include <cstdint>
 
-namespace database
+#include <kcenon/database/compat.h>
+
+namespace kcenon::database
 {
 	/**
 	 * @enum database_types
@@ -69,4 +71,4 @@ namespace database
 		default: return "unknown";
 		}
 	}
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/forward.h
+++ b/include/kcenon/database/forward.h
@@ -8,6 +8,8 @@
  * in the database_system module to reduce compilation dependencies.
  */
 
+#include <kcenon/database/compat.h>
+
 namespace kcenon::database {
 
 /// @name Core classes

--- a/include/kcenon/database/integrated/adapters/backends/common_logger_backend.h
+++ b/include/kcenon/database/integrated/adapters/backends/common_logger_backend.h
@@ -25,7 +25,7 @@
 #include <kcenon/common/interfaces/logger_interface.h>
 #endif
 
-namespace database
+namespace kcenon::database
 {
 namespace integrated
 {
@@ -79,4 +79,4 @@ private:
 } // namespace backends
 } // namespace adapters
 } // namespace integrated
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/integrated/adapters/backends/fallback_logger_backend.h
+++ b/include/kcenon/database/integrated/adapters/backends/fallback_logger_backend.h
@@ -23,7 +23,7 @@
 #include <fstream>
 #include <mutex>
 
-namespace database
+namespace kcenon::database
 {
 namespace integrated
 {
@@ -72,4 +72,4 @@ private:
 } // namespace backends
 } // namespace adapters
 } // namespace integrated
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/integrated/adapters/backends/fallback_monitoring_backend.h
+++ b/include/kcenon/database/integrated/adapters/backends/fallback_monitoring_backend.h
@@ -26,7 +26,7 @@
 #include <unordered_map>
 #include <vector>
 
-namespace database
+namespace kcenon::database
 {
 namespace integrated
 {
@@ -103,4 +103,4 @@ private:
 } // namespace backends
 } // namespace adapters
 } // namespace integrated
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/integrated/adapters/backends/fallback_thread_backend.h
+++ b/include/kcenon/database/integrated/adapters/backends/fallback_thread_backend.h
@@ -27,7 +27,7 @@
 #include <thread>
 #include <vector>
 
-namespace database
+namespace kcenon::database
 {
 namespace integrated
 {
@@ -91,4 +91,4 @@ private:
 } // namespace backends
 } // namespace adapters
 } // namespace integrated
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/integrated/adapters/backends/logger_backend.h
+++ b/include/kcenon/database/integrated/adapters/backends/logger_backend.h
@@ -18,7 +18,7 @@
 
 #include <string>
 
-namespace database
+namespace kcenon::database
 {
 namespace integrated
 {
@@ -73,4 +73,4 @@ public:
 } // namespace backends
 } // namespace adapters
 } // namespace integrated
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/integrated/adapters/backends/monitoring_backend.h
+++ b/include/kcenon/database/integrated/adapters/backends/monitoring_backend.h
@@ -20,7 +20,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace database
+namespace kcenon::database
 {
 namespace integrated
 {
@@ -187,4 +187,4 @@ public:
 } // namespace backends
 } // namespace adapters
 } // namespace integrated
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/integrated/adapters/backends/null_logger_backend.h
+++ b/include/kcenon/database/integrated/adapters/backends/null_logger_backend.h
@@ -17,7 +17,7 @@
 
 #include <kcenon/database/integrated/adapters/backends/logger_backend.h>
 
-namespace database
+namespace kcenon::database
 {
 namespace integrated
 {
@@ -75,4 +75,4 @@ public:
 } // namespace backends
 } // namespace adapters
 } // namespace integrated
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/integrated/adapters/backends/null_monitoring_backend.h
+++ b/include/kcenon/database/integrated/adapters/backends/null_monitoring_backend.h
@@ -18,7 +18,7 @@
 #include <kcenon/database/integrated/adapters/backends/monitoring_backend.h>
 #include <kcenon/database/integrated/adapters/monitoring_adapter.h>
 
-namespace database
+namespace kcenon::database
 {
 namespace integrated
 {
@@ -131,4 +131,4 @@ public:
 } // namespace backends
 } // namespace adapters
 } // namespace integrated
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/integrated/adapters/backends/null_thread_backend.h
+++ b/include/kcenon/database/integrated/adapters/backends/null_thread_backend.h
@@ -17,7 +17,7 @@
 
 #include <kcenon/database/integrated/adapters/backends/thread_backend.h>
 
-namespace database
+namespace kcenon::database
 {
 namespace integrated
 {
@@ -94,4 +94,4 @@ public:
 } // namespace backends
 } // namespace adapters
 } // namespace integrated
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/integrated/adapters/backends/system_monitoring_backend.h
+++ b/include/kcenon/database/integrated/adapters/backends/system_monitoring_backend.h
@@ -33,7 +33,7 @@ namespace monitoring
 }
 }
 
-namespace database
+namespace kcenon::database
 {
 namespace integrated
 {
@@ -128,4 +128,4 @@ private:
 } // namespace backends
 } // namespace adapters
 } // namespace integrated
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/integrated/adapters/backends/thread_backend.h
+++ b/include/kcenon/database/integrated/adapters/backends/thread_backend.h
@@ -20,7 +20,7 @@
 #include <cstddef>
 #include <functional>
 
-namespace database
+namespace kcenon::database
 {
 namespace integrated
 {
@@ -100,4 +100,4 @@ public:
 } // namespace backends
 } // namespace adapters
 } // namespace integrated
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/integrated/adapters/logger_adapter.h
+++ b/include/kcenon/database/integrated/adapters/logger_adapter.h
@@ -25,7 +25,7 @@
  *
  * @example
  * @code
- * using namespace database::integrated;
+ * using namespace kcenon::database::integrated;
  *
  * db_logger_config config;
  * config.enable_query_logging = true;
@@ -73,12 +73,12 @@
 #include <kcenon/database/integrated/core/common_result.h>
 
 // Forward declare backend interface
-namespace database::integrated::adapters::backends
+namespace kcenon::database::integrated::adapters::backends
 {
 	class logger_backend;
 }
 
-namespace database
+namespace kcenon::database
 {
 namespace integrated
 {
@@ -261,4 +261,4 @@ private:
 
 } // namespace adapters
 } // namespace integrated
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/integrated/adapters/monitoring_adapter.h
+++ b/include/kcenon/database/integrated/adapters/monitoring_adapter.h
@@ -23,7 +23,7 @@
  *
  * @example
  * @code
- * using namespace database::integrated;
+ * using namespace kcenon::database::integrated;
  *
  * db_monitoring_config config;
  * config.enable_metrics = true;
@@ -74,12 +74,12 @@
 #include <kcenon/database/integrated/adapters/backends/monitoring_backend.h>
 
 // Forward declare backend class only
-namespace database::integrated::adapters::backends
+namespace kcenon::database::integrated::adapters::backends
 {
 	class monitoring_backend;
 }
 
-namespace database
+namespace kcenon::database
 {
 namespace integrated
 {
@@ -307,4 +307,4 @@ private:
 
 } // namespace adapters
 } // namespace integrated
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/integrated/adapters/thread_adapter.h
+++ b/include/kcenon/database/integrated/adapters/thread_adapter.h
@@ -21,7 +21,7 @@
  *
  * @example
  * @code
- * using namespace database::integrated;
+ * using namespace kcenon::database::integrated;
  *
  * db_thread_config config;
  * config.pool_name = "db_async";
@@ -64,12 +64,12 @@
 #include <kcenon/database/integrated/core/common_result.h>
 
 // Forward declare backend interface
-namespace database::integrated::adapters::backends
+namespace kcenon::database::integrated::adapters::backends
 {
 	class thread_backend;
 }
 
-namespace database
+namespace kcenon::database
 {
 namespace integrated
 {
@@ -240,4 +240,4 @@ auto thread_adapter::submit(F&& f, Args&&... args) -> std::future<std::invoke_re
 
 } // namespace adapters
 } // namespace integrated
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/integrated/connection_string_builder.h
+++ b/include/kcenon/database/integrated/connection_string_builder.h
@@ -11,7 +11,7 @@
  *
  * @example
  * @code
- * using namespace database::integrated;
+ * using namespace kcenon::database::integrated;
  *
  * // PostgreSQL connection string
  * auto pg_conn = connection_string_builder()
@@ -49,7 +49,7 @@
 #include <string_view>
 #include <vector>
 
-namespace database::integrated {
+namespace kcenon::database::integrated {
 
 /**
  * @brief SSL connection mode for database connections
@@ -193,4 +193,4 @@ private:
     [[nodiscard]] static std::string ssl_mode_to_postgres_string(enum ssl_mode mode);
 };
 
-} // namespace database::integrated
+} // namespace kcenon::database::integrated

--- a/include/kcenon/database/integrated/core/configuration.h
+++ b/include/kcenon/database/integrated/core/configuration.h
@@ -13,7 +13,7 @@
  *
  * @example
  * @code
- * using namespace database::integrated;
+ * using namespace kcenon::database::integrated;
  *
  * // Zero-config usage with defaults
  * unified_db_config config_simple;
@@ -35,7 +35,7 @@
 #include <cstdint>
 #include <string>
 
-namespace database
+namespace kcenon::database
 {
 namespace integrated
 {
@@ -480,4 +480,4 @@ struct unified_db_config
 };
 
 } // namespace integrated
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/integrated/core/database_coordinator.h
+++ b/include/kcenon/database/integrated/core/database_coordinator.h
@@ -26,7 +26,7 @@
  *
  * @example
  * @code
- * using namespace database::integrated;
+ * using namespace kcenon::database::integrated;
  *
  * // Create configuration
  * unified_db_config config;
@@ -73,7 +73,7 @@
 #include <kcenon/database/integrated/core/common_result.h>
 
 // Forward declarations to avoid circular dependencies
-namespace database
+namespace kcenon::database
 {
 namespace integrated
 {
@@ -206,4 +206,4 @@ private:
 };
 
 } // namespace integrated
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/integrated/unified_database_system.h
+++ b/include/kcenon/database/integrated/unified_database_system.h
@@ -22,7 +22,7 @@
  * **Example Usage:**
  *
  * @code
- * using namespace database::integrated;
+ * using namespace kcenon::database::integrated;
  *
  * // 1. Zero-config usage (simplest)
  * unified_database_system db;
@@ -87,7 +87,7 @@
 // Include query builder
 #include <kcenon/database/query_builder.h>
 
-namespace database::integrated {
+namespace kcenon::database::integrated {
 
 // Forward declarations
 class database_coordinator;
@@ -664,4 +664,4 @@ inline kcenon::common::Result<std::unique_ptr<unified_database_system>> create_d
         .build();
 }
 
-} // namespace database::integrated
+} // namespace kcenon::database::integrated

--- a/include/kcenon/database/monitoring/performance_monitor.h
+++ b/include/kcenon/database/monitoring/performance_monitor.h
@@ -16,7 +16,7 @@
 #include <functional>
 #include <string>
 
-namespace database::monitoring
+namespace kcenon::database::monitoring
 {
 	// Forward declaration for query_timer
 	class performance_monitor;
@@ -341,4 +341,4 @@ namespace database::monitoring
 	#define MONITOR_QUERY_ERROR(error) \
 		timer_.set_error(error)
 
-} // namespace database::monitoring
+} // namespace kcenon::database::monitoring

--- a/include/kcenon/database/monitoring/pool_metrics.h
+++ b/include/kcenon/database/monitoring/pool_metrics.h
@@ -10,7 +10,7 @@
 #include <map>
 #include <mutex>
 
-namespace database::monitoring {
+namespace kcenon::database::monitoring {
 
 /**
  * @struct pool_metrics
@@ -247,4 +247,4 @@ struct priority_metrics : public pool_metrics {
 };
 #endif // USE_THREAD_SYSTEM
 
-} // namespace database::monitoring
+} // namespace kcenon::database::monitoring

--- a/include/kcenon/database/orm/entity.h
+++ b/include/kcenon/database/orm/entity.h
@@ -16,7 +16,7 @@
 #include <mutex>
 #include <optional>
 
-namespace database::orm
+namespace kcenon::database::orm
 {
 	// Forward declarations
 	class entity_base;
@@ -311,4 +311,4 @@ namespace database::orm
 		return field_constraint::foreign_key;
 	}
 
-} // namespace database::orm
+} // namespace kcenon::database::orm

--- a/include/kcenon/database/postgres_manager.h
+++ b/include/kcenon/database/postgres_manager.h
@@ -6,7 +6,7 @@
 
 #include <kcenon/database/core/database_backend.h>
 
-namespace database
+namespace kcenon::database
 {
 	/**
 	 * @class postgres_manager
@@ -125,4 +125,4 @@ namespace database
 		std::string last_error_;  ///< Last error message
 		std::string connection_string_; ///< Connection string for connection_info
 	};
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/protocol/database_protocol.h
+++ b/include/kcenon/database/protocol/database_protocol.h
@@ -13,7 +13,7 @@
 #include <kcenon/database/database_types.h>
 #include <kcenon/database/core/result.h>
 
-namespace database::protocol {
+namespace kcenon::database::protocol {
 
 /**
  * @enum message_type
@@ -307,4 +307,4 @@ private:
     static std::string read_string(const std::vector<uint8_t>& buffer, size_t& offset);
 };
 
-} // namespace database::protocol
+} // namespace kcenon::database::protocol

--- a/include/kcenon/database/protocol/database_protocol_container.h
+++ b/include/kcenon/database/protocol/database_protocol_container.h
@@ -10,7 +10,7 @@
 #include <core/container.h>
 #include <memory>
 
-namespace database::protocol {
+namespace kcenon::database::protocol {
 
 /**
  * @class container_protocol_serializer
@@ -50,6 +50,6 @@ public:
     static std::string serialize_to_json(const query_request& request);
 };
 
-} // namespace database::protocol
+} // namespace kcenon::database::protocol
 
 #endif // USE_CONTAINER_SYSTEM

--- a/include/kcenon/database/query/immutable_query_builder.h
+++ b/include/kcenon/database/query/immutable_query_builder.h
@@ -12,7 +12,7 @@
 #include <optional>
 #include <memory>
 
-namespace database
+namespace kcenon::database
 {
 	/**
 	 * @class immutable_query_builder
@@ -163,4 +163,4 @@ namespace database
 		std::string join_type_to_string(join_type type) const;
 	};
 
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/query_builder.h
+++ b/include/kcenon/database/query_builder.h
@@ -14,7 +14,7 @@
 #include <memory>
 #include <initializer_list>
 
-namespace database
+namespace kcenon::database
 {
 	/**
 	 * @enum join_type
@@ -163,4 +163,4 @@ namespace database
 		void ensure_dialect();
 	};
 
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/query_builder/condition_builder.h
+++ b/include/kcenon/database/query_builder/condition_builder.h
@@ -10,7 +10,7 @@
 #include <vector>
 #include <memory>
 
-namespace database::query {
+namespace kcenon::database::query {
 
 /**
  * @enum logical_op
@@ -144,4 +144,4 @@ private:
     std::string logical_op_to_string(logical_op op) const;
 };
 
-} // namespace database::query
+} // namespace kcenon::database::query

--- a/include/kcenon/database/query_builder/join_builder.h
+++ b/include/kcenon/database/query_builder/join_builder.h
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-namespace database::query {
+namespace kcenon::database::query {
 
 /**
  * @enum join_type
@@ -153,4 +153,4 @@ private:
     std::string join_type_to_string(join_type type) const;
 };
 
-} // namespace database::query
+} // namespace kcenon::database::query

--- a/include/kcenon/database/query_builder/sql_dialect.h
+++ b/include/kcenon/database/query_builder/sql_dialect.h
@@ -10,7 +10,7 @@
 #include <memory>
 #include <vector>
 
-namespace database::query {
+namespace kcenon::database::query {
 
 /**
  * @class sql_dialect
@@ -188,4 +188,4 @@ public:
     bool supports_feature(const std::string& feature) const override;
 };
 
-} // namespace database::query
+} // namespace kcenon::database::query

--- a/include/kcenon/database/query_builder/value_formatter.h
+++ b/include/kcenon/database/query_builder/value_formatter.h
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-namespace database::query {
+namespace kcenon::database::query {
 
 /**
  * @class value_formatter
@@ -85,4 +85,4 @@ private:
     std::string escape_sqlite_string(const std::string& str) const;
 };
 
-} // namespace database::query
+} // namespace kcenon::database::query

--- a/include/kcenon/database/query_dialect.h
+++ b/include/kcenon/database/query_dialect.h
@@ -13,7 +13,7 @@
 #include <map>
 #include <variant>
 
-namespace database
+namespace kcenon::database
 {
 	// Forward declarations
 	class query_condition;
@@ -304,4 +304,4 @@ namespace database
 	 */
 	std::unique_ptr<query_dialect> create_dialect(database_types type);
 
-} // namespace database
+} // namespace kcenon::database

--- a/include/kcenon/database/security/secure_connection.h
+++ b/include/kcenon/database/security/secure_connection.h
@@ -15,7 +15,7 @@
 #include <functional>
 #include <optional>
 
-namespace database::security
+namespace kcenon::database::security
 {
 	/**
 	 * @enum encryption_type
@@ -433,4 +433,4 @@ namespace database::security
 	}
 
 
-} // namespace database::security
+} // namespace kcenon::database::security

--- a/include/kcenon/database/utils/backend_logger.h
+++ b/include/kcenon/database/utils/backend_logger.h
@@ -23,7 +23,7 @@
 #include <string>
 #include <string_view>
 
-namespace database
+namespace kcenon::database
 {
 namespace utils
 {
@@ -110,4 +110,4 @@ private:
 };
 
 } // namespace utils
-} // namespace database
+} // namespace kcenon::database

--- a/integration_tests/failures/error_handling_test.cpp
+++ b/integration_tests/failures/error_handling_test.cpp
@@ -9,8 +9,8 @@
 #include "framework/system_fixture.h"
 #include "framework/test_helpers.h"
 
-using namespace database;
-using namespace database::testing;
+using namespace kcenon::database;
+using namespace kcenon::database::testing;
 
 /**
  * @brief Test suite for error handling and failure scenarios.

--- a/integration_tests/framework/backend_fixture.h
+++ b/integration_tests/framework/backend_fixture.h
@@ -17,7 +17,7 @@
 #include <thread>
 #include <vector>
 
-namespace database::testing {
+namespace kcenon::database::testing {
 
 /**
  * @enum BackendKind
@@ -250,4 +250,4 @@ struct BackendParamName {
   }
 };
 
-} // namespace database::testing
+} // namespace kcenon::database::testing

--- a/integration_tests/framework/system_fixture.h
+++ b/integration_tests/framework/system_fixture.h
@@ -13,7 +13,7 @@
 #include <string>
 #include <thread>
 
-namespace database::testing {
+namespace kcenon::database::testing {
 /**
  * @class DatabaseSystemFixture
  * @brief Base test fixture for database system integration tests.
@@ -214,4 +214,4 @@ protected:
   bool connected_{false};
 };
 
-} // namespace database::testing
+} // namespace kcenon::database::testing

--- a/integration_tests/framework/test_helpers.h
+++ b/integration_tests/framework/test_helpers.h
@@ -13,7 +13,7 @@
 #include <string>
 #include <vector>
 
-namespace database::testing {
+namespace kcenon::database::testing {
 /**
  * @class PerformanceTimer
  * @brief Simple timer for measuring performance.
@@ -278,4 +278,4 @@ double MeasureThroughput(Func &&func, std::chrono::milliseconds duration) {
   return operations / seconds;
 }
 
-} // namespace database::testing
+} // namespace kcenon::database::testing

--- a/integration_tests/performance/database_performance_test.cpp
+++ b/integration_tests/performance/database_performance_test.cpp
@@ -8,8 +8,8 @@
 #include "framework/system_fixture.h"
 #include "framework/test_helpers.h"
 
-using namespace database;
-using namespace database::testing;
+using namespace kcenon::database;
+using namespace kcenon::database::testing;
 
 /**
  * @brief Test suite for database performance scenarios.

--- a/integration_tests/scenarios/parameterized_backend_test.cpp
+++ b/integration_tests/scenarios/parameterized_backend_test.cpp
@@ -16,7 +16,7 @@
 #include <thread>
 #include <vector>
 
-namespace database::testing {
+namespace kcenon::database::testing {
 
 using BackendParam = ParameterizedBackendFixture;
 
@@ -370,4 +370,4 @@ INSTANTIATE_TEST_SUITE_P(
     MultiBackend, BackendParam,
     ::testing::ValuesIn(EnabledBackends()), BackendParamName());
 
-} // namespace database::testing
+} // namespace kcenon::database::testing

--- a/integration_tests/scenarios/query_execution_test.cpp
+++ b/integration_tests/scenarios/query_execution_test.cpp
@@ -7,8 +7,8 @@
 #include "framework/system_fixture.h"
 #include "framework/test_helpers.h"
 
-using namespace database;
-using namespace database::testing;
+using namespace kcenon::database;
+using namespace kcenon::database::testing;
 
 // Helper function to extract string from variant
 inline std::string get_string_value(const core::database_value& val) {

--- a/legacy_include/database/adapters/common_system_database_adapter.h
+++ b/legacy_include/database/adapters/common_system_database_adapter.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/adapters/common_system_database_adapter.h
 //
 // External consumers using <database/adapters/common_system_database_adapter.h> should migrate to
-// <kcenon/database/adapters/common_system_database_adapter.h>. This stub will be removed in the next minor release.
+// <kcenon/database/adapters/common_system_database_adapter.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/adapters/common_system_database_adapter.h> is deprecated; use <kcenon/database/adapters/common_system_database_adapter.h>")
 #include <kcenon/database/adapters/common_system_database_adapter.h>

--- a/legacy_include/database/adapters/thread_pool_adapter.h
+++ b/legacy_include/database/adapters/thread_pool_adapter.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/adapters/thread_pool_adapter.h
 //
 // External consumers using <database/adapters/thread_pool_adapter.h> should migrate to
-// <kcenon/database/adapters/thread_pool_adapter.h>. This stub will be removed in the next minor release.
+// <kcenon/database/adapters/thread_pool_adapter.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/adapters/thread_pool_adapter.h> is deprecated; use <kcenon/database/adapters/thread_pool_adapter.h>")
 #include <kcenon/database/adapters/thread_pool_adapter.h>

--- a/legacy_include/database/async/async_operations.h
+++ b/legacy_include/database/async/async_operations.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/async/async_operations.h
 //
 // External consumers using <database/async/async_operations.h> should migrate to
-// <kcenon/database/async/async_operations.h>. This stub will be removed in the next minor release.
+// <kcenon/database/async/async_operations.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/async/async_operations.h> is deprecated; use <kcenon/database/async/async_operations.h>")
 #include <kcenon/database/async/async_operations.h>

--- a/legacy_include/database/backends/mongodb_backend.h
+++ b/legacy_include/database/backends/mongodb_backend.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/backends/mongodb_backend.h
 //
 // External consumers using <database/backends/mongodb_backend.h> should migrate to
-// <kcenon/database/backends/mongodb_backend.h>. This stub will be removed in the next minor release.
+// <kcenon/database/backends/mongodb_backend.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/backends/mongodb_backend.h> is deprecated; use <kcenon/database/backends/mongodb_backend.h>")
 #include <kcenon/database/backends/mongodb_backend.h>

--- a/legacy_include/database/backends/postgresql_backend.h
+++ b/legacy_include/database/backends/postgresql_backend.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/backends/postgresql_backend.h
 //
 // External consumers using <database/backends/postgresql_backend.h> should migrate to
-// <kcenon/database/backends/postgresql_backend.h>. This stub will be removed in the next minor release.
+// <kcenon/database/backends/postgresql_backend.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/backends/postgresql_backend.h> is deprecated; use <kcenon/database/backends/postgresql_backend.h>")
 #include <kcenon/database/backends/postgresql_backend.h>

--- a/legacy_include/database/backends/redis_backend.h
+++ b/legacy_include/database/backends/redis_backend.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/backends/redis_backend.h
 //
 // External consumers using <database/backends/redis_backend.h> should migrate to
-// <kcenon/database/backends/redis_backend.h>. This stub will be removed in the next minor release.
+// <kcenon/database/backends/redis_backend.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/backends/redis_backend.h> is deprecated; use <kcenon/database/backends/redis_backend.h>")
 #include <kcenon/database/backends/redis_backend.h>

--- a/legacy_include/database/backends/sqlite_backend.h
+++ b/legacy_include/database/backends/sqlite_backend.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/backends/sqlite_backend.h
 //
 // External consumers using <database/backends/sqlite_backend.h> should migrate to
-// <kcenon/database/backends/sqlite_backend.h>. This stub will be removed in the next minor release.
+// <kcenon/database/backends/sqlite_backend.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/backends/sqlite_backend.h> is deprecated; use <kcenon/database/backends/sqlite_backend.h>")
 #include <kcenon/database/backends/sqlite_backend.h>

--- a/legacy_include/database/config/feature_flags.h
+++ b/legacy_include/database/config/feature_flags.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/config/feature_flags.h
 //
 // External consumers using <database/config/feature_flags.h> should migrate to
-// <kcenon/database/config/feature_flags.h>. This stub will be removed in the next minor release.
+// <kcenon/database/config/feature_flags.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/config/feature_flags.h> is deprecated; use <kcenon/database/config/feature_flags.h>")
 #include <kcenon/database/config/feature_flags.h>

--- a/legacy_include/database/core/backend_base.h
+++ b/legacy_include/database/core/backend_base.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/core/backend_base.h
 //
 // External consumers using <database/core/backend_base.h> should migrate to
-// <kcenon/database/core/backend_base.h>. This stub will be removed in the next minor release.
+// <kcenon/database/core/backend_base.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/core/backend_base.h> is deprecated; use <kcenon/database/core/backend_base.h>")
 #include <kcenon/database/core/backend_base.h>

--- a/legacy_include/database/core/backend_registry.h
+++ b/legacy_include/database/core/backend_registry.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/core/backend_registry.h
 //
 // External consumers using <database/core/backend_registry.h> should migrate to
-// <kcenon/database/core/backend_registry.h>. This stub will be removed in the next minor release.
+// <kcenon/database/core/backend_registry.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/core/backend_registry.h> is deprecated; use <kcenon/database/core/backend_registry.h>")
 #include <kcenon/database/core/backend_registry.h>

--- a/legacy_include/database/core/concepts.h
+++ b/legacy_include/database/core/concepts.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/core/concepts.h
 //
 // External consumers using <database/core/concepts.h> should migrate to
-// <kcenon/database/core/concepts.h>. This stub will be removed in the next minor release.
+// <kcenon/database/core/concepts.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/core/concepts.h> is deprecated; use <kcenon/database/core/concepts.h>")
 #include <kcenon/database/core/concepts.h>

--- a/legacy_include/database/core/connection_pool.h
+++ b/legacy_include/database/core/connection_pool.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/core/connection_pool.h
 //
 // External consumers using <database/core/connection_pool.h> should migrate to
-// <kcenon/database/core/connection_pool.h>. This stub will be removed in the next minor release.
+// <kcenon/database/core/connection_pool.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/core/connection_pool.h> is deprecated; use <kcenon/database/core/connection_pool.h>")
 #include <kcenon/database/core/connection_pool.h>

--- a/legacy_include/database/core/database_backend.h
+++ b/legacy_include/database/core/database_backend.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/core/database_backend.h
 //
 // External consumers using <database/core/database_backend.h> should migrate to
-// <kcenon/database/core/database_backend.h>. This stub will be removed in the next minor release.
+// <kcenon/database/core/database_backend.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/core/database_backend.h> is deprecated; use <kcenon/database/core/database_backend.h>")
 #include <kcenon/database/core/database_backend.h>

--- a/legacy_include/database/core/database_context.h
+++ b/legacy_include/database/core/database_context.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/core/database_context.h
 //
 // External consumers using <database/core/database_context.h> should migrate to
-// <kcenon/database/core/database_context.h>. This stub will be removed in the next minor release.
+// <kcenon/database/core/database_context.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/core/database_context.h> is deprecated; use <kcenon/database/core/database_context.h>")
 #include <kcenon/database/core/database_context.h>

--- a/legacy_include/database/core/result.h
+++ b/legacy_include/database/core/result.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/core/result.h
 //
 // External consumers using <database/core/result.h> should migrate to
-// <kcenon/database/core/result.h>. This stub will be removed in the next minor release.
+// <kcenon/database/core/result.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/core/result.h> is deprecated; use <kcenon/database/core/result.h>")
 #include <kcenon/database/core/result.h>

--- a/legacy_include/database/database_manager.h
+++ b/legacy_include/database/database_manager.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/database_manager.h
 //
 // External consumers using <database/database_manager.h> should migrate to
-// <kcenon/database/database_manager.h>. This stub will be removed in the next minor release.
+// <kcenon/database/database_manager.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/database_manager.h> is deprecated; use <kcenon/database/database_manager.h>")
 #include <kcenon/database/database_manager.h>

--- a/legacy_include/database/database_types.h
+++ b/legacy_include/database/database_types.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/database_types.h
 //
 // External consumers using <database/database_types.h> should migrate to
-// <kcenon/database/database_types.h>. This stub will be removed in the next minor release.
+// <kcenon/database/database_types.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/database_types.h> is deprecated; use <kcenon/database/database_types.h>")
 #include <kcenon/database/database_types.h>

--- a/legacy_include/database/di/service_registration.h
+++ b/legacy_include/database/di/service_registration.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/di/service_registration.h
 //
 // External consumers using <database/di/service_registration.h> should migrate to
-// <kcenon/database/di/service_registration.h>. This stub will be removed in the next minor release.
+// <kcenon/database/di/service_registration.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/di/service_registration.h> is deprecated; use <kcenon/database/di/service_registration.h>")
 #include <kcenon/database/di/service_registration.h>

--- a/legacy_include/database/forward.h
+++ b/legacy_include/database/forward.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/forward.h
 //
 // External consumers using <database/forward.h> should migrate to
-// <kcenon/database/forward.h>. This stub will be removed in the next minor release.
+// <kcenon/database/forward.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/forward.h> is deprecated; use <kcenon/database/forward.h>")
 #include <kcenon/database/forward.h>

--- a/legacy_include/database/integrated/adapters/backends/common_logger_backend.h
+++ b/legacy_include/database/integrated/adapters/backends/common_logger_backend.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/integrated/adapters/backends/common_logger_backend.h
 //
 // External consumers using <database/integrated/adapters/backends/common_logger_backend.h> should migrate to
-// <kcenon/database/integrated/adapters/backends/common_logger_backend.h>. This stub will be removed in the next minor release.
+// <kcenon/database/integrated/adapters/backends/common_logger_backend.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/integrated/adapters/backends/common_logger_backend.h> is deprecated; use <kcenon/database/integrated/adapters/backends/common_logger_backend.h>")
 #include <kcenon/database/integrated/adapters/backends/common_logger_backend.h>

--- a/legacy_include/database/integrated/adapters/backends/fallback_logger_backend.h
+++ b/legacy_include/database/integrated/adapters/backends/fallback_logger_backend.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/integrated/adapters/backends/fallback_logger_backend.h
 //
 // External consumers using <database/integrated/adapters/backends/fallback_logger_backend.h> should migrate to
-// <kcenon/database/integrated/adapters/backends/fallback_logger_backend.h>. This stub will be removed in the next minor release.
+// <kcenon/database/integrated/adapters/backends/fallback_logger_backend.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/integrated/adapters/backends/fallback_logger_backend.h> is deprecated; use <kcenon/database/integrated/adapters/backends/fallback_logger_backend.h>")
 #include <kcenon/database/integrated/adapters/backends/fallback_logger_backend.h>

--- a/legacy_include/database/integrated/adapters/backends/fallback_monitoring_backend.h
+++ b/legacy_include/database/integrated/adapters/backends/fallback_monitoring_backend.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/integrated/adapters/backends/fallback_monitoring_backend.h
 //
 // External consumers using <database/integrated/adapters/backends/fallback_monitoring_backend.h> should migrate to
-// <kcenon/database/integrated/adapters/backends/fallback_monitoring_backend.h>. This stub will be removed in the next minor release.
+// <kcenon/database/integrated/adapters/backends/fallback_monitoring_backend.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/integrated/adapters/backends/fallback_monitoring_backend.h> is deprecated; use <kcenon/database/integrated/adapters/backends/fallback_monitoring_backend.h>")
 #include <kcenon/database/integrated/adapters/backends/fallback_monitoring_backend.h>

--- a/legacy_include/database/integrated/adapters/backends/fallback_thread_backend.h
+++ b/legacy_include/database/integrated/adapters/backends/fallback_thread_backend.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/integrated/adapters/backends/fallback_thread_backend.h
 //
 // External consumers using <database/integrated/adapters/backends/fallback_thread_backend.h> should migrate to
-// <kcenon/database/integrated/adapters/backends/fallback_thread_backend.h>. This stub will be removed in the next minor release.
+// <kcenon/database/integrated/adapters/backends/fallback_thread_backend.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/integrated/adapters/backends/fallback_thread_backend.h> is deprecated; use <kcenon/database/integrated/adapters/backends/fallback_thread_backend.h>")
 #include <kcenon/database/integrated/adapters/backends/fallback_thread_backend.h>

--- a/legacy_include/database/integrated/adapters/backends/logger_backend.h
+++ b/legacy_include/database/integrated/adapters/backends/logger_backend.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/integrated/adapters/backends/logger_backend.h
 //
 // External consumers using <database/integrated/adapters/backends/logger_backend.h> should migrate to
-// <kcenon/database/integrated/adapters/backends/logger_backend.h>. This stub will be removed in the next minor release.
+// <kcenon/database/integrated/adapters/backends/logger_backend.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/integrated/adapters/backends/logger_backend.h> is deprecated; use <kcenon/database/integrated/adapters/backends/logger_backend.h>")
 #include <kcenon/database/integrated/adapters/backends/logger_backend.h>

--- a/legacy_include/database/integrated/adapters/backends/monitoring_backend.h
+++ b/legacy_include/database/integrated/adapters/backends/monitoring_backend.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/integrated/adapters/backends/monitoring_backend.h
 //
 // External consumers using <database/integrated/adapters/backends/monitoring_backend.h> should migrate to
-// <kcenon/database/integrated/adapters/backends/monitoring_backend.h>. This stub will be removed in the next minor release.
+// <kcenon/database/integrated/adapters/backends/monitoring_backend.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/integrated/adapters/backends/monitoring_backend.h> is deprecated; use <kcenon/database/integrated/adapters/backends/monitoring_backend.h>")
 #include <kcenon/database/integrated/adapters/backends/monitoring_backend.h>

--- a/legacy_include/database/integrated/adapters/backends/null_logger_backend.h
+++ b/legacy_include/database/integrated/adapters/backends/null_logger_backend.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/integrated/adapters/backends/null_logger_backend.h
 //
 // External consumers using <database/integrated/adapters/backends/null_logger_backend.h> should migrate to
-// <kcenon/database/integrated/adapters/backends/null_logger_backend.h>. This stub will be removed in the next minor release.
+// <kcenon/database/integrated/adapters/backends/null_logger_backend.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/integrated/adapters/backends/null_logger_backend.h> is deprecated; use <kcenon/database/integrated/adapters/backends/null_logger_backend.h>")
 #include <kcenon/database/integrated/adapters/backends/null_logger_backend.h>

--- a/legacy_include/database/integrated/adapters/backends/null_monitoring_backend.h
+++ b/legacy_include/database/integrated/adapters/backends/null_monitoring_backend.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/integrated/adapters/backends/null_monitoring_backend.h
 //
 // External consumers using <database/integrated/adapters/backends/null_monitoring_backend.h> should migrate to
-// <kcenon/database/integrated/adapters/backends/null_monitoring_backend.h>. This stub will be removed in the next minor release.
+// <kcenon/database/integrated/adapters/backends/null_monitoring_backend.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/integrated/adapters/backends/null_monitoring_backend.h> is deprecated; use <kcenon/database/integrated/adapters/backends/null_monitoring_backend.h>")
 #include <kcenon/database/integrated/adapters/backends/null_monitoring_backend.h>

--- a/legacy_include/database/integrated/adapters/backends/null_thread_backend.h
+++ b/legacy_include/database/integrated/adapters/backends/null_thread_backend.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/integrated/adapters/backends/null_thread_backend.h
 //
 // External consumers using <database/integrated/adapters/backends/null_thread_backend.h> should migrate to
-// <kcenon/database/integrated/adapters/backends/null_thread_backend.h>. This stub will be removed in the next minor release.
+// <kcenon/database/integrated/adapters/backends/null_thread_backend.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/integrated/adapters/backends/null_thread_backend.h> is deprecated; use <kcenon/database/integrated/adapters/backends/null_thread_backend.h>")
 #include <kcenon/database/integrated/adapters/backends/null_thread_backend.h>

--- a/legacy_include/database/integrated/adapters/backends/system_monitoring_backend.h
+++ b/legacy_include/database/integrated/adapters/backends/system_monitoring_backend.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/integrated/adapters/backends/system_monitoring_backend.h
 //
 // External consumers using <database/integrated/adapters/backends/system_monitoring_backend.h> should migrate to
-// <kcenon/database/integrated/adapters/backends/system_monitoring_backend.h>. This stub will be removed in the next minor release.
+// <kcenon/database/integrated/adapters/backends/system_monitoring_backend.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/integrated/adapters/backends/system_monitoring_backend.h> is deprecated; use <kcenon/database/integrated/adapters/backends/system_monitoring_backend.h>")
 #include <kcenon/database/integrated/adapters/backends/system_monitoring_backend.h>

--- a/legacy_include/database/integrated/adapters/backends/thread_backend.h
+++ b/legacy_include/database/integrated/adapters/backends/thread_backend.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/integrated/adapters/backends/thread_backend.h
 //
 // External consumers using <database/integrated/adapters/backends/thread_backend.h> should migrate to
-// <kcenon/database/integrated/adapters/backends/thread_backend.h>. This stub will be removed in the next minor release.
+// <kcenon/database/integrated/adapters/backends/thread_backend.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/integrated/adapters/backends/thread_backend.h> is deprecated; use <kcenon/database/integrated/adapters/backends/thread_backend.h>")
 #include <kcenon/database/integrated/adapters/backends/thread_backend.h>

--- a/legacy_include/database/integrated/adapters/logger_adapter.h
+++ b/legacy_include/database/integrated/adapters/logger_adapter.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/integrated/adapters/logger_adapter.h
 //
 // External consumers using <database/integrated/adapters/logger_adapter.h> should migrate to
-// <kcenon/database/integrated/adapters/logger_adapter.h>. This stub will be removed in the next minor release.
+// <kcenon/database/integrated/adapters/logger_adapter.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/integrated/adapters/logger_adapter.h> is deprecated; use <kcenon/database/integrated/adapters/logger_adapter.h>")
 #include <kcenon/database/integrated/adapters/logger_adapter.h>

--- a/legacy_include/database/integrated/adapters/monitoring_adapter.h
+++ b/legacy_include/database/integrated/adapters/monitoring_adapter.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/integrated/adapters/monitoring_adapter.h
 //
 // External consumers using <database/integrated/adapters/monitoring_adapter.h> should migrate to
-// <kcenon/database/integrated/adapters/monitoring_adapter.h>. This stub will be removed in the next minor release.
+// <kcenon/database/integrated/adapters/monitoring_adapter.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/integrated/adapters/monitoring_adapter.h> is deprecated; use <kcenon/database/integrated/adapters/monitoring_adapter.h>")
 #include <kcenon/database/integrated/adapters/monitoring_adapter.h>

--- a/legacy_include/database/integrated/adapters/thread_adapter.h
+++ b/legacy_include/database/integrated/adapters/thread_adapter.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/integrated/adapters/thread_adapter.h
 //
 // External consumers using <database/integrated/adapters/thread_adapter.h> should migrate to
-// <kcenon/database/integrated/adapters/thread_adapter.h>. This stub will be removed in the next minor release.
+// <kcenon/database/integrated/adapters/thread_adapter.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/integrated/adapters/thread_adapter.h> is deprecated; use <kcenon/database/integrated/adapters/thread_adapter.h>")
 #include <kcenon/database/integrated/adapters/thread_adapter.h>

--- a/legacy_include/database/integrated/connection_string_builder.h
+++ b/legacy_include/database/integrated/connection_string_builder.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/integrated/connection_string_builder.h
 //
 // External consumers using <database/integrated/connection_string_builder.h> should migrate to
-// <kcenon/database/integrated/connection_string_builder.h>. This stub will be removed in the next minor release.
+// <kcenon/database/integrated/connection_string_builder.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/integrated/connection_string_builder.h> is deprecated; use <kcenon/database/integrated/connection_string_builder.h>")
 #include <kcenon/database/integrated/connection_string_builder.h>

--- a/legacy_include/database/integrated/core/common_result.h
+++ b/legacy_include/database/integrated/core/common_result.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/integrated/core/common_result.h
 //
 // External consumers using <database/integrated/core/common_result.h> should migrate to
-// <kcenon/database/integrated/core/common_result.h>. This stub will be removed in the next minor release.
+// <kcenon/database/integrated/core/common_result.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/integrated/core/common_result.h> is deprecated; use <kcenon/database/integrated/core/common_result.h>")
 #include <kcenon/database/integrated/core/common_result.h>

--- a/legacy_include/database/integrated/core/configuration.h
+++ b/legacy_include/database/integrated/core/configuration.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/integrated/core/configuration.h
 //
 // External consumers using <database/integrated/core/configuration.h> should migrate to
-// <kcenon/database/integrated/core/configuration.h>. This stub will be removed in the next minor release.
+// <kcenon/database/integrated/core/configuration.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/integrated/core/configuration.h> is deprecated; use <kcenon/database/integrated/core/configuration.h>")
 #include <kcenon/database/integrated/core/configuration.h>

--- a/legacy_include/database/integrated/core/database_coordinator.h
+++ b/legacy_include/database/integrated/core/database_coordinator.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/integrated/core/database_coordinator.h
 //
 // External consumers using <database/integrated/core/database_coordinator.h> should migrate to
-// <kcenon/database/integrated/core/database_coordinator.h>. This stub will be removed in the next minor release.
+// <kcenon/database/integrated/core/database_coordinator.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/integrated/core/database_coordinator.h> is deprecated; use <kcenon/database/integrated/core/database_coordinator.h>")
 #include <kcenon/database/integrated/core/database_coordinator.h>

--- a/legacy_include/database/integrated/unified_database_system.h
+++ b/legacy_include/database/integrated/unified_database_system.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/integrated/unified_database_system.h
 //
 // External consumers using <database/integrated/unified_database_system.h> should migrate to
-// <kcenon/database/integrated/unified_database_system.h>. This stub will be removed in the next minor release.
+// <kcenon/database/integrated/unified_database_system.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/integrated/unified_database_system.h> is deprecated; use <kcenon/database/integrated/unified_database_system.h>")
 #include <kcenon/database/integrated/unified_database_system.h>

--- a/legacy_include/database/monitoring/performance_monitor.h
+++ b/legacy_include/database/monitoring/performance_monitor.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/monitoring/performance_monitor.h
 //
 // External consumers using <database/monitoring/performance_monitor.h> should migrate to
-// <kcenon/database/monitoring/performance_monitor.h>. This stub will be removed in the next minor release.
+// <kcenon/database/monitoring/performance_monitor.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/monitoring/performance_monitor.h> is deprecated; use <kcenon/database/monitoring/performance_monitor.h>")
 #include <kcenon/database/monitoring/performance_monitor.h>

--- a/legacy_include/database/monitoring/pool_metrics.h
+++ b/legacy_include/database/monitoring/pool_metrics.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/monitoring/pool_metrics.h
 //
 // External consumers using <database/monitoring/pool_metrics.h> should migrate to
-// <kcenon/database/monitoring/pool_metrics.h>. This stub will be removed in the next minor release.
+// <kcenon/database/monitoring/pool_metrics.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/monitoring/pool_metrics.h> is deprecated; use <kcenon/database/monitoring/pool_metrics.h>")
 #include <kcenon/database/monitoring/pool_metrics.h>

--- a/legacy_include/database/orm/entity.h
+++ b/legacy_include/database/orm/entity.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/orm/entity.h
 //
 // External consumers using <database/orm/entity.h> should migrate to
-// <kcenon/database/orm/entity.h>. This stub will be removed in the next minor release.
+// <kcenon/database/orm/entity.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/orm/entity.h> is deprecated; use <kcenon/database/orm/entity.h>")
 #include <kcenon/database/orm/entity.h>

--- a/legacy_include/database/postgres_manager.h
+++ b/legacy_include/database/postgres_manager.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/postgres_manager.h
 //
 // External consumers using <database/postgres_manager.h> should migrate to
-// <kcenon/database/postgres_manager.h>. This stub will be removed in the next minor release.
+// <kcenon/database/postgres_manager.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/postgres_manager.h> is deprecated; use <kcenon/database/postgres_manager.h>")
 #include <kcenon/database/postgres_manager.h>

--- a/legacy_include/database/protocol/database_protocol.h
+++ b/legacy_include/database/protocol/database_protocol.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/protocol/database_protocol.h
 //
 // External consumers using <database/protocol/database_protocol.h> should migrate to
-// <kcenon/database/protocol/database_protocol.h>. This stub will be removed in the next minor release.
+// <kcenon/database/protocol/database_protocol.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/protocol/database_protocol.h> is deprecated; use <kcenon/database/protocol/database_protocol.h>")
 #include <kcenon/database/protocol/database_protocol.h>

--- a/legacy_include/database/protocol/database_protocol_container.h
+++ b/legacy_include/database/protocol/database_protocol_container.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/protocol/database_protocol_container.h
 //
 // External consumers using <database/protocol/database_protocol_container.h> should migrate to
-// <kcenon/database/protocol/database_protocol_container.h>. This stub will be removed in the next minor release.
+// <kcenon/database/protocol/database_protocol_container.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/protocol/database_protocol_container.h> is deprecated; use <kcenon/database/protocol/database_protocol_container.h>")
 #include <kcenon/database/protocol/database_protocol_container.h>

--- a/legacy_include/database/query/immutable_query_builder.h
+++ b/legacy_include/database/query/immutable_query_builder.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/query/immutable_query_builder.h
 //
 // External consumers using <database/query/immutable_query_builder.h> should migrate to
-// <kcenon/database/query/immutable_query_builder.h>. This stub will be removed in the next minor release.
+// <kcenon/database/query/immutable_query_builder.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/query/immutable_query_builder.h> is deprecated; use <kcenon/database/query/immutable_query_builder.h>")
 #include <kcenon/database/query/immutable_query_builder.h>

--- a/legacy_include/database/query_builder.h
+++ b/legacy_include/database/query_builder.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/query_builder.h
 //
 // External consumers using <database/query_builder.h> should migrate to
-// <kcenon/database/query_builder.h>. This stub will be removed in the next minor release.
+// <kcenon/database/query_builder.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/query_builder.h> is deprecated; use <kcenon/database/query_builder.h>")
 #include <kcenon/database/query_builder.h>

--- a/legacy_include/database/query_builder/condition_builder.h
+++ b/legacy_include/database/query_builder/condition_builder.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/query_builder/condition_builder.h
 //
 // External consumers using <database/query_builder/condition_builder.h> should migrate to
-// <kcenon/database/query_builder/condition_builder.h>. This stub will be removed in the next minor release.
+// <kcenon/database/query_builder/condition_builder.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/query_builder/condition_builder.h> is deprecated; use <kcenon/database/query_builder/condition_builder.h>")
 #include <kcenon/database/query_builder/condition_builder.h>

--- a/legacy_include/database/query_builder/join_builder.h
+++ b/legacy_include/database/query_builder/join_builder.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/query_builder/join_builder.h
 //
 // External consumers using <database/query_builder/join_builder.h> should migrate to
-// <kcenon/database/query_builder/join_builder.h>. This stub will be removed in the next minor release.
+// <kcenon/database/query_builder/join_builder.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/query_builder/join_builder.h> is deprecated; use <kcenon/database/query_builder/join_builder.h>")
 #include <kcenon/database/query_builder/join_builder.h>

--- a/legacy_include/database/query_builder/sql_dialect.h
+++ b/legacy_include/database/query_builder/sql_dialect.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/query_builder/sql_dialect.h
 //
 // External consumers using <database/query_builder/sql_dialect.h> should migrate to
-// <kcenon/database/query_builder/sql_dialect.h>. This stub will be removed in the next minor release.
+// <kcenon/database/query_builder/sql_dialect.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/query_builder/sql_dialect.h> is deprecated; use <kcenon/database/query_builder/sql_dialect.h>")
 #include <kcenon/database/query_builder/sql_dialect.h>

--- a/legacy_include/database/query_builder/value_formatter.h
+++ b/legacy_include/database/query_builder/value_formatter.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/query_builder/value_formatter.h
 //
 // External consumers using <database/query_builder/value_formatter.h> should migrate to
-// <kcenon/database/query_builder/value_formatter.h>. This stub will be removed in the next minor release.
+// <kcenon/database/query_builder/value_formatter.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/query_builder/value_formatter.h> is deprecated; use <kcenon/database/query_builder/value_formatter.h>")
 #include <kcenon/database/query_builder/value_formatter.h>

--- a/legacy_include/database/query_dialect.h
+++ b/legacy_include/database/query_dialect.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/query_dialect.h
 //
 // External consumers using <database/query_dialect.h> should migrate to
-// <kcenon/database/query_dialect.h>. This stub will be removed in the next minor release.
+// <kcenon/database/query_dialect.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/query_dialect.h> is deprecated; use <kcenon/database/query_dialect.h>")
 #include <kcenon/database/query_dialect.h>

--- a/legacy_include/database/security/secure_connection.h
+++ b/legacy_include/database/security/secure_connection.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/security/secure_connection.h
 //
 // External consumers using <database/security/secure_connection.h> should migrate to
-// <kcenon/database/security/secure_connection.h>. This stub will be removed in the next minor release.
+// <kcenon/database/security/secure_connection.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/security/secure_connection.h> is deprecated; use <kcenon/database/security/secure_connection.h>")
 #include <kcenon/database/security/secure_connection.h>

--- a/legacy_include/database/utils/backend_logger.h
+++ b/legacy_include/database/utils/backend_logger.h
@@ -6,7 +6,7 @@
 // Generated from include/kcenon/database/utils/backend_logger.h
 //
 // External consumers using <database/utils/backend_logger.h> should migrate to
-// <kcenon/database/utils/backend_logger.h>. This stub will be removed in the next minor release.
+// <kcenon/database/utils/backend_logger.h>. This stub will be removed in version 2.0.0.
 #pragma once
 #pragma message("Header <database/utils/backend_logger.h> is deprecated; use <kcenon/database/utils/backend_logger.h>")
 #include <kcenon/database/utils/backend_logger.h>

--- a/samples/async_operations_demo.cpp
+++ b/samples/async_operations_demo.cpp
@@ -38,8 +38,8 @@ int main() {
 #include <kcenon/database/database_manager.h>
 #include <kcenon/database/async/async_operations.h>
 
-using namespace database;
-using namespace database::async;
+using namespace kcenon::database;
+using namespace kcenon::database::async;
 
 void demonstrate_basic_async_operations() {
     std::cout << "=== Basic Asynchronous Database Operations ===\n";

--- a/samples/basic_usage.cpp
+++ b/samples/basic_usage.cpp
@@ -25,7 +25,7 @@
 #include <kcenon/database/postgres_manager.h>
 #include <kcenon/database/core/database_context.h>
 
-using namespace database;
+using namespace kcenon::database;
 
 int main() {
     std::cout << "=== Database System - Basic Usage Example ===" << std::endl;

--- a/samples/integrated/async_queries.cpp
+++ b/samples/integrated/async_queries.cpp
@@ -24,7 +24,7 @@
 #include <chrono>
 #include <iomanip>
 
-using namespace database::integrated;
+using namespace kcenon::database::integrated;
 using namespace std::chrono;
 
 void print_header(const std::string& title) {

--- a/samples/integrated/basic_usage.cpp
+++ b/samples/integrated/basic_usage.cpp
@@ -24,7 +24,7 @@
 #include <iostream>
 #include <iomanip>
 
-using namespace database::integrated;
+using namespace kcenon::database::integrated;
 
 void print_header(const std::string& title) {
     std::cout << "\n" << std::string(60, '=') << "\n";

--- a/samples/integrated/migration_from_legacy.cpp
+++ b/samples/integrated/migration_from_legacy.cpp
@@ -16,7 +16,7 @@
 #include <iostream>
 #include <iomanip>
 
-using namespace database::integrated;
+using namespace kcenon::database::integrated;
 
 void print_header(const std::string& title) {
     std::cout << "\n" << std::string(70, '=') << "\n";

--- a/samples/integrated/monitoring.cpp
+++ b/samples/integrated/monitoring.cpp
@@ -23,7 +23,7 @@
 #include <thread>
 #include <chrono>
 
-using namespace database::integrated;
+using namespace kcenon::database::integrated;
 using namespace std::chrono;
 
 void print_header(const std::string& title) {

--- a/samples/migration/async_executor_demo.cpp
+++ b/samples/migration/async_executor_demo.cpp
@@ -23,7 +23,7 @@
 #include <vector>
 #include <kcenon/database/async/async_operations.h>
 
-using namespace database::async;
+using namespace kcenon::database::async;
 using namespace std::chrono;
 
 void demonstrate_basic_usage() {

--- a/samples/orm_framework_demo.cpp
+++ b/samples/orm_framework_demo.cpp
@@ -25,8 +25,8 @@
 #include <kcenon/database/orm/entity.h>
 #include <kcenon/database/core/database_context.h>
 
-using namespace database;
-using namespace database::orm;
+using namespace kcenon::database;
+using namespace kcenon::database::orm;
 
 // Example Entity: User
 class User : public entity_base

--- a/samples/performance_monitoring_demo.cpp
+++ b/samples/performance_monitoring_demo.cpp
@@ -27,8 +27,8 @@
 #include <kcenon/database/core/database_context.h>
 #include <kcenon/database/monitoring/performance_monitor.h>
 
-using namespace database;
-using namespace database::monitoring;
+using namespace kcenon::database;
+using namespace kcenon::database::monitoring;
 
 void demonstrate_basic_metrics(std::shared_ptr<database_context> context) {
     std::cout << "=== Basic Performance Metrics Demonstration ===\n";

--- a/samples/postgres_advanced.cpp
+++ b/samples/postgres_advanced.cpp
@@ -26,7 +26,7 @@
 #include <kcenon/database/postgres_manager.h>
 #include <kcenon/database/core/database_backend.h>
 
-using namespace database;
+using namespace kcenon::database;
 
 int main() {
     std::cout << "=== Database System - PostgreSQL Advanced Features Example ===" << std::endl;

--- a/samples/security_framework_demo.cpp
+++ b/samples/security_framework_demo.cpp
@@ -27,8 +27,8 @@
 #include <kcenon/database/security/secure_connection.h>
 #include <kcenon/database/core/database_context.h>
 
-using namespace database;
-using namespace database::security;
+using namespace kcenon::database;
+using namespace kcenon::database::security;
 
 void demonstrate_secure_connections() {
     std::cout << "=== Secure Connection Management ===\n";

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,10 +88,10 @@ set(HEADER_FILES
 # Collect all source files
 set(SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/core/database_context.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/database_manager.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/postgres_manager.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/query_builder.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/query_dialect.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/database_manager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/backends/postgres_manager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/query_builder/query_builder.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/query_builder/query_dialect.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/query_builder/value_formatter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/query_builder/sql_dialect.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/query_builder/condition_builder.cpp

--- a/src/backends/mongodb_backend.cpp
+++ b/src/backends/mongodb_backend.cpp
@@ -28,7 +28,7 @@ namespace
 const database::utils::backend_logger logger_("MongoDB");
 }
 
-namespace database
+namespace kcenon::database
 {
 namespace backends
 {
@@ -429,7 +429,7 @@ std::string mongodb_backend::build_connection_uri(const core::connection_config&
 }
 
 } // namespace backends
-} // namespace database
+} // namespace kcenon::database
 
 // Auto-registration with backend_registry when MongoDB support is compiled in
 #ifdef USE_MONGODB

--- a/src/backends/postgres_manager.cpp
+++ b/src/backends/postgres_manager.cpp
@@ -32,7 +32,7 @@ constexpr unsigned int PG_FLOAT8OID = 701;
 constexpr unsigned int PG_BOOLOID = 16;
 }
 
-namespace database
+namespace kcenon::database
 {
 	postgres_manager::postgres_manager(void)
 		: connection_(nullptr)
@@ -432,4 +432,4 @@ namespace database
 
 		return info;
 	}
-} // namespace database
+} // namespace kcenon::database

--- a/src/backends/postgresql_backend.cpp
+++ b/src/backends/postgresql_backend.cpp
@@ -59,7 +59,7 @@ bool query_starts_with(const std::string& query, const char* keyword) {
 }
 }
 
-namespace database
+namespace kcenon::database
 {
 namespace backends
 {
@@ -1050,7 +1050,7 @@ std::string postgresql_backend::sanitize_error(const std::string& error_message)
 }
 
 } // namespace backends
-} // namespace database
+} // namespace kcenon::database
 
 // Auto-registration with backend_registry when PostgreSQL support is compiled in
 #ifdef USE_POSTGRESQL

--- a/src/backends/redis_backend.cpp
+++ b/src/backends/redis_backend.cpp
@@ -21,7 +21,7 @@ namespace
 const database::utils::backend_logger logger_("Redis");
 }
 
-namespace database
+namespace kcenon::database
 {
 namespace backends
 {
@@ -414,7 +414,7 @@ std::map<std::string, std::string> redis_backend::connection_info() const
 }
 
 } // namespace backends
-} // namespace database
+} // namespace kcenon::database
 
 // Auto-registration with backend_registry when Redis support is compiled in
 #ifdef USE_REDIS

--- a/src/backends/sqlite_backend.cpp
+++ b/src/backends/sqlite_backend.cpp
@@ -22,7 +22,7 @@ namespace
 const database::utils::backend_logger logger_("SQLite");
 }
 
-namespace database
+namespace kcenon::database
 {
 namespace backends
 {
@@ -630,7 +630,7 @@ std::map<std::string, std::string> sqlite_backend::connection_info() const
 }
 
 } // namespace backends
-} // namespace database
+} // namespace kcenon::database
 
 // Auto-registration with backend_registry when SQLite support is compiled in
 #ifdef USE_SQLITE

--- a/src/core/backend_registry.cpp
+++ b/src/core/backend_registry.cpp
@@ -6,7 +6,7 @@
 
 #include <algorithm>
 
-namespace database
+namespace kcenon::database
 {
 namespace core
 {
@@ -114,4 +114,4 @@ void backend_registry::clear()
 }
 
 } // namespace core
-} // namespace database
+} // namespace kcenon::database

--- a/src/core/connection_pool.cpp
+++ b/src/core/connection_pool.cpp
@@ -6,7 +6,7 @@
 
 #include <utility>
 
-namespace database
+namespace kcenon::database
 {
 namespace core
 {
@@ -310,4 +310,4 @@ std::unique_ptr<database_backend> connection_pool::take_idle_locked()
 
 } // namespace pool
 } // namespace core
-} // namespace database
+} // namespace kcenon::database

--- a/src/core/database_backend.cpp
+++ b/src/core/database_backend.cpp
@@ -7,7 +7,7 @@
 #include <sstream>
 #include <algorithm>
 
-namespace database
+namespace kcenon::database
 {
 namespace core
 {
@@ -79,4 +79,4 @@ connection_config connection_config::from_string(const std::string& connect_stri
 }
 
 } // namespace core
-} // namespace database
+} // namespace kcenon::database

--- a/src/core/database_context.cpp
+++ b/src/core/database_context.cpp
@@ -8,7 +8,7 @@
 #include <kcenon/database/async/async_operations.h>
 #include <kcenon/database/security/secure_connection.h>
 
-namespace database
+namespace kcenon::database
 {
 
 database_context::database_context()
@@ -31,4 +31,4 @@ database_context::~database_context()
     // Cleanup: All shared_ptrs will be automatically destroyed
 }
 
-} // namespace database
+} // namespace kcenon::database

--- a/src/core/database_manager.cpp
+++ b/src/core/database_manager.cpp
@@ -15,7 +15,7 @@
 #endif
 #include <sstream>
 
-namespace database
+namespace kcenon::database
 {
 	database_manager::database_manager(std::shared_ptr<database_context> context)
 		: connected_(false)
@@ -222,4 +222,4 @@ namespace database
 		return query_builder(db_type);
 	}
 
-}; // namespace database
+}; // namespace kcenon::database

--- a/src/integrated/adapters/backends/common_logger_backend.cpp
+++ b/src/integrated/adapters/backends/common_logger_backend.cpp
@@ -20,7 +20,7 @@ namespace
 	}
 }
 
-namespace database
+namespace kcenon::database
 {
 namespace integrated
 {
@@ -150,4 +150,4 @@ kcenon::common::interfaces::log_level common_logger_backend::convert_log_level(d
 } // namespace backends
 } // namespace adapters
 } // namespace integrated
-} // namespace database
+} // namespace kcenon::database

--- a/src/integrated/adapters/backends/fallback_logger_backend.cpp
+++ b/src/integrated/adapters/backends/fallback_logger_backend.cpp
@@ -63,7 +63,7 @@ namespace
 	}
 }
 
-namespace database
+namespace kcenon::database
 {
 namespace integrated
 {
@@ -192,4 +192,4 @@ void fallback_logger_backend::flush()
 } // namespace backends
 } // namespace adapters
 } // namespace integrated
-} // namespace database
+} // namespace kcenon::database

--- a/src/integrated/adapters/backends/fallback_monitoring_backend.cpp
+++ b/src/integrated/adapters/backends/fallback_monitoring_backend.cpp
@@ -22,7 +22,7 @@ namespace
 	}
 }
 
-namespace database
+namespace kcenon::database
 {
 namespace integrated
 {
@@ -356,4 +356,4 @@ void fallback_monitoring_backend::update_avg_latency()
 } // namespace backends
 } // namespace adapters
 } // namespace integrated
-} // namespace database
+} // namespace kcenon::database

--- a/src/integrated/adapters/backends/fallback_thread_backend.cpp
+++ b/src/integrated/adapters/backends/fallback_thread_backend.cpp
@@ -14,7 +14,7 @@ namespace
 	}
 }
 
-namespace database
+namespace kcenon::database
 {
 namespace integrated
 {
@@ -258,4 +258,4 @@ void fallback_thread_backend::worker_thread()
 } // namespace backends
 } // namespace adapters
 } // namespace integrated
-} // namespace database
+} // namespace kcenon::database

--- a/src/integrated/adapters/backends/system_monitoring_backend.cpp
+++ b/src/integrated/adapters/backends/system_monitoring_backend.cpp
@@ -25,7 +25,7 @@ namespace
 	}
 }
 
-namespace database
+namespace kcenon::database
 {
 namespace integrated
 {
@@ -581,4 +581,4 @@ database_metrics system_monitoring_backend::convert_to_database_metrics(
 } // namespace backends
 } // namespace adapters
 } // namespace integrated
-} // namespace database
+} // namespace kcenon::database

--- a/src/integrated/adapters/logger_adapter.cpp
+++ b/src/integrated/adapters/logger_adapter.cpp
@@ -16,7 +16,7 @@
 #include <algorithm>
 #include <sstream>
 
-namespace database
+namespace kcenon::database
 {
 namespace integrated
 {
@@ -305,4 +305,4 @@ void logger_adapter::flush()
 
 } // namespace adapters
 } // namespace integrated
-} // namespace database
+} // namespace kcenon::database

--- a/src/integrated/adapters/monitoring_adapter.cpp
+++ b/src/integrated/adapters/monitoring_adapter.cpp
@@ -12,7 +12,7 @@
 #include <kcenon/database/integrated/adapters/backends/system_monitoring_backend.h>
 #endif
 
-namespace database
+namespace kcenon::database
 {
 namespace integrated
 {
@@ -248,4 +248,4 @@ std::string monitoring_adapter::export_prometheus_metrics()
 
 } // namespace adapters
 } // namespace integrated
-} // namespace database
+} // namespace kcenon::database

--- a/src/integrated/adapters/thread_adapter.cpp
+++ b/src/integrated/adapters/thread_adapter.cpp
@@ -7,7 +7,7 @@
 #include <kcenon/database/integrated/adapters/backends/null_thread_backend.h>
 #include <kcenon/database/integrated/adapters/backends/fallback_thread_backend.h>
 
-namespace database
+namespace kcenon::database
 {
 namespace integrated
 {
@@ -157,4 +157,4 @@ bool thread_adapter::is_idle() const
 
 } // namespace adapters
 } // namespace integrated
-} // namespace database
+} // namespace kcenon::database

--- a/src/integrated/connection_string_builder.cpp
+++ b/src/integrated/connection_string_builder.cpp
@@ -6,7 +6,7 @@
 
 #include <sstream>
 
-namespace database::integrated {
+namespace kcenon::database::integrated {
 
 connection_string_builder& connection_string_builder::host(std::string_view h) {
     host_ = std::string(h);
@@ -257,4 +257,4 @@ std::string connection_string_builder::ssl_mode_to_postgres_string(enum ssl_mode
     }
 }
 
-} // namespace database::integrated
+} // namespace kcenon::database::integrated

--- a/src/integrated/core/database_coordinator.cpp
+++ b/src/integrated/core/database_coordinator.cpp
@@ -11,7 +11,7 @@
 #include <chrono>
 #include <stdexcept>
 
-namespace database
+namespace kcenon::database
 {
 namespace integrated
 {
@@ -434,4 +434,4 @@ common::Result<database_coordinator::coordinator_stats> database_coordinator::ge
 }
 
 } // namespace integrated
-} // namespace database
+} // namespace kcenon::database

--- a/src/integrated/unified_database_system.cpp
+++ b/src/integrated/unified_database_system.cpp
@@ -23,7 +23,7 @@
 #include <stdexcept>
 #include <sstream>
 
-namespace database::integrated {
+namespace kcenon::database::integrated {
 
 // ============================================================================
 // Helper Functions
@@ -914,4 +914,4 @@ unified_database_system::builder unified_database_system::create_builder() {
     return builder{};
 }
 
-} // namespace database::integrated
+} // namespace kcenon::database::integrated

--- a/src/modules/backends.cppm
+++ b/src/modules/backends.cppm
@@ -60,12 +60,12 @@ import kcenon.common;
 // ============================================================================
 
 #ifdef USE_POSTGRESQL
-export namespace database::backends {
+export namespace kcenon::database::backends {
 
 // Re-export PostgreSQL backend
 using ::database::backends::postgresql_backend;
 
-} // namespace database::backends
+} // namespace kcenon::database::backends
 #endif
 
 // ============================================================================
@@ -73,12 +73,12 @@ using ::database::backends::postgresql_backend;
 // ============================================================================
 
 #ifdef USE_SQLITE
-export namespace database::backends {
+export namespace kcenon::database::backends {
 
 // Re-export SQLite backend
 using ::database::backends::sqlite_backend;
 
-} // namespace database::backends
+} // namespace kcenon::database::backends
 #endif
 
 // ============================================================================
@@ -86,12 +86,12 @@ using ::database::backends::sqlite_backend;
 // ============================================================================
 
 #ifdef USE_MONGODB
-export namespace database::backends {
+export namespace kcenon::database::backends {
 
 // Re-export MongoDB backend
 using ::database::backends::mongodb_backend;
 
-} // namespace database::backends
+} // namespace kcenon::database::backends
 #endif
 
 // ============================================================================
@@ -99,10 +99,10 @@ using ::database::backends::mongodb_backend;
 // ============================================================================
 
 #ifdef USE_REDIS
-export namespace database::backends {
+export namespace kcenon::database::backends {
 
 // Re-export Redis backend
 using ::database::backends::redis_backend;
 
-} // namespace database::backends
+} // namespace kcenon::database::backends
 #endif

--- a/src/modules/core.cppm
+++ b/src/modules/core.cppm
@@ -50,7 +50,7 @@ import kcenon.common;
 // Core Type Aliases
 // ============================================================================
 
-export namespace database {
+export namespace kcenon::database {
 
 /// @brief Variant type for individual database cell values
 using core::database_value;
@@ -59,13 +59,13 @@ using core::database_row;
 /// @brief Collection of rows returned from a database query
 using core::database_result;
 
-} // namespace database
+} // namespace kcenon::database
 
 // ============================================================================
 // Database Types Enumeration
 // ============================================================================
 
-export namespace database {
+export namespace kcenon::database {
 
 // Re-export database types enumeration
 using ::database::database_types;
@@ -74,80 +74,80 @@ using ::database::connection_mode;
 // Re-export to_string functions
 using ::database::to_string;
 
-} // namespace database
+} // namespace kcenon::database
 
 // ============================================================================
 // Connection Configuration
 // ============================================================================
 
-export namespace database::core {
+export namespace kcenon::database::core {
 
 // Re-export connection configuration
 using ::database::core::connection_config;
 
-} // namespace database::core
+} // namespace kcenon::database::core
 
 // ============================================================================
 // Backend Interface
 // ============================================================================
 
-export namespace database::core {
+export namespace kcenon::database::core {
 
 // Re-export backend interface
 using ::database::core::database_backend;
 using ::database::core::backend_factory_fn;
 
-} // namespace database::core
+} // namespace kcenon::database::core
 
 // ============================================================================
 // Backend Registry
 // ============================================================================
 
-export namespace database::core {
+export namespace kcenon::database::core {
 
 // Re-export backend registry
 using ::database::core::backend_registry;
 
-} // namespace database::core
+} // namespace kcenon::database::core
 
 // ============================================================================
 // Database Context (Dependency Injection)
 // ============================================================================
 
-export namespace database {
+export namespace kcenon::database {
 
 // Re-export database context
 using ::database::database_context;
 
-} // namespace database
+} // namespace kcenon::database
 
 // ============================================================================
 // Proxy Configuration
 // ============================================================================
 
-export namespace database::proxy {
+export namespace kcenon::database::proxy {
 
 // Re-export proxy configuration
 using ::database::proxy::proxy_connection_config;
 
-} // namespace database::proxy
+} // namespace kcenon::database::proxy
 
 // ============================================================================
 // Database Manager
 // ============================================================================
 
-export namespace database {
+export namespace kcenon::database {
 
 // Re-export database manager
 using ::database::database_manager;
 
-} // namespace database
+} // namespace kcenon::database
 
 // ============================================================================
 // Legacy Types (deprecated)
 // ============================================================================
 
-export namespace database {
+export namespace kcenon::database {
 
 // Re-export legacy database_base (deprecated)
 using ::database::database_base;
@@ -157,4 +157,4 @@ using ::database::database_value;
 using ::database::database_row;
 using ::database::database_result;
 
-} // namespace database
+} // namespace kcenon::database

--- a/src/modules/database.cppm
+++ b/src/modules/database.cppm
@@ -13,7 +13,7 @@
  * @code
  * import kcenon.database;
  *
- * using namespace database;
+ * using namespace kcenon::database;
  *
  * // Create database context and manager
  * auto context = std::make_shared<database_context>();
@@ -63,7 +63,7 @@ export import :query;
 // Tier 3: Backend implementations (optional, depends on build configuration)
 export import :backends;
 
-export namespace database {
+export namespace kcenon::database {
 
 /**
  * @brief Version information for database_system module.
@@ -77,4 +77,4 @@ struct module_version {
     static constexpr const char* module_name = "kcenon.database";
 };
 
-} // namespace database
+} // namespace kcenon::database

--- a/src/modules/query.cppm
+++ b/src/modules/query.cppm
@@ -40,7 +40,7 @@ import kcenon.common;
 // Query Enumerations
 // ============================================================================
 
-export namespace database {
+export namespace kcenon::database {
 
 // Re-export join type enumeration
 using ::database::join_type;
@@ -48,35 +48,35 @@ using ::database::join_type;
 // Re-export sort order enumeration
 using ::database::sort_order;
 
-} // namespace database
+} // namespace kcenon::database
 
 // ============================================================================
 // Query Condition
 // ============================================================================
 
-export namespace database {
+export namespace kcenon::database {
 
 // Re-export query condition class
 using ::database::query_condition;
 
-} // namespace database
+} // namespace kcenon::database
 
 // ============================================================================
 // Query Builder
 // ============================================================================
 
-export namespace database {
+export namespace kcenon::database {
 
 // Re-export query builder class
 using ::database::query_builder;
 
-} // namespace database
+} // namespace kcenon::database
 
 // ============================================================================
 // Query Dialect (Strategy Pattern)
 // ============================================================================
 
-export namespace database {
+export namespace kcenon::database {
 
 // Re-export query dialect interface
 using ::database::query_dialect;
@@ -84,13 +84,13 @@ using ::database::query_dialect;
 // Re-export dialect factory function
 using ::database::create_dialect;
 
-} // namespace database
+} // namespace kcenon::database
 
 // ============================================================================
 // SQL Dialect Implementation
 // ============================================================================
 
-export namespace database::detail {
+export namespace kcenon::database::detail {
 
 // Re-export SQL dialect implementation
 using ::database::detail::sql_dialect;
@@ -101,4 +101,4 @@ using ::database::detail::mongodb_dialect;
 // Re-export Redis dialect implementation
 using ::database::detail::redis_dialect;
 
-} // namespace database::detail
+} // namespace kcenon::database::detail

--- a/src/monitoring/performance_monitor.cpp
+++ b/src/monitoring/performance_monitor.cpp
@@ -9,7 +9,7 @@
 #include <iomanip>
 #include <functional>
 
-namespace database::monitoring
+namespace kcenon::database::monitoring
 {
 	// performance_alert implementation
 	performance_alert::performance_alert(alert_type type, const std::string& message,
@@ -539,4 +539,4 @@ namespace database::monitoring
 		return metrics.str();
 	}
 
-} // namespace database::monitoring
+} // namespace kcenon::database::monitoring

--- a/src/orm/entity.cpp
+++ b/src/orm/entity.cpp
@@ -18,7 +18,7 @@
 #define ORM_LOG_INFO(message) \
 	std::cout << "[ORM] Info: " << message << std::endl
 
-namespace database::orm
+namespace kcenon::database::orm
 {
 	// field_metadata implementation
 	field_metadata::field_metadata(const std::string& name,
@@ -250,4 +250,4 @@ namespace database::orm
 	// Note: Template implementations moved to header file to avoid
 	// template instantiation issues. Only non-template methods implemented here.
 
-} // namespace database::orm
+} // namespace kcenon::database::orm

--- a/src/protocol/database_protocol.cpp
+++ b/src/protocol/database_protocol.cpp
@@ -5,7 +5,7 @@
 #include <kcenon/database/protocol/database_protocol.h>
 #include <cstring>
 
-namespace database::protocol {
+namespace kcenon::database::protocol {
 
 // Protocol serialization implementation
 std::vector<uint8_t> protocol_serializer::serialize_header(const message_header& header) {
@@ -341,4 +341,4 @@ std::string protocol_serializer::read_string(const std::vector<uint8_t>& buffer,
     return value;
 }
 
-} // namespace database::protocol
+} // namespace kcenon::database::protocol

--- a/src/protocol/database_protocol_container.cpp
+++ b/src/protocol/database_protocol_container.cpp
@@ -8,7 +8,7 @@
 #include <core/container.h>
 #include <core/value_types.h>
 
-namespace database::protocol {
+namespace kcenon::database::protocol {
 
 using namespace container_module;
 
@@ -166,6 +166,6 @@ std::string container_protocol_serializer::serialize_to_json(const query_request
     return {};
 }
 
-} // namespace database::protocol
+} // namespace kcenon::database::protocol
 
 #endif // USE_CONTAINER_SYSTEM

--- a/src/query/immutable_query_builder.cpp
+++ b/src/query/immutable_query_builder.cpp
@@ -6,7 +6,7 @@
 #include <sstream>
 #include <algorithm>
 
-namespace database
+namespace kcenon::database
 {
 	// Public constructor
 	immutable_query_builder::immutable_query_builder(const std::string& table)
@@ -356,4 +356,4 @@ namespace database
 		}
 	}
 
-} // namespace database
+} // namespace kcenon::database

--- a/src/query_builder/condition_builder.cpp
+++ b/src/query_builder/condition_builder.cpp
@@ -5,7 +5,7 @@
 #include <kcenon/database/query_builder/condition_builder.h>
 #include <sstream>
 
-namespace database::query {
+namespace kcenon::database::query {
 
 condition_builder::condition_builder()
     : current_group_level_(0) {}
@@ -136,4 +136,4 @@ std::string condition_builder::logical_op_to_string(logical_op op) const {
     }
 }
 
-} // namespace database::query
+} // namespace kcenon::database::query

--- a/src/query_builder/join_builder.cpp
+++ b/src/query_builder/join_builder.cpp
@@ -5,7 +5,7 @@
 #include <kcenon/database/query_builder/join_builder.h>
 #include <sstream>
 
-namespace database::query {
+namespace kcenon::database::query {
 
 join_builder::join_builder() = default;
 
@@ -100,4 +100,4 @@ std::string join_builder::join_type_to_string(join_type type) const {
     }
 }
 
-} // namespace database::query
+} // namespace kcenon::database::query

--- a/src/query_builder/query_builder.cpp
+++ b/src/query_builder/query_builder.cpp
@@ -7,7 +7,7 @@
 #include <algorithm>
 #include <stdexcept>
 
-namespace database
+namespace kcenon::database
 {
 	// query_condition implementation
 	query_condition::query_condition(const std::string& field, const std::string& op, const core::database_value& value)
@@ -399,4 +399,4 @@ namespace database
 		}
 	}
 
-} // namespace database
+} // namespace kcenon::database

--- a/src/query_builder/query_dialect.cpp
+++ b/src/query_builder/query_dialect.cpp
@@ -8,7 +8,7 @@
 #include <sstream>
 #include <stdexcept>
 
-namespace database
+namespace kcenon::database
 {
 	std::unique_ptr<query_dialect> create_dialect(database_types type)
 	{
@@ -806,4 +806,4 @@ namespace database
 
 	} // namespace detail
 
-} // namespace database
+} // namespace kcenon::database

--- a/src/query_builder/sql_dialect.cpp
+++ b/src/query_builder/sql_dialect.cpp
@@ -5,7 +5,7 @@
 #include <kcenon/database/query_builder/sql_dialect.h>
 #include <stdexcept>
 
-namespace database::query {
+namespace kcenon::database::query {
 
 // Factory method
 std::unique_ptr<sql_dialect> sql_dialect::create(database_types type) {
@@ -225,4 +225,4 @@ bool sqlite_dialect::supports_feature(const std::string& feature) const {
     return false;
 }
 
-} // namespace database::query
+} // namespace kcenon::database::query

--- a/src/query_builder/value_formatter.cpp
+++ b/src/query_builder/value_formatter.cpp
@@ -8,7 +8,7 @@
 #include <cmath>
 #include <variant>
 
-namespace database::query {
+namespace kcenon::database::query {
 
 value_formatter::value_formatter(database_types db_type)
     : db_type_(db_type) {}
@@ -198,4 +198,4 @@ std::string value_formatter::escape_sqlite_string(const std::string& str) const 
     return result;
 }
 
-} // namespace database::query
+} // namespace kcenon::database::query

--- a/src/security/secure_connection.cpp
+++ b/src/security/secure_connection.cpp
@@ -20,7 +20,7 @@
 #include <openssl/err.h>
 #endif
 
-namespace database::security
+namespace kcenon::database::security
 {
 
 	// ─────────────────────────────────────────────
@@ -946,4 +946,4 @@ namespace database::security
 		return true;
 	}
 
-} // namespace database::security
+} // namespace kcenon::database::security

--- a/tests/async/test_async_operations.cpp
+++ b/tests/async/test_async_operations.cpp
@@ -29,7 +29,7 @@
 
 #include <kcenon/database/async/async_operations.h>
 
-using namespace database::async;
+using namespace kcenon::database::async;
 
 //=============================================================================
 // async_result<T> Tests

--- a/tests/backend_base_test.cpp
+++ b/tests/backend_base_test.cpp
@@ -24,8 +24,8 @@
 #include <kcenon/database/core/backend_base.h>
 #include <kcenon/database/core/database_backend.h>
 
-using namespace database;
-using namespace database::core;
+using namespace kcenon::database;
+using namespace kcenon::database::core;
 
 // =============================================================================
 // Test Backend Implementations

--- a/tests/backend_contract_test.cpp
+++ b/tests/backend_contract_test.cpp
@@ -26,9 +26,9 @@
 #include <kcenon/database/core/database_backend.h>
 #include "mocks/mock_backend.h"
 
-using namespace database;
-using namespace database::core;
-using namespace database::testing;
+using namespace kcenon::database;
+using namespace kcenon::database::core;
+using namespace kcenon::database::testing;
 
 // =============================================================================
 // Test Fixture

--- a/tests/backend_registry_test.cpp
+++ b/tests/backend_registry_test.cpp
@@ -28,8 +28,8 @@
 #include <kcenon/database/core/backend_registry.h>
 #include <kcenon/database/core/database_backend.h>
 
-using namespace database;
-using namespace database::core;
+using namespace kcenon::database;
+using namespace kcenon::database::core;
 
 // =============================================================================
 // Test Backend Implementations

--- a/tests/benchmark_tests.cpp
+++ b/tests/benchmark_tests.cpp
@@ -18,11 +18,11 @@
 #include <kcenon/database/security/secure_connection.h>
 #include <kcenon/database/async/async_operations.h>
 
-using namespace database;
-using namespace database::orm;
-using namespace database::monitoring;
-using namespace database::security;
-using namespace database::async;
+using namespace kcenon::database;
+using namespace kcenon::database::orm;
+using namespace kcenon::database::monitoring;
+using namespace kcenon::database::security;
+using namespace kcenon::database::async;
 
 // Benchmark database manager operations
 static void BM_DatabaseManagerCreation(benchmark::State& state) {

--- a/tests/integrated/test_configuration.cpp
+++ b/tests/integrated/test_configuration.cpp
@@ -20,7 +20,7 @@
 #include <iostream>
 #include <string>
 
-using namespace database::integrated;
+using namespace kcenon::database::integrated;
 
 /**
  * @brief Test default configuration values

--- a/tests/integrated/test_connection_string_builder.cpp
+++ b/tests/integrated/test_connection_string_builder.cpp
@@ -12,7 +12,7 @@
 #include <iostream>
 #include <string>
 
-using namespace database::integrated;
+using namespace kcenon::database::integrated;
 
 // Test counters
 static int tests_passed = 0;

--- a/tests/integrated/test_container_protocol.cpp
+++ b/tests/integrated/test_container_protocol.cpp
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-using namespace database::protocol;
+using namespace kcenon::database::protocol;
 
 /**
  * @brief Test suite for container-based protocol serialization

--- a/tests/integrated/test_database_coordinator.cpp
+++ b/tests/integrated/test_database_coordinator.cpp
@@ -22,8 +22,8 @@
 #include <iostream>
 #include <thread>
 
-using namespace database::integrated;
-using namespace database::integrated::adapters;
+using namespace kcenon::database::integrated;
+using namespace kcenon::database::integrated::adapters;
 
 // Test result tracking
 int tests_passed = 0;

--- a/tests/integrated/test_logger_adapter.cpp
+++ b/tests/integrated/test_logger_adapter.cpp
@@ -18,8 +18,8 @@
 #include <thread>
 #include <vector>
 
-using namespace database::integrated;
-using namespace database::integrated::adapters;
+using namespace kcenon::database::integrated;
+using namespace kcenon::database::integrated::adapters;
 
 namespace fs = std::filesystem;
 

--- a/tests/integrated/test_monitoring_adapter.cpp
+++ b/tests/integrated/test_monitoring_adapter.cpp
@@ -18,8 +18,8 @@
 #include <iostream>
 #include <cassert>
 
-using namespace database::integrated;
-using namespace database::integrated::adapters;
+using namespace kcenon::database::integrated;
+using namespace kcenon::database::integrated::adapters;
 
 // Test result tracking
 int tests_passed = 0;

--- a/tests/integrated/test_thread_adapter.cpp
+++ b/tests/integrated/test_thread_adapter.cpp
@@ -18,8 +18,8 @@
 #include <iostream>
 #include <thread>
 
-using namespace database::integrated;
-using namespace database::integrated::adapters;
+using namespace kcenon::database::integrated;
+using namespace kcenon::database::integrated::adapters;
 
 // Test result tracking
 int tests_passed = 0;

--- a/tests/integrated/test_unified_database_system.cpp
+++ b/tests/integrated/test_unified_database_system.cpp
@@ -20,7 +20,7 @@
 #include <chrono>
 #include <thread>
 
-using namespace database::integrated;
+using namespace kcenon::database::integrated;
 
 // Test counters
 static int tests_passed = 0;

--- a/tests/integration_tests.cpp
+++ b/tests/integration_tests.cpp
@@ -22,11 +22,11 @@
 #include <kcenon/database/security/secure_connection.h>
 #include <kcenon/database/async/async_operations.h>
 
-using namespace database;
-using namespace database::orm;
-using namespace database::monitoring;
-using namespace database::security;
-using namespace database::async;
+using namespace kcenon::database;
+using namespace kcenon::database::orm;
+using namespace kcenon::database::monitoring;
+using namespace kcenon::database::security;
+using namespace kcenon::database::async;
 
 // Test entity for integration tests
 class IntegrationTestUser : public entity_base

--- a/tests/mocks/database_test_utils.h
+++ b/tests/mocks/database_test_utils.h
@@ -12,7 +12,7 @@
 #include <chrono>
 #include <functional>
 
-namespace database::testing {
+namespace kcenon::database::testing {
 
 /**
  * @brief Helper function to create test data rows
@@ -242,4 +242,4 @@ inline bool is_error(const kcenon::common::VoidResult& result) {
 
 } // namespace assertions
 
-} // namespace database::testing
+} // namespace kcenon::database::testing

--- a/tests/mocks/mock_backend.cpp
+++ b/tests/mocks/mock_backend.cpp
@@ -5,7 +5,7 @@
 #include "mock_backend.h"
 #include <algorithm>
 
-namespace database::testing {
+namespace kcenon::database::testing {
 
 // mock_backend implementation
 mock_backend::mock_backend()
@@ -296,4 +296,4 @@ mock_backend mock_backend_builder::build() {
     return std::move(*mock_);
 }
 
-} // namespace database::testing
+} // namespace kcenon::database::testing

--- a/tests/mocks/mock_backend.h
+++ b/tests/mocks/mock_backend.h
@@ -11,7 +11,7 @@
 #include <mutex>
 #include <regex>
 
-namespace database::testing {
+namespace kcenon::database::testing {
 
 /**
  * @class mock_backend
@@ -147,4 +147,4 @@ private:
     std::unique_ptr<mock_backend> mock_;
 };
 
-} // namespace database::testing
+} // namespace kcenon::database::testing

--- a/tests/mocks/mock_backend_expectations.cpp
+++ b/tests/mocks/mock_backend_expectations.cpp
@@ -5,7 +5,7 @@
 #include "mock_backend_expectations.h"
 #include "mock_backend.h"
 
-namespace database::testing {
+namespace kcenon::database::testing {
 
 // backend_expectation implementation
 backend_expectation::backend_expectation()
@@ -191,4 +191,4 @@ backend_expectation_builder& backend_expectation_builder::any_times() {
     return *this;
 }
 
-} // namespace database::testing
+} // namespace kcenon::database::testing

--- a/tests/mocks/mock_backend_expectations.h
+++ b/tests/mocks/mock_backend_expectations.h
@@ -12,7 +12,7 @@
 #include <optional>
 #include <stdexcept>
 
-namespace database::testing {
+namespace kcenon::database::testing {
 
 // Forward declaration
 class mock_backend;
@@ -120,4 +120,4 @@ public:
         : std::runtime_error(message) {}
 };
 
-} // namespace database::testing
+} // namespace kcenon::database::testing

--- a/tests/mocks/mock_connection_pool.h
+++ b/tests/mocks/mock_connection_pool.h
@@ -13,7 +13,7 @@
 #include <atomic>
 #include <chrono>
 
-namespace database::testing {
+namespace kcenon::database::testing {
 
 /**
  * @class mock_connection_pool
@@ -254,4 +254,4 @@ inline void mock_connection_pool::configure_all(std::function<void(mock_database
     }
 }
 
-} // namespace database::testing
+} // namespace kcenon::database::testing

--- a/tests/mocks/mock_database.cpp
+++ b/tests/mocks/mock_database.cpp
@@ -5,7 +5,7 @@
 #include "mock_database.h"
 #include <algorithm>
 
-namespace database::testing {
+namespace kcenon::database::testing {
 
 // mock_database implementation
 mock_database::mock_database()
@@ -304,4 +304,4 @@ mock_database mock_database_builder::build() {
     return std::move(*mock_);
 }
 
-} // namespace database::testing
+} // namespace kcenon::database::testing

--- a/tests/mocks/mock_database.h
+++ b/tests/mocks/mock_database.h
@@ -11,7 +11,7 @@
 #include <mutex>
 #include <regex>
 
-namespace database::testing {
+namespace kcenon::database::testing {
 
 /**
  * @class mock_database
@@ -137,4 +137,4 @@ private:
     std::unique_ptr<mock_database> mock_;
 };
 
-} // namespace database::testing
+} // namespace kcenon::database::testing

--- a/tests/mocks/mock_expectations.cpp
+++ b/tests/mocks/mock_expectations.cpp
@@ -6,7 +6,7 @@
 #include "mock_database.h"
 #include <cstdint>
 
-namespace database::testing {
+namespace kcenon::database::testing {
 
 // expectation implementation
 expectation::expectation()
@@ -177,4 +177,4 @@ expectation_builder& expectation_builder::any_times() {
     return *this;
 }
 
-} // namespace database::testing
+} // namespace kcenon::database::testing

--- a/tests/mocks/mock_expectations.h
+++ b/tests/mocks/mock_expectations.h
@@ -12,7 +12,7 @@
 #include <optional>
 #include <stdexcept>
 
-namespace database::testing {
+namespace kcenon::database::testing {
 
 // Forward declaration
 class mock_database;
@@ -116,4 +116,4 @@ public:
         : std::runtime_error(message) {}
 };
 
-} // namespace database::testing
+} // namespace kcenon::database::testing

--- a/tests/mongodb_backend_test.cpp
+++ b/tests/mongodb_backend_test.cpp
@@ -20,9 +20,9 @@
 #include <kcenon/database/backends/mongodb_backend.h>
 #include <kcenon/database/core/database_backend.h>
 
-using namespace database;
-using namespace database::backends;
-using namespace database::core;
+using namespace kcenon::database;
+using namespace kcenon::database::backends;
+using namespace kcenon::database::core;
 
 // =============================================================================
 // Test Fixture

--- a/tests/monitoring/test_performance_monitor.cpp
+++ b/tests/monitoring/test_performance_monitor.cpp
@@ -17,8 +17,8 @@
 #include <kcenon/database/monitoring/performance_monitor.h>
 #include <kcenon/database/monitoring/pool_metrics.h>
 
-using namespace database;
-using namespace database::monitoring;
+using namespace kcenon::database;
+using namespace kcenon::database::monitoring;
 
 //=============================================================================
 // Helper: create a query_metrics with given parameters

--- a/tests/orm/test_entity_metadata.cpp
+++ b/tests/orm/test_entity_metadata.cpp
@@ -12,7 +12,7 @@
 
 #include <kcenon/database/orm/entity.h>
 
-using namespace database::orm;
+using namespace kcenon::database::orm;
 
 //=============================================================================
 // field_metadata Tests

--- a/tests/postgresql_backend_test.cpp
+++ b/tests/postgresql_backend_test.cpp
@@ -20,9 +20,9 @@
 #include <kcenon/database/backends/postgresql_backend.h>
 #include <kcenon/database/core/database_backend.h>
 
-using namespace database;
-using namespace database::backends;
-using namespace database::core;
+using namespace kcenon::database;
+using namespace kcenon::database::backends;
+using namespace kcenon::database::core;
 
 // =============================================================================
 // Test Fixture

--- a/tests/protocol/test_protocol_serializer.cpp
+++ b/tests/protocol/test_protocol_serializer.cpp
@@ -15,7 +15,7 @@
 
 #include <kcenon/database/protocol/database_protocol.h>
 
-using namespace database::protocol;
+using namespace kcenon::database::protocol;
 
 //=============================================================================
 // message_header Tests

--- a/tests/query/test_immutable_query_builder.cpp
+++ b/tests/query/test_immutable_query_builder.cpp
@@ -13,7 +13,7 @@
 
 #include <kcenon/database/query/immutable_query_builder.h>
 
-using namespace database;
+using namespace kcenon::database;
 
 //=============================================================================
 // immutable_query_builder Tests

--- a/tests/query_builder/sql_dialect_test.cpp
+++ b/tests/query_builder/sql_dialect_test.cpp
@@ -18,7 +18,7 @@
 #include <kcenon/database/query_builder/sql_dialect.h>
 #include <memory>
 
-namespace database::query::tests
+namespace kcenon::database::query::tests
 {
 
 //=============================================================================
@@ -279,4 +279,4 @@ TEST_F(CrossDialectTest, CurrentTimestampFunction)
     EXPECT_EQ(sqlite_->current_timestamp(), "CURRENT_TIMESTAMP");
 }
 
-} // namespace database::query::tests
+} // namespace kcenon::database::query::tests

--- a/tests/query_builder/value_formatter_test.cpp
+++ b/tests/query_builder/value_formatter_test.cpp
@@ -10,8 +10,8 @@
 #include <gtest/gtest.h>
 #include <kcenon/database/query_builder/value_formatter.h>
 
-using namespace database;
-using namespace database::query;
+using namespace kcenon::database;
+using namespace kcenon::database::query;
 
 class ValueFormatterTest : public ::testing::Test {
 protected:

--- a/tests/redis_backend_test.cpp
+++ b/tests/redis_backend_test.cpp
@@ -20,9 +20,9 @@
 #include <kcenon/database/backends/redis_backend.h>
 #include <kcenon/database/core/database_backend.h>
 
-using namespace database;
-using namespace database::backends;
-using namespace database::core;
+using namespace kcenon::database;
+using namespace kcenon::database::backends;
+using namespace kcenon::database::core;
 
 // =============================================================================
 // Test Fixture

--- a/tests/security/credential_test.cpp
+++ b/tests/security/credential_test.cpp
@@ -22,9 +22,9 @@
 #include <kcenon/database/core/database_backend.h>
 #include <kcenon/database/database_types.h>
 
-using namespace database;
-using namespace database::backends;
-using namespace database::core;
+using namespace kcenon::database;
+using namespace kcenon::database::backends;
+using namespace kcenon::database::core;
 
 /**
  * @class CredentialSecurityTest

--- a/tests/security/data_masking_test.cpp
+++ b/tests/security/data_masking_test.cpp
@@ -23,9 +23,9 @@
 #include <kcenon/database/core/database_backend.h>
 #include <kcenon/database/query_builder.h>
 
-using namespace database;
-using namespace database::backends;
-using namespace database::core;
+using namespace kcenon::database;
+using namespace kcenon::database::backends;
+using namespace kcenon::database::core;
 
 /**
  * @class DataMaskingTest

--- a/tests/security/sql_injection_test.cpp
+++ b/tests/security/sql_injection_test.cpp
@@ -20,9 +20,9 @@
 #include <kcenon/database/backends/sqlite_backend.h>
 #include <kcenon/database/core/database_backend.h>
 
-using namespace database;
-using namespace database::backends;
-using namespace database::core;
+using namespace kcenon::database;
+using namespace kcenon::database::backends;
+using namespace kcenon::database::core;
 
 /**
  * @class SQLInjectionTest

--- a/tests/sql_query_builder_test.cpp
+++ b/tests/sql_query_builder_test.cpp
@@ -13,7 +13,7 @@
 #include <map>
 #include <vector>
 
-namespace database::tests
+namespace kcenon::database::tests
 {
 
 class SQLQueryBuilderTest : public ::testing::Test
@@ -517,4 +517,4 @@ TEST_F(SQLQueryBuilderTest, SwitchDatabase)
     EXPECT_TRUE(query.find("[users]") != std::string::npos);  // SQLite syntax
 }
 
-} // namespace database::tests
+} // namespace kcenon::database::tests

--- a/tests/sqlite_backend_test.cpp
+++ b/tests/sqlite_backend_test.cpp
@@ -24,9 +24,9 @@
 #include <kcenon/database/backends/sqlite_backend.h>
 #include <kcenon/database/core/database_backend.h>
 
-using namespace database;
-using namespace database::backends;
-using namespace database::core;
+using namespace kcenon::database;
+using namespace kcenon::database::backends;
+using namespace kcenon::database::core;
 
 /**
  * @class SQLiteBackendTest

--- a/tests/stress/async_stress_test.cpp
+++ b/tests/stress/async_stress_test.cpp
@@ -25,9 +25,9 @@
 #include <kcenon/database/core/database_backend.h>
 #include <kcenon/database/query_builder.h>
 
-using namespace database;
-using namespace database::backends;
-using namespace database::core;
+using namespace kcenon::database;
+using namespace kcenon::database::backends;
+using namespace kcenon::database::core;
 
 /**
  * @class AsyncStressTest

--- a/tests/stress/memory_stress_test.cpp
+++ b/tests/stress/memory_stress_test.cpp
@@ -27,9 +27,9 @@
 #include <mach/task.h>
 #endif
 
-using namespace database;
-using namespace database::backends;
-using namespace database::core;
+using namespace kcenon::database;
+using namespace kcenon::database::backends;
+using namespace kcenon::database::core;
 
 /**
  * @class MemoryStressTest

--- a/tests/test_async.cpp
+++ b/tests/test_async.cpp
@@ -10,7 +10,7 @@
 
 #include <kcenon/database/async/async_operations.h>
 
-using namespace database::async;
+using namespace kcenon::database::async;
 
 // Phase 4: Asynchronous Operations Tests
 class AsyncOperationsTest : public ::testing::Test {

--- a/tests/test_container_protocol_standalone.cpp
+++ b/tests/test_container_protocol_standalone.cpp
@@ -21,7 +21,7 @@
 #include <kcenon/database/protocol/database_protocol.h>
 #include <kcenon/database/protocol/database_protocol_container.h>
 
-using namespace database::protocol;
+using namespace kcenon::database::protocol;
 
 // Simple assertion macro
 #define TEST_ASSERT(condition, message) \

--- a/tests/test_database.cpp
+++ b/tests/test_database.cpp
@@ -10,7 +10,7 @@
 #include <kcenon/database/database_manager.h>
 #include <kcenon/database/database_types.h>
 
-using namespace database;
+using namespace kcenon::database;
 
 // Test fixture for database tests
 class DatabaseTest : public ::testing::Test {

--- a/tests/test_monitoring.cpp
+++ b/tests/test_monitoring.cpp
@@ -12,8 +12,8 @@
 #include <kcenon/database/database_types.h>
 #include <kcenon/database/monitoring/performance_monitor.h>
 
-using namespace database;
-using namespace database::monitoring;
+using namespace kcenon::database;
+using namespace kcenon::database::monitoring;
 
 // Phase 4: Performance Monitoring Tests
 class PerformanceMonitorTest : public ::testing::Test {

--- a/tests/test_orm.cpp
+++ b/tests/test_orm.cpp
@@ -8,7 +8,7 @@
 
 #include <kcenon/database/orm/entity.h>
 
-using namespace database::orm;
+using namespace kcenon::database::orm;
 
 // Test entity for ORM tests
 class TestUser : public entity_base {

--- a/tests/test_query_builder.cpp
+++ b/tests/test_query_builder.cpp
@@ -10,7 +10,7 @@
 #include <kcenon/database/database_manager.h>
 #include <kcenon/database/database_types.h>
 
-using namespace database;
+using namespace kcenon::database;
 
 // Connection Pool Tests removed in Phase 4.3 - pooling moved to server-side ProxyMode
 // Use ProxyMode with database_server for centralized connection pooling

--- a/tests/test_security.cpp
+++ b/tests/test_security.cpp
@@ -8,7 +8,7 @@
 
 #include <kcenon/database/security/secure_connection.h>
 
-using namespace database::security;
+using namespace kcenon::database::security;
 
 // Phase 4: Security Framework Tests
 // Note: Security tests are conceptual demonstrations

--- a/tests/universal_query_builder_test.cpp
+++ b/tests/universal_query_builder_test.cpp
@@ -12,7 +12,7 @@
 #include <string>
 #include <map>
 
-namespace database::tests
+namespace kcenon::database::tests
 {
 
 class UniversalQueryBuilderTest : public ::testing::Test
@@ -347,4 +347,4 @@ TEST_F(UniversalQueryBuilderTest, LimitForMongoDB)
 }
 #endif // USE_MONGODB
 
-} // namespace database::tests
+} // namespace kcenon::database::tests


### PR DESCRIPTION
## Summary

Aligns the internal namespace with the canonical `kcenon/database/...` include
path and tidies the source layout, per the P0 API-consistency refactor.

- **Namespace migration**: every in-tree namespace definition (headers, sources,
  and C++20 module partitions) now opens `kcenon::database` instead of the
  top-level `database` namespace.
- **Tracked compat alias**: new header `kcenon/database/compat.h` declares the
  global alias `namespace database = kcenon::database;`, pulled in by the
  foundation headers (`database_types.h`, `core/result.h`, `forward.h`,
  `database_manager.h`). Existing consumers that spell types as `database::` or
  `::database::` keep compiling unchanged. Define
  `DATABASE_DISABLE_LEGACY_NAMESPACE` to build without it.
- **Source relocation**: the four loose `*_manager` / query translation units at
  the `src` root move into their domain folders:
  `database_manager.cpp` -> `core/`, `postgres_manager.cpp` -> `backends/`,
  `query_builder.cpp` and `query_dialect.cpp` -> `query_builder/`. Public include
  paths are unchanged.
- **Lifecycle decision (explicit removal version)**: the legacy `legacy_include/`
  forwarding tree stays installed (default ON) with its deprecation pragma, and
  the `database::` alias is retained — both are **scheduled for removal in
  version 2.0.0**. Removing a public include path or a namespace spelling is
  source-breaking, so per SemVer it belongs to the next major release, not a
  minor one. The vague "next minor release" wording in the legacy stubs and
  `cmake/options.cmake` is replaced with "version 2.0.0", and CHANGELOG records
  the decision.

## Acceptance criteria

- [x] namespace migrated to `kcenon::database::` (compat alias retained and tracked)
- [x] `legacy_include/` given an explicit deprecation/removal version (2.0.0)
- [x] loose `src` manager files relocated into domain folders

## Lifecycle decision (for #590)

`legacy_include/` is **deprecated-with-version**, not removed-from-install:
- legacy `<database/...>` include shims: removed in **2.0.0**
- `database::` namespace alias (`compat.h`): removed in **2.0.0**

Both removals share the same 2.0.0 breaking-change window so consumers migrate
include path and namespace together.

## Test plan

A full multi-backend build needs external services and vcpkg-provisioned
dependencies (libpqxx, mongo-cxx, hiredis), which are provided by CI. Locally,
the namespace refactor was verified by `-fsyntax-only` compilation of the changed
translation units and a representative header from every domain, using the real
`common_system` headers and C++20:

- `database_types.h`, `core/result.h`, `compat.h` — compile clean (0 errors).
- Moved units `query_builder/query_builder.cpp`, `query_builder/query_dialect.cpp`
  — compile clean.
- `adapters/common_system_database_adapter.h` (uses `::database::`, not migrated)
  — compiles clean, confirming the compat alias resolves legacy-spelled
  references.
- Headers across core / orm / monitoring / protocol / query_builder / security /
  async / integrated / utils — all compile clean.

Full backend builds, sanitizers, static analysis, and the unit/integration test
suites are exercised by CI.

Closes #591.
