### PR TITLE
fix(security): fail closed on empty master key; RAND_bytes for key gen

### DIFF
--- a/src/security/secure_connection.cpp
+++ b/src/security/secure_connection.cpp
@@ -104,17 +104,26 @@ namespace kcenon::database::security
 			return false;
 		}
 
-		// Generate new key
+		// Generate new key using a cryptographically secure RNG
 		std::string old_key = master_key_;
+		std::string new_key(32, '\0');
+#ifdef DATABASE_HAS_OPENSSL
+		if (RAND_bytes(reinterpret_cast<unsigned char*>(new_key.data()),
+		               static_cast<int>(new_key.size())) != 1)
+		{
+			return false;  // CSPRNG failure — abort rather than emit a weak key
+		}
+#else
+		// WARNING: std::mt19937 is NOT a cryptographically secure RNG.
+		// Build with OpenSSL to enable RAND_bytes key generation.
 		std::random_device rd;
 		std::mt19937 gen(rd());
-		std::uniform_int_distribution<int> dist(33, 126);  // printable ASCII
-		std::string new_key;
-		new_key.reserve(32);
-		for (int i = 0; i < 32; ++i)
+		std::uniform_int_distribution<int> dist(0, 255);
+		for (auto& c : new_key)
 		{
-			new_key.push_back(static_cast<char>(dist(gen)));
+			c = static_cast<char>(dist(gen));
 		}
+#endif
 
 		// Re-encrypt all stored credentials with new key
 		std::unordered_map<std::string, std::string> rotated;
@@ -286,9 +295,16 @@ namespace kcenon::database::security
 			return {};
 		}
 
+		// Fail closed: never encrypt with a hardcoded default key. A configured
+		// master key is required for any cryptographic operation.
+		if (master_key_.empty())
+		{
+			return {};
+		}
+
 #ifdef DATABASE_HAS_OPENSSL
 		// AES-256-GCM encryption
-		std::string key = master_key_.empty() ? "default_key_placeholder!!" : master_key_;
+		std::string key = master_key_;
 		// Pad or truncate key to 32 bytes for AES-256
 		key.resize(32, '\0');
 
@@ -356,6 +372,13 @@ namespace kcenon::database::security
 			return {};
 		}
 
+		// Fail closed: never decrypt with a hardcoded default key. A configured
+		// master key is required for any cryptographic operation.
+		if (master_key_.empty())
+		{
+			return {};
+		}
+
 #ifdef DATABASE_HAS_OPENSSL
 		// AES-256-GCM decryption: parse "aes:<iv_hex>:<ciphertext_hex>:<tag_hex>"
 		if (encrypted_data.substr(0, 4) == "aes:")
@@ -371,7 +394,7 @@ namespace kcenon::database::security
 			auto ciphertext = hex_to_bytes(encrypted_data.substr(first + 1, second - first - 1));
 			auto tag = hex_to_bytes(encrypted_data.substr(second + 1));
 
-			std::string key = master_key_.empty() ? "default_key_placeholder!!" : master_key_;
+			std::string key = master_key_;
 			key.resize(32, '\0');
 
 			EVP_CIPHER_CTX* ctx = EVP_CIPHER_CTX_new();
@@ -580,16 +603,25 @@ namespace kcenon::database::security
 	{
 		std::lock_guard<std::mutex> lock(encryption_mutex_);
 
-		// Generate a random key for the field
+		// Generate a random key for the field using a cryptographically secure RNG
+		std::string key(32, '\0');
+#ifdef DATABASE_HAS_OPENSSL
+		if (RAND_bytes(reinterpret_cast<unsigned char*>(key.data()),
+		               static_cast<int>(key.size())) != 1)
+		{
+			return false;  // CSPRNG failure — abort rather than emit a weak key
+		}
+#else
+		// WARNING: std::mt19937 is NOT a cryptographically secure RNG.
+		// Build with OpenSSL to enable RAND_bytes key generation.
 		std::random_device rd;
 		std::mt19937 gen(rd());
 		std::uniform_int_distribution<> dis(0, 255);
-
-		std::string key(32, '\0');
 		for (auto& c : key)
 		{
 			c = static_cast<char>(dis(gen));
 		}
+#endif
 
 		// Hex-encode the key for storage
 		std::ostringstream oss;
@@ -613,15 +645,25 @@ namespace kcenon::database::security
 		}
 
 		// Generate new key (in production, would re-encrypt existing data)
+		// using a cryptographically secure RNG.
+		std::string key(32, '\0');
+#ifdef DATABASE_HAS_OPENSSL
+		if (RAND_bytes(reinterpret_cast<unsigned char*>(key.data()),
+		               static_cast<int>(key.size())) != 1)
+		{
+			return false;  // CSPRNG failure — abort rather than emit a weak key
+		}
+#else
+		// WARNING: std::mt19937 is NOT a cryptographically secure RNG.
+		// Build with OpenSSL to enable RAND_bytes key generation.
 		std::random_device rd;
 		std::mt19937 gen(rd());
 		std::uniform_int_distribution<> dis(0, 255);
-
-		std::string key(32, '\0');
 		for (auto& c : key)
 		{
 			c = static_cast<char>(dis(gen));
 		}
+#endif
 
 		std::ostringstream oss;
 		for (unsigned char c : key)
@@ -650,17 +692,25 @@ namespace kcenon::database::security
 		// Auto-generate field key if not present
 		if (field_keys_.find(key) == field_keys_.end())
 		{
-			// Temporarily release lock to call generate_field_key
-			// Instead, inline the key generation
+			// Inline the key generation using a cryptographically secure RNG.
+			std::string field_key(32, '\0');
+#ifdef DATABASE_HAS_OPENSSL
+			if (RAND_bytes(reinterpret_cast<unsigned char*>(field_key.data()),
+			               static_cast<int>(field_key.size())) != 1)
+			{
+				return false;  // CSPRNG failure — abort rather than emit a weak key
+			}
+#else
+			// WARNING: std::mt19937 is NOT a cryptographically secure RNG.
+			// Build with OpenSSL to enable RAND_bytes key generation.
 			std::random_device rd;
 			std::mt19937 gen(rd());
 			std::uniform_int_distribution<> dis(0, 255);
-
-			std::string field_key(32, '\0');
 			for (auto& c : field_key)
 			{
 				c = static_cast<char>(dis(gen));
 			}
+#endif
 
 			std::ostringstream oss;
 			for (unsigned char ch : field_key)

--- a/tests/test_security.cpp
+++ b/tests/test_security.cpp
@@ -52,3 +52,72 @@ TEST_F(SecurityTest, SecurityConceptDemonstration) {
   // Test that security concepts are understood
   EXPECT_TRUE(true); // Security concepts validated
 }
+
+// Regression test for kcenon/database_system#599.
+// Credential encryption must fail closed when no master key is configured:
+// it must NOT silently fall back to a hardcoded default key (which would
+// "encrypt" credentials under a publicly-known key). With no master key set,
+// store_credentials produces no usable ciphertext, so a subsequent
+// get_credentials cannot round-trip the credential back out.
+TEST_F(SecurityTest, CredentialEncryptionFailsClosedWithoutMasterKey) {
+  credential_manager mgr;  // No master key configured.
+
+  security_credentials creds;
+  creds.username = "alice";
+  creds.password_hash = "hashed_secret";
+
+  // store_credentials returns true (entry recorded), but the encrypted blob
+  // is empty because encryption fails closed.
+  mgr.store_credentials("conn-1", creds);
+
+  // The credential must NOT be retrievable: a fail-closed encrypt means there
+  // is nothing to decrypt back into a valid credential.
+  auto retrieved = mgr.get_credentials("conn-1");
+  EXPECT_FALSE(retrieved.has_value())
+      << "Credentials round-tripped without a master key — encryption "
+         "silently used a default key instead of failing closed (#599).";
+}
+
+// With a master key configured, the round-trip succeeds, confirming the
+// fail-closed guard does not change behavior when a key is present.
+TEST_F(SecurityTest, CredentialEncryptionRoundTripsWithMasterKey) {
+  credential_manager mgr;
+  mgr.set_master_key("a-strong-32-byte-master-key-value");
+
+  security_credentials creds;
+  creds.username = "bob";
+  creds.password_hash = "hashed_secret";
+
+  mgr.store_credentials("conn-2", creds);
+
+  auto retrieved = mgr.get_credentials("conn-2");
+  ASSERT_TRUE(retrieved.has_value())
+      << "Round-trip failed with a configured master key.";
+  EXPECT_EQ(retrieved->username, "bob");
+  EXPECT_EQ(retrieved->password_hash, "hashed_secret");
+}
+
+// Field-level encryption must also fail closed: with neither a field key nor a
+// master encryption key configured, derive_key yields nothing and
+// encrypt_field_data must return empty rather than encrypt under a default key.
+TEST_F(SecurityTest, FieldEncryptionFailsClosedWithoutKey) {
+  encryption_manager mgr;  // No master key, no field key.
+
+  std::string ciphertext = mgr.encrypt_field_data("sensitive", "ssn");
+  EXPECT_TRUE(ciphertext.empty())
+      << "Field encryption produced output without any configured key (#599).";
+}
+
+// With a configured master encryption key, field encryption round-trips.
+TEST_F(SecurityTest, FieldEncryptionRoundTripsWithMasterKey) {
+  encryption_manager mgr;
+  mgr.set_master_encryption_key("a-strong-32-byte-master-key-value");
+
+  const std::string plaintext = "sensitive";
+  std::string ciphertext = mgr.encrypt_field_data(plaintext, "ssn");
+  ASSERT_FALSE(ciphertext.empty())
+      << "Field encryption returned empty with a configured key.";
+
+  std::string decrypted = mgr.decrypt_field_data(ciphertext, "ssn");
+  EXPECT_EQ(decrypted, plaintext);
+}


### PR DESCRIPTION
## What

Make credential encryption fail closed when no master key is configured, and use the OpenSSL CSPRNG (`RAND_bytes`) for all cryptographic key generation.

## Why

`src/security/secure_connection.cpp` substituted a hardcoded constant key (`"default_key_placeholder!!"`) when `master_key_` was empty, so data was silently encrypted/decrypted under a publicly-known key. Key generation/rotation used `std::mt19937`, a non-cryptographic PRNG. Both are security defects in a released library. (Issue text cited `src/backends/`; the actual path is `src/security/`.)

## How

- Empty master key now fails closed (returns failure, no placeholder key) in `credential_manager` encrypt and decrypt, placed before the `#ifdef DATABASE_HAS_OPENSSL` so OpenSSL and OpenSSL-absent builds behave identically. Behavior is unchanged when a master key is set.
- All four `std::mt19937` key-generation sites (`rotate_encryption_keys`, `generate_field_key`, `rotate_field_key`, `configure_encrypted_column`) now use `RAND_bytes` with return-value checking; a guarded `mt19937` fallback remains only under `#else` (OpenSSL absent), matching the file's existing degradation pattern.
- Field-encryption path was already fail-closed via `derive_key()`; added a regression test pinning it.
- Added 4 unit tests in `tests/test_security.cpp` (fail-closed without key + round-trip with key, for both credential and field encryption).
- Local: `database_unit_tests --gtest_filter='SecurityTest.*'` 6/6 pass (OpenSSL 3.6.2, `cmake --preset debug`).

## Where

- `src/security/secure_connection.cpp`
- `tests/test_security.cpp`

## Scope note

Ships as the single-purpose security CAPA. The error-code range collision (#600) is intentionally NOT bundled here, to keep this fix's V&V evidence isolated. The 3 pre-existing `RAND_bytes` IV/salt calls lacking return checks are noted as a follow-up hardening item, out of scope.

Closes #599
