### PR TITLE
docs(audit): document backend feature support and CMake/vcpkg defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   legacy `<database/...>` include shims, so consumers migrate include path and
   namespace together ([#591](https://github.com/kcenon/database_system/issues/591)).
 
+### Documentation
+
+- Reworked `docs/BACKENDS.md` into the authoritative **backend and integration
+  feature matrix**: each backend, ecosystem integration, OpenSSL, and the legacy
+  include shims now lists its CMake option/default, vcpkg feature and
+  default-features membership, support level, and a verification command. Added a
+  dedicated section reconciling the **CMake-vs-vcpkg default mismatch** (the two
+  default surfaces are intentionally different: direct CMake defaults ecosystem
+  integration ON with graceful fallback, while the vcpkg default ships only the
+  `postgresql` feature). Documented the legacy `<database/...>` shim and
+  `database::` namespace-alias lifecycle (both removed in **2.0.0**). Linked the
+  matrix from `README.md`, `README.kr.md`, and `docs/advanced/CURRENT_STATE.md`,
+  extended the README build-option tables with the integration/OpenSSL/legacy
+  options, and surfaced MongoDB/Redis experimental status at every introduction
+  point ([#590](https://github.com/kcenon/database_system/issues/590)).
+
 ## [1.0.0] - 2026-04-16
 
 ### Changed

--- a/README.kr.md
+++ b/README.kr.md
@@ -182,8 +182,11 @@ auto query = builder
 
 | 백엔드 | CMake 옵션 | vcpkg 기능 | 상태 | 비고 |
 |---------|--------------|---------------|--------|-------|
-| **MongoDB** | `USE_MONGODB=ON` | `mongodb` | 🧪 실험적 | NoSQL 문서 저장소 |
-| **Redis** | `USE_REDIS=ON` | `redis` | 🧪 실험적 | 인메모리 데이터 저장소 |
+| **MongoDB** | `USE_MONGODB=ON` | `mongodb` | 🧪 실험적 | NoSQL 문서 저장소, 제한적 테스트 |
+| **Redis** | `USE_REDIS=ON` | `redis` | 🧪 실험적 | 인메모리 데이터 저장소, 제한적 테스트 |
+
+> 권위 있는 지원 수준, CMake vs vcpkg 기본값, 실험적 백엔드 제한 사항 및
+> 안정화 로드맵은 [백엔드 및 통합 기능 매트릭스 →](docs/BACKENDS.md)를 참조하세요.
 
 **실험적 백엔드를 활성화하려면:**
 
@@ -633,13 +636,26 @@ target_link_libraries(your_target PRIVATE database_system::database)
 
 | 옵션 | 기본값 | 설명 |
 |--------|---------|-------------|
-| `USE_POSTGRESQL` | ON | PostgreSQL 지원 활성화 |
-| `USE_SQLITE` | OFF | SQLite 지원 활성화 |
-| `USE_MONGODB` | OFF | MongoDB 지원 활성화 |
-| `USE_REDIS` | OFF | Redis 지원 활성화 |
+| `USE_POSTGRESQL` | ON | PostgreSQL 지원 활성화 (안정) |
+| `USE_SQLITE` | OFF | SQLite 지원 활성화 (안정) |
+| `USE_MONGODB` | OFF | MongoDB 지원 활성화 (🧪 실험적) |
+| `USE_REDIS` | OFF | Redis 지원 활성화 (🧪 실험적) |
+| `USE_OPENSSL` | ON | `secure_connection`용 OpenSSL TLS / 암호화 활성화 |
+| `USE_THREAD_SYSTEM` | ON | thread_system 통합 활성화 (미발견 시 자동 비활성화) |
+| `USE_MONITORING_SYSTEM` | ON | monitoring_system 통합 활성화 (미발견 시 자동 비활성화) |
+| `USE_CONTAINER_SYSTEM` | ON | container_system 통합 활성화 (미발견 시 자동 비활성화) |
+| `DATABASE_DISABLE_LEGACY_HEADERS` | OFF | `<database/...>` 포워딩 심 설치 건너뛰기 (2.0.0에서 제거 예정) |
 | `BUILD_DATABASE_SAMPLES` | ON | 샘플 프로그램 빌드 |
 | `USE_UNIT_TEST` | ON | 단위 테스트 빌드 |
-| `BUILD_WITH_COMMON_SYSTEM` | OFF | common_system 통합 활성화 (Result<T>, KCENON_HAS_COMMON_SYSTEM 설정) |
+| `BUILD_WITH_COMMON_SYSTEM` | 발견 시 ON | common_system 통합 (Result<T>, KCENON_HAS_COMMON_SYSTEM 설정); common_system은 필수 Tier 0 의존성 |
+
+> **CMake vs vcpkg 기본값 (의도적으로 다름).** 직접 CMake / FetchContent 빌드는
+> 에코시스템 통합 옵션(`USE_THREAD_SYSTEM`, `USE_MONITORING_SYSTEM`,
+> `USE_CONTAINER_SYSTEM`)을 기본 **ON**으로 두고 형제 시스템이 없으면 우아하게
+> 비활성화됩니다. `vcpkg install`은 `postgresql` 기본 기능만 제공하며 에코시스템
+> 통합은 `vcpkg install kcenon-database-system[ecosystem]`로 선택합니다. 전체
+> 조정 내역, 기능별 검증 명령, 레거시 심 수명 주기는
+> [백엔드 및 통합 기능 매트릭스 →](docs/BACKENDS.md)를 참조하세요.
 
 [📦 전체 빌드 가이드 →](docs/guides/BUILD_GUIDE.md)
 

--- a/README.md
+++ b/README.md
@@ -182,8 +182,12 @@ auto query = builder
 
 | Backend | CMake Option | vcpkg Feature | Status | Notes |
 |---------|--------------|---------------|--------|-------|
-| **MongoDB** | `USE_MONGODB=ON` | `mongodb` | 🧪 Experimental | NoSQL document store |
-| **Redis** | `USE_REDIS=ON` | `redis` | 🧪 Experimental | In-memory data store |
+| **MongoDB** | `USE_MONGODB=ON` | `mongodb` | 🧪 Experimental | NoSQL document store, limited testing |
+| **Redis** | `USE_REDIS=ON` | `redis` | 🧪 Experimental | In-memory data store, limited testing |
+
+> See the [Backend and Integration Feature Matrix →](docs/BACKENDS.md) for the
+> authoritative support levels, CMake-vs-vcpkg defaults, and experimental-backend
+> limitations and stabilization roadmap.
 
 **To enable experimental backends:**
 
@@ -633,13 +637,28 @@ target_link_libraries(your_target PRIVATE database_system::database)
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `USE_POSTGRESQL` | ON | Enable PostgreSQL support |
-| `USE_SQLITE` | OFF | Enable SQLite support |
-| `USE_MONGODB` | OFF | Enable MongoDB support |
-| `USE_REDIS` | OFF | Enable Redis support |
+| `USE_POSTGRESQL` | ON | Enable PostgreSQL support (stable) |
+| `USE_SQLITE` | OFF | Enable SQLite support (stable) |
+| `USE_MONGODB` | OFF | Enable MongoDB support (🧪 experimental) |
+| `USE_REDIS` | OFF | Enable Redis support (🧪 experimental) |
+| `USE_OPENSSL` | ON | Enable OpenSSL-backed TLS / crypto for `secure_connection` |
+| `USE_THREAD_SYSTEM` | ON | Enable thread_system integration (auto-disables if not found) |
+| `USE_MONITORING_SYSTEM` | ON | Enable monitoring_system integration (auto-disables if not found) |
+| `USE_CONTAINER_SYSTEM` | ON | Enable container_system integration (auto-disables if not found) |
+| `DATABASE_DISABLE_LEGACY_HEADERS` | OFF | Skip installing `<database/...>` forwarding shims (removed in 2.0.0) |
 | `BUILD_DATABASE_SAMPLES` | ON | Build sample programs |
 | `USE_UNIT_TEST` | ON | Build unit tests |
-| `BUILD_WITH_COMMON_SYSTEM` | OFF | Enable common_system integration (Result<T>, sets KCENON_HAS_COMMON_SYSTEM) |
+| `BUILD_WITH_COMMON_SYSTEM` | ON when found | common_system integration (Result<T>, sets KCENON_HAS_COMMON_SYSTEM); common_system is a required Tier 0 dependency |
+
+> **CMake vs vcpkg defaults (intentionally different).** A direct CMake /
+> FetchContent build defaults the ecosystem-integration options (`USE_THREAD_SYSTEM`,
+> `USE_MONITORING_SYSTEM`, `USE_CONTAINER_SYSTEM`) to **ON** and degrades
+> gracefully when a sibling system is absent. A `vcpkg install` ships only the
+> `postgresql` default feature; ecosystem integration is opt-in via
+> `vcpkg install kcenon-database-system[ecosystem]`. See the
+> [Backend and Integration Feature Matrix →](docs/BACKENDS.md) for the full
+> reconciliation, per-feature verification commands, and the legacy shim
+> lifecycle.
 
 [📦 Complete Build Guide →](docs/guides/BUILD_GUIDE.md)
 

--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -1,22 +1,135 @@
 ---
 doc_id: "DBS-GUID-002"
-doc_title: "Backend Stability Overview"
-doc_version: "1.0.0"
-doc_date: "2026-04-04"
+doc_title: "Backend and Integration Feature Matrix"
+doc_version: "1.1.0"
+doc_date: "2026-05-31"
 doc_status: "Released"
 project: "database_system"
 category: "GUID"
 ---
 
-# Backend Stability Overview
+# Backend and Integration Feature Matrix
 
-> **SSOT**: This document is the single source of truth for **Backend Stability Overview**.
+> **SSOT**: This document is the single source of truth for **backend support
+> status, ecosystem-integration support status, and the CMake-vs-vcpkg default
+> behavior** of `database_system`.
 
-This document describes the maturity level of each database backend in the
-database\_system project and outlines the process for graduating experimental
-backends to stable status.
+This document records the maturity level and default-enablement behavior of every
+database backend and ecosystem integration option, reconciles the CMake build
+defaults against the vcpkg feature defaults, and documents the lifecycle of the
+legacy `<database/...>` include shims. It also outlines the process for graduating
+experimental backends to stable status.
 
-## Status Summary
+---
+
+## 1. Feature Matrix
+
+The following matrix is the authoritative summary. Each row lists the controlling
+CMake option (and its default), the vcpkg feature that pulls in the dependency
+(and whether it is in the vcpkg **default-features** set), the support level, and a
+command that verifies the feature configures.
+
+| Feature / Integration | CMake option | CMake default | vcpkg feature | In vcpkg default-features | Support level | Verification command |
+|---|---|:---:|---|:---:|---|---|
+| PostgreSQL backend | `USE_POSTGRESQL` | **ON** | `postgresql` | **Yes** | Stable | `cmake --preset default` |
+| SQLite backend | `USE_SQLITE` | OFF | `sqlite` | No | Stable | `cmake -B build -DUSE_SQLITE=ON` |
+| MongoDB backend | `USE_MONGODB` | OFF | `mongodb` | No | **Experimental** | `cmake -B build -DUSE_MONGODB=ON` |
+| Redis backend | `USE_REDIS` | OFF | `redis` | No | **Experimental** | `cmake -B build -DUSE_REDIS=ON` |
+| OpenSSL (TLS / crypto) | `USE_OPENSSL` | **ON** | (pulled in by `postgresql`) | **Yes** (via `postgresql`) | Stable | `cmake --preset default` (warns if OpenSSL absent) |
+| thread_system integration | `USE_THREAD_SYSTEM` | **ON** | `ecosystem` | No | Optional (graceful fallback) | `cmake -B build -DUSE_THREAD_SYSTEM=ON` |
+| monitoring_system integration | `USE_MONITORING_SYSTEM` | **ON** | `ecosystem` | No | Optional (graceful fallback) | `cmake -B build -DUSE_MONITORING_SYSTEM=ON` |
+| container_system integration | `USE_CONTAINER_SYSTEM` | **ON** | `ecosystem` | No | Optional (graceful fallback) | `cmake -B build -DUSE_CONTAINER_SYSTEM=ON` |
+| logger_system integration | (auto, via adapters) | n/a | `ecosystem` | No | Optional (graceful fallback) | `cmake -B build -DUSE_THREAD_SYSTEM=ON` |
+| common_system (Tier 0) | (required, auto) | n/a (`BUILD_WITH_COMMON_SYSTEM` set ON on detection) | `kcenon-common-system` (top-level dependency) | **Yes** (always) | Required | `cmake --preset default` (FATAL_ERROR if missing) |
+| Legacy `<database/...>` include shims | `DATABASE_DISABLE_LEGACY_HEADERS` | OFF (shims **installed**) | n/a | n/a | Deprecated, removal in **2.0.0** | `cmake --preset default` then check `<prefix>/include/database/` |
+| Legacy `database::` namespace alias | `DATABASE_DISABLE_LEGACY_NAMESPACE` | OFF (alias **active**) | n/a | n/a | Deprecated, removal in **2.0.0** | compile any source using `database::` against installed headers |
+
+Notes:
+
+- "In vcpkg default-features" reflects the `default-features` array of
+  `vcpkg.json`, which currently contains only `postgresql`. Consumers therefore
+  receive PostgreSQL (and its OpenSSL dependency) out of the box, and must opt in
+  to every other backend and to ecosystem integration.
+- The integration rows are gated by the `ecosystem` vcpkg feature, which installs
+  `kcenon-thread-system`, `kcenon-logger-system`, `kcenon-container-system`, and
+  `kcenon-monitoring-system`. With a plain `vcpkg install` (default features only)
+  these packages are **not** installed, so the CMake integration options
+  gracefully disable themselves at configure time (see Section 3).
+- The `OpenSSL` row has **no dedicated vcpkg feature**: OpenSSL is a transitive
+  dependency of the `postgresql` feature (`"openssl", "version>=": "3.3.0"`), so
+  it is present whenever the default `postgresql` feature is installed.
+
+---
+
+## 2. CMake-vs-vcpkg Default Reconciliation
+
+There is an intentional and documented mismatch between the CMake build defaults
+and the vcpkg default-features set. **The two default surfaces serve different
+audiences and are deliberately NOT aligned.**
+
+| Option group | CMake default (direct / FetchContent build) | vcpkg default (`vcpkg install`) |
+|---|---|---|
+| PostgreSQL (`USE_POSTGRESQL`) | ON | included (`postgresql` is the only default feature) |
+| OpenSSL (`USE_OPENSSL`) | ON | included transitively via `postgresql` |
+| Ecosystem integration (`USE_THREAD_SYSTEM`, `USE_MONITORING_SYSTEM`, `USE_CONTAINER_SYSTEM`) | **ON** | **not included** (behind the `ecosystem` feature) |
+| SQLite / MongoDB / Redis | OFF | not included (opt-in features) |
+
+### Why they differ (intentional)
+
+- **Direct CMake / FetchContent consumers** are typically building inside the
+  kcenon monorepo or a superbuild where `thread_system`, `monitoring_system`, and
+  `container_system` are already present. Defaulting the integration options to
+  `ON` gives those consumers the full-featured build with no extra flags. When a
+  sibling system is *not* present, the CMake logic degrades gracefully: each
+  `USE_*_SYSTEM` option that cannot be satisfied is automatically forced `OFF`
+  with a `STATUS`/`WARNING` message (see `cmake/dependencies.cmake`), so the
+  default-ON posture never breaks a standalone configure.
+- **vcpkg consumers** install `database_system` as a standalone port. Pulling the
+  entire kcenon ecosystem (four additional registry packages) into every default
+  install would be surprising and heavyweight, and those packages may not be
+  present in a consumer's registry. The vcpkg default is therefore deliberately
+  minimal — PostgreSQL only — and ecosystem integration is opt-in via the
+  `ecosystem` feature: `vcpkg install kcenon-database-system[ecosystem]`.
+
+### Net effect for consumers
+
+| Build path | What you get by default |
+|---|---|
+| `cmake --preset default` (no vcpkg) | PostgreSQL + OpenSSL + ecosystem integration **if the sibling systems are findable**; integration auto-disables otherwise |
+| `vcpkg install kcenon-database-system` | PostgreSQL + OpenSSL only; **no** ecosystem integration |
+| `vcpkg install kcenon-database-system[ecosystem]` | PostgreSQL + OpenSSL + ecosystem integration packages installed |
+| `cmake --preset full` | All four backends (PostgreSQL, SQLite, MongoDB, Redis) + integration |
+
+This difference is **by design**; do not "fix" it by forcing the ecosystem
+packages into the vcpkg default-features set or by flipping the CMake integration
+options to OFF. If the policy ever changes, update this section, `vcpkg.json`, and
+`cmake/options.cmake` together.
+
+---
+
+## 3. Graceful-Degradation Contract (ecosystem integrations)
+
+The ecosystem integration options default to `ON` but never hard-fail a build:
+
+```
+USE_THREAD_SYSTEM=ON  -> find_system_dependency(thread_system)
+                          found     -> integration enabled
+                          not found -> WARNING + USE_THREAD_SYSTEM forced OFF
+```
+
+The same pattern applies to `USE_MONITORING_SYSTEM` and `USE_CONTAINER_SYSTEM`
+(`cmake/dependencies.cmake`). Only `common_system` is mandatory: if it is not
+found, configuration aborts with `FATAL_ERROR` because the `Result<T>` pattern is
+required.
+
+`USE_OPENSSL=ON` is also non-fatal when OpenSSL is absent: `secure_connection`
+falls back to placeholder crypto with a loud `WARNING` (not for production). Pass
+`-DUSE_OPENSSL=OFF` only for minimal embedded builds; see
+`docs/compliance/ISO_27001.md`.
+
+---
+
+## 4. Backend Status Summary
 
 | Backend          | Status         | Since   | vcpkg Feature    | Notes                                |
 |------------------|----------------|---------|------------------|--------------------------------------|
@@ -26,12 +139,14 @@ backends to stable status.
 | Redis            | Experimental   | v0.1.0  | `redis`          | Key-value store backend, limited testing |
 
 > Experimental status is also declared in `vcpkg.json` feature descriptions
-> (e.g., `"Enable MongoDB backend (experimental)"`). Both sources must be
-> updated together when a backend is promoted.
+> (e.g., `"Enable MongoDB backend (experimental)"`), in `cmake/options.cmake`
+> (the `USE_MONGODB` / `USE_REDIS` option help strings and the configure-time
+> `WARNING` messages), and in `README.md`. All of these sources must be updated
+> together when a backend is promoted.
 
 ---
 
-## Stable Backends
+## 5. Stable Backends
 
 ### PostgreSQL
 
@@ -42,6 +157,18 @@ database\_system project.
 - Transaction management
 - Comprehensive integration test coverage
 - CI-validated on Linux, macOS, and Windows
+
+> **External-dependency / external-service requirement**: `USE_POSTGRESQL`
+> defaults to `ON`, but actual PostgreSQL support is compiled in **only when the
+> `libpqxx` client library (and OpenSSL) are found**. If `libpqxx` is absent,
+> `src/CMakeLists.txt` emits `WARNING "PostgreSQL libraries not found, disabling
+> PostgreSQL support"` and force-sets `USE_POSTGRESQL=OFF` — the configure still
+> succeeds. Verified locally: `cmake --preset default` with no vcpkg toolchain
+> configures cleanly and reports `PostgreSQL support: OFF` because `libpqxx` was
+> not on the system; the vcpkg `postgresql` default feature (or a system
+> `libpqxx-dev`) provides it. A *running* PostgreSQL server is required only to
+> execute integration tests or runtime connections, not to configure or build —
+> the default configure does not contact any database server.
 
 > **Note (Phase 4.3)**: Local client-side connection pooling has been removed. Production pooling is handled server-side via ProxyMode with `database_server` middleware. See [CHANGELOG](CHANGELOG.md) and [README](../README.md).
 
@@ -56,10 +183,13 @@ SQLite provides an embedded, zero-configuration database option.
 
 ---
 
-## Experimental Backends
+## 6. Experimental Backends
 
 > **Warning**: Experimental backends are **not recommended for production use**.
-> APIs may change without notice in future releases.
+> APIs may change without notice in future releases. Their experimental status is
+> surfaced at every introduction point: `vcpkg.json` feature descriptions,
+> `cmake/options.cmake` option help strings and configure-time `WARNING`s,
+> `README.md` / `README.kr.md`, and this document.
 
 ### MongoDB
 
@@ -110,7 +240,31 @@ release without deprecation warnings.
 
 ---
 
-## Stabilization Criteria
+## 7. Legacy Include Shim and Namespace Lifecycle
+
+The pre-#591 public surface is preserved by two backward-compatibility mechanisms,
+both **installed by default** and both **scheduled for removal in version 2.0.0**.
+Because removing a public include path or a public namespace spelling is
+source-breaking, removal is deferred to the next SemVer **major** release (current
+version is 1.0.0).
+
+| Compatibility surface | Controlling option | Default | Behavior | Removal target |
+|---|---|:---:|---|:---:|
+| Legacy `<database/...>` include shims (53 forwarding headers under `legacy_include/database/`) | `DATABASE_DISABLE_LEGACY_HEADERS` | OFF (installed) | Each shim emits a `#pragma message` redirecting to `<kcenon/database/...>` and includes the canonical header | **2.0.0** |
+| Legacy `database::` namespace alias (`kcenon/database/compat.h`) | `DATABASE_DISABLE_LEGACY_NAMESPACE` | OFF (alias active) | `namespace database = kcenon::database;` keeps the old spelling compiling | **2.0.0** |
+
+- Consumers that have migrated to `<kcenon/database/...>` and `kcenon::database::`
+  can set `DATABASE_DISABLE_LEGACY_HEADERS=ON` and/or
+  `DATABASE_DISABLE_LEGACY_NAMESPACE` to build without the compatibility surface.
+- Both surfaces are intended to be removed together in the **2.0.0** breaking
+  window so consumers migrate include path and namespace in one step.
+- See issues [#582](https://github.com/kcenon/database_system/issues/582) and
+  [#591](https://github.com/kcenon/database_system/issues/591) and the CHANGELOG
+  "Deprecated" section for the full rationale.
+
+---
+
+## 8. Stabilization Criteria
 
 Before an experimental backend can be promoted to **stable**, all of the
 following criteria must be met:
@@ -142,7 +296,7 @@ Legend: done = met, partial = in progress, -- = not started.
 
 ---
 
-## Stabilization Roadmap
+## 9. Stabilization Roadmap
 
 ### Phase 1 -- Documentation and Clarity (current)
 
@@ -173,7 +327,7 @@ Legend: done = met, partial = in progress, -- = not started.
 
 ---
 
-## Backend Comparison Table
+## 10. Backend Comparison Table
 
 | Feature                    | PostgreSQL | SQLite | MongoDB      | Redis        |
 |----------------------------|:----------:|:------:|:------------:|:------------:|

--- a/docs/advanced/CURRENT_STATE.md
+++ b/docs/advanced/CURRENT_STATE.md
@@ -51,7 +51,12 @@ This document captures the current state of the `database_system` at the beginni
 - C++20 compiler (see `README.md` for authoritative compiler baseline)
 - common_system (required): IDatabase interface, Result<T>
 - container_system (optional): Query results
-- Database backends (PostgreSQL, SQLite, MongoDB, Redis)
+- Database backends: PostgreSQL (stable, default ON), SQLite (stable, opt-in),
+  MongoDB and Redis (**experimental**, opt-in)
+
+> The authoritative backend / ecosystem-integration support matrix, the
+> CMake-vs-vcpkg default reconciliation, and the legacy include-shim lifecycle
+> (removal target **2.0.0**) live in [docs/BACKENDS.md](../BACKENDS.md).
 
 ---
 


### PR DESCRIPTION
## Summary

Documentation/audit chore (no code behavior change). Reworks `docs/BACKENDS.md` into the authoritative **backend and ecosystem-integration feature matrix** and reconciles the CMake-vs-vcpkg default behavior.

## What changed

- **`docs/BACKENDS.md`** — now the SSOT for backend status, integration support, and CMake-vs-vcpkg defaults. Adds a feature matrix where every backend (PostgreSQL, SQLite, MongoDB, Redis), every ecosystem integration (thread/monitoring/container/logger/common), OpenSSL, and the legacy include shims list their CMake option/default, vcpkg feature and default-features membership, support level, and a verification command. New sections:
  - CMake-vs-vcpkg default reconciliation (documented as **intentionally different**)
  - Graceful-degradation contract for ecosystem integrations
  - Legacy `<database/...>` include-shim and `database::` namespace-alias lifecycle (removal target **2.0.0**)
- **`README.md` / `README.kr.md`** — extended the Build Options tables with the integration options (`USE_THREAD_SYSTEM`, `USE_MONITORING_SYSTEM`, `USE_CONTAINER_SYSTEM`), `USE_OPENSSL`, and `DATABASE_DISABLE_LEGACY_HEADERS`; added a CMake-vs-vcpkg default note; linked the matrix; marked MongoDB/Redis experimental at the introduction points.
- **`docs/advanced/CURRENT_STATE.md`** — annotated backend stability and linked the matrix.
- **`CHANGELOG.md`** — Documentation entry under `[Unreleased]`.

## CMake-vs-vcpkg decision

Documented as **intentionally different** (not aligned):
- Direct CMake / FetchContent build defaults the ecosystem-integration options to **ON** and auto-disables any sibling system that is not found (graceful fallback in `cmake/dependencies.cmake`).
- vcpkg default-features ships only `postgresql` (which transitively pulls OpenSSL); full ecosystem integration is opt-in via `vcpkg install kcenon-database-system[ecosystem]`.

## Legacy shim lifecycle

Documented consistently with #591: legacy `<database/...>` shims (53 forwarding headers, gated by `DATABASE_DISABLE_LEGACY_HEADERS=OFF`) and the `database::` namespace alias (gated by `DATABASE_DISABLE_LEGACY_NAMESPACE`) both remain installed by default with deprecation `#pragma message` and are scheduled for removal in **2.0.0**.

## Verification

- `cmake --preset default` (no vcpkg toolchain) configures cleanly. Confirmed the documented PostgreSQL behavior: `USE_POSTGRESQL` defaults ON but auto-disables when `libpqxx` is absent (`src/CMakeLists.txt` forces it OFF with a warning) — the configure still succeeds and contacts no database server.
- Verified all backend features exposed in `vcpkg.json` (postgresql, sqlite, mongodb, redis, ecosystem) are mentioned in the docs.
- The vcpkg-toolchain path was not run locally (vcpkg not installed in this environment); it is documented from `vcpkg.json` and deferred to CI.

Closes #590