### PR TITLE
fix(error)!: move local error_code enum into common reserved -500..-599 (v1.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** Remapped every non-zero `kcenon::database::error_code` enumerator
+  into common_system's reserved `database_system` band `[-599, -500]`. The old
+  values collided with common's `common_errors` band (`-1..-99`): casting the
+  former `connection_failed = -5` into the shared `kcenon::common::error_info::code`
+  made consumers resolve it as `Cancelled` / category `Common` instead of
+  `DatabaseSystem`. New values: `success = 0` (unchanged),
+  `connection_failed = -500` (aligned to
+  `common::error::codes::database_system::connection_failed`),
+  `query_failed = -540` (aligned to `database_system::query_failed`),
+  `timeout = -542` (aligned to `database_system::query_timeout`),
+  `invalid_state = -596`, `not_implemented = -597`, `invalid_argument = -598`,
+  `unknown_error = -599`. In addition, every hand-coded error code that previously
+  fed `kcenon::common::error_info` with a positive or `-1..-99` value (backend
+  managers, `backend_registry`, integrated adapters, coordinator, and unified
+  system) is now routed through these in-band codes, so the shared error registry
+  attributes them to the `DatabaseSystem` category. Any consumer comparing against
+  the old numeric values must update. This is a SemVer-major break for callers that
+  read raw `error_info::code`; it must ship as **v1.1.0 coordinated with the
+  ecosystem** — the version bump and release are owner-coordinated and are
+  intentionally not performed here
+  ([#600](https://github.com/kcenon/database_system/issues/600)).
 - Internal namespace migrated from `database::` to `kcenon::database::` so the
   namespace matches the canonical `kcenon/database/...` include path. All in-tree
   namespace definitions (headers, sources, and C++20 module partitions) now open

--- a/include/kcenon/database/core/result.h
+++ b/include/kcenon/database/core/result.h
@@ -41,16 +41,36 @@ using error_info = kcenon::common::error_info;
 // Database-specific error codes
 // =============================================================================
 
-/// Error codes for database operations
+/// @brief Error codes for database operations.
+///
+/// All non-zero values live in common_system's reserved database_system band
+/// [-599, -500] (see kcenon::common::error::category::database_system). This
+/// guarantees that when a backend casts one of these into the shared
+/// kcenon::common::error_info::code, consumers calling
+/// kcenon::common::error::get_category_name() / get_error_message() resolve the
+/// "DatabaseSystem" category instead of mis-attributing the code to the common
+/// (-1..-99) band.
+///
+/// Where common already defines a matching database code in
+/// kcenon::common::error::codes::database_system, the enumerator is aligned to
+/// that exact value so the shared message table returns the correct text:
+///   - connection_failed -> database_system::connection_failed (base-0  = -500)
+///   - query_failed      -> database_system::query_failed      (base-40 = -540)
+///   - timeout           -> database_system::query_timeout     (base-42 = -542)
+///
+/// Database-specific generics with no common equivalent occupy distinct unused
+/// slots at the tail of the band; none collide with a common database_system
+/// code or with the adapter-local constants in
+/// common_system_database_adapter.h (-580..-585).
 enum class error_code {
 	success = 0,
-	unknown_error = -1,
-	invalid_argument = -2,
-	not_implemented = -3,
-	invalid_state = -4,
-	connection_failed = -5,
-	query_failed = -6,
-	timeout = -7
+	connection_failed = -500, // == common::error::codes::database_system::connection_failed
+	invalid_state = -596,
+	not_implemented = -597,
+	invalid_argument = -598,
+	unknown_error = -599,
+	query_failed = -540,      // == common::error::codes::database_system::query_failed
+	timeout = -542            // == common::error::codes::database_system::query_timeout
 };
 
 } // namespace kcenon::database

--- a/src/backends/postgres_manager.cpp
+++ b/src/backends/postgres_manager.cpp
@@ -4,6 +4,8 @@
 
 #include <kcenon/database/postgres_manager.h>
 
+#include <kcenon/database/core/result.h>
+
 #ifdef USE_POSTGRESQL
 #include <pqxx/pqxx>
 #elif defined(HAVE_LIBPQ)
@@ -54,7 +56,7 @@ namespace kcenon::database
 	kcenon::common::VoidResult postgres_manager::initialize(const core::connection_config& config)
 	{
 		if (initialized_) {
-			return kcenon::common::error_info{-1, "Already initialized", "postgres_manager"};
+			return kcenon::common::error_info{static_cast<int>(error_code::invalid_state), "Already initialized", "postgres_manager"};
 		}
 
 		// Build connection string from config
@@ -112,7 +114,8 @@ namespace kcenon::database
 		initialized_ = true;
 		return kcenon::common::ok();
 #endif
-		return kcenon::common::error_info{-2, last_error_, "postgres_manager"};
+		// Connection-open failure path (initialize): map to connection_failed.
+		return kcenon::common::error_info{static_cast<int>(error_code::connection_failed), last_error_, "postgres_manager"};
 	}
 
 	kcenon::common::VoidResult postgres_manager::shutdown()
@@ -151,7 +154,8 @@ namespace kcenon::database
 		POSTGRES_LOG_WARNING("PostgreSQL support not compiled. Mock disconnect.");
 		return kcenon::common::ok();
 #endif
-		return kcenon::common::error_info{-3, last_error_, "postgres_manager"};
+		// Disconnect failure path (shutdown): map to connection_failed.
+		return kcenon::common::error_info{static_cast<int>(error_code::connection_failed), last_error_, "postgres_manager"};
 	}
 
 	bool postgres_manager::is_initialized() const
@@ -162,7 +166,7 @@ namespace kcenon::database
 	kcenon::common::Result<uint64_t> postgres_manager::execute_modification_query(const std::string& query_string)
 	{
 		if (!initialized_) {
-			return kcenon::common::error_info{-1, "Not initialized", "postgres_manager"};
+			return kcenon::common::error_info{static_cast<int>(error_code::invalid_state), "Not initialized", "postgres_manager"};
 		}
 
 #ifdef USE_POSTGRESQL
@@ -175,7 +179,7 @@ namespace kcenon::database
 		} catch (const std::exception& e) {
 			last_error_ = std::string("Modification query error: ") + e.what();
 			POSTGRES_LOG_ERROR("execute_modification_query", last_error_);
-			return kcenon::common::error_info{-2, last_error_, "postgres_manager"};
+			return kcenon::common::error_info{static_cast<int>(error_code::query_failed), last_error_, "postgres_manager"};
 		}
 #elif defined(HAVE_LIBPQ)
 		try {
@@ -183,7 +187,7 @@ namespace kcenon::database
 			if (PQresultStatus(result) != PGRES_COMMAND_OK) {
 				last_error_ = PQerrorMessage(static_cast<PGconn*>(connection_));
 				PQclear(result);
-				return kcenon::common::error_info{-2, last_error_, "postgres_manager"};
+				return kcenon::common::error_info{static_cast<int>(error_code::query_failed), last_error_, "postgres_manager"};
 			}
 			const char* affected_rows = PQcmdTuples(result);
 			uint64_t count = 0;
@@ -195,7 +199,7 @@ namespace kcenon::database
 		} catch (const std::exception& e) {
 			last_error_ = std::string("Modification query error: ") + e.what();
 			POSTGRES_LOG_ERROR("execute_modification_query", last_error_);
-			return kcenon::common::error_info{-2, last_error_, "postgres_manager"};
+			return kcenon::common::error_info{static_cast<int>(error_code::query_failed), last_error_, "postgres_manager"};
 		}
 #else
 		POSTGRES_LOG_WARNING("PostgreSQL support not compiled. Mock modification: " + query_string.substr(0, 20) + "...");
@@ -206,7 +210,7 @@ namespace kcenon::database
 	kcenon::common::Result<core::database_result> postgres_manager::select_query(const std::string& query_string)
 	{
 		if (!initialized_) {
-			return kcenon::common::error_info{-1, "Not initialized", "postgres_manager"};
+			return kcenon::common::error_info{static_cast<int>(error_code::invalid_state), "Not initialized", "postgres_manager"};
 		}
 
 		core::database_result result;
@@ -244,7 +248,7 @@ namespace kcenon::database
 		} catch (const std::exception& e) {
 			last_error_ = std::string("Select query error: ") + e.what();
 			POSTGRES_LOG_ERROR("select_query", last_error_);
-			return kcenon::common::error_info{-2, last_error_, "postgres_manager"};
+			return kcenon::common::error_info{static_cast<int>(error_code::query_failed), last_error_, "postgres_manager"};
 		}
 #elif defined(HAVE_LIBPQ)
 		try {
@@ -252,7 +256,7 @@ namespace kcenon::database
 			if (PQresultStatus(pg_result) != PGRES_TUPLES_OK) {
 				last_error_ = PQerrorMessage(static_cast<PGconn*>(connection_));
 				PQclear(pg_result);
-				return kcenon::common::error_info{-2, last_error_, "postgres_manager"};
+				return kcenon::common::error_info{static_cast<int>(error_code::query_failed), last_error_, "postgres_manager"};
 			}
 
 			int rows = PQntuples(pg_result);
@@ -286,7 +290,7 @@ namespace kcenon::database
 		} catch (const std::exception& e) {
 			last_error_ = std::string("Select query error: ") + e.what();
 			POSTGRES_LOG_ERROR("select_query", last_error_);
-			return kcenon::common::error_info{-2, last_error_, "postgres_manager"};
+			return kcenon::common::error_info{static_cast<int>(error_code::query_failed), last_error_, "postgres_manager"};
 		}
 #else
 		POSTGRES_LOG_WARNING("PostgreSQL support not compiled. Mock select: " + query_string.substr(0, 20) + "...");
@@ -304,7 +308,7 @@ namespace kcenon::database
 	kcenon::common::VoidResult postgres_manager::execute_query(const std::string& query_string)
 	{
 		if (!initialized_) {
-			return kcenon::common::error_info{-1, "Not initialized", "postgres_manager"};
+			return kcenon::common::error_info{static_cast<int>(error_code::invalid_state), "Not initialized", "postgres_manager"};
 		}
 
 #ifdef USE_POSTGRESQL
@@ -316,14 +320,14 @@ namespace kcenon::database
 		} catch (const std::exception& e) {
 			last_error_ = std::string("Execute error: ") + e.what();
 			POSTGRES_LOG_ERROR("execute_query", last_error_);
-			return kcenon::common::error_info{-2, last_error_, "postgres_manager"};
+			return kcenon::common::error_info{static_cast<int>(error_code::query_failed), last_error_, "postgres_manager"};
 		}
 #elif defined(HAVE_LIBPQ)
 		PGresult* result = PQexec(static_cast<PGconn*>(connection_), query_string.c_str());
 		if (result == nullptr) {
 			last_error_ = "PostgreSQL execute failed";
 			POSTGRES_LOG_ERROR("execute_query", last_error_);
-			return kcenon::common::error_info{-2, last_error_, "postgres_manager"};
+			return kcenon::common::error_info{static_cast<int>(error_code::query_failed), last_error_, "postgres_manager"};
 		}
 
 		ExecStatusType status = PQresultStatus(result);
@@ -333,7 +337,7 @@ namespace kcenon::database
 			last_error_ = PQerrorMessage(static_cast<PGconn*>(connection_));
 			POSTGRES_LOG_ERROR("execute_query", last_error_);
 			PQclear(result);
-			return kcenon::common::error_info{-2, last_error_, "postgres_manager"};
+			return kcenon::common::error_info{static_cast<int>(error_code::query_failed), last_error_, "postgres_manager"};
 		}
 
 		PQclear(result);
@@ -347,11 +351,11 @@ namespace kcenon::database
 	kcenon::common::VoidResult postgres_manager::begin_transaction()
 	{
 		if (!initialized_) {
-			return kcenon::common::error_info{-1, "Not initialized", "postgres_manager"};
+			return kcenon::common::error_info{static_cast<int>(error_code::invalid_state), "Not initialized", "postgres_manager"};
 		}
 
 		if (in_transaction_) {
-			return kcenon::common::error_info{-2, "Transaction already active", "postgres_manager"};
+			return kcenon::common::error_info{static_cast<int>(error_code::invalid_state), "Transaction already active", "postgres_manager"};
 		}
 
 		auto result = execute_query("BEGIN");
@@ -364,11 +368,11 @@ namespace kcenon::database
 	kcenon::common::VoidResult postgres_manager::commit_transaction()
 	{
 		if (!initialized_) {
-			return kcenon::common::error_info{-1, "Not initialized", "postgres_manager"};
+			return kcenon::common::error_info{static_cast<int>(error_code::invalid_state), "Not initialized", "postgres_manager"};
 		}
 
 		if (!in_transaction_) {
-			return kcenon::common::error_info{-2, "No active transaction", "postgres_manager"};
+			return kcenon::common::error_info{static_cast<int>(error_code::invalid_state), "No active transaction", "postgres_manager"};
 		}
 
 		auto result = execute_query("COMMIT");
@@ -381,11 +385,11 @@ namespace kcenon::database
 	kcenon::common::VoidResult postgres_manager::rollback_transaction()
 	{
 		if (!initialized_) {
-			return kcenon::common::error_info{-1, "Not initialized", "postgres_manager"};
+			return kcenon::common::error_info{static_cast<int>(error_code::invalid_state), "Not initialized", "postgres_manager"};
 		}
 
 		if (!in_transaction_) {
-			return kcenon::common::error_info{-2, "No active transaction", "postgres_manager"};
+			return kcenon::common::error_info{static_cast<int>(error_code::invalid_state), "No active transaction", "postgres_manager"};
 		}
 
 		auto result = execute_query("ROLLBACK");

--- a/src/core/backend_registry.cpp
+++ b/src/core/backend_registry.cpp
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 #include <kcenon/database/core/backend_registry.h>
+#include <kcenon/database/core/result.h>
 
 #include <algorithm>
 
@@ -22,12 +23,12 @@ kcenon::common::VoidResult backend_registry::register_backend(const std::string&
 {
 	if (name.empty())
 	{
-		return kcenon::common::error_info{1, "Backend name cannot be empty", "backend_registry"};
+		return kcenon::common::error_info{static_cast<int>(error_code::invalid_argument), "Backend name cannot be empty", "backend_registry"};
 	}
 
 	if (!factory)
 	{
-		return kcenon::common::error_info{2, "Factory function cannot be null", "backend_registry"};
+		return kcenon::common::error_info{static_cast<int>(error_code::invalid_argument), "Factory function cannot be null", "backend_registry"};
 	}
 
 	std::lock_guard<std::mutex> lock(mutex_);
@@ -35,7 +36,7 @@ kcenon::common::VoidResult backend_registry::register_backend(const std::string&
 	// Check if backend already registered
 	if (factories_.find(name) != factories_.end())
 	{
-		return kcenon::common::error_info{3, "Backend '" + name + "' is already registered", "backend_registry"};
+		return kcenon::common::error_info{static_cast<int>(error_code::invalid_state), "Backend '" + name + "' is already registered", "backend_registry"};
 	}
 
 	factories_[name] = factory;
@@ -49,7 +50,7 @@ kcenon::common::VoidResult backend_registry::unregister_backend(const std::strin
 	auto it = factories_.find(name);
 	if (it == factories_.end())
 	{
-		return kcenon::common::error_info{4, "Backend '" + name + "' not found", "backend_registry"};
+		return kcenon::common::error_info{static_cast<int>(error_code::invalid_state), "Backend '" + name + "' not found", "backend_registry"};
 	}
 
 	factories_.erase(it);

--- a/src/core/database_manager.cpp
+++ b/src/core/database_manager.cpp
@@ -4,6 +4,7 @@
 
 #include <kcenon/database/database_manager.h>
 
+#include <kcenon/database/core/result.h>
 #include <kcenon/database/core/backend_registry.h>
 #include <kcenon/database/backends/postgresql_backend.h>
 #include <kcenon/database/backends/sqlite_backend.h>
@@ -89,7 +90,7 @@ namespace kcenon::database
 		if (!database_)
 		{
 			return kcenon::common::VoidResult(
-				kcenon::common::error_info{-1, "No database backend configured", "database_manager"});
+				kcenon::common::error_info{static_cast<int>(error_code::invalid_state), "No database backend configured", "database_manager"});
 		}
 
 		// Store connection string for potential reconnection
@@ -111,7 +112,7 @@ namespace kcenon::database
 		if (!database_)
 		{
 			return kcenon::common::VoidResult(
-				kcenon::common::error_info{-1, "No database backend", "database_manager"});
+				kcenon::common::error_info{static_cast<int>(error_code::invalid_state), "No database backend", "database_manager"});
 		}
 
 		auto result = database_->shutdown();
@@ -127,7 +128,7 @@ namespace kcenon::database
 		if (!database_)
 		{
 			return kcenon::common::VoidResult(
-				kcenon::common::error_info{-1, "No database backend", "database_manager"});
+				kcenon::common::error_info{static_cast<int>(error_code::invalid_state), "No database backend", "database_manager"});
 		}
 		// database_backend uses execute_query for DDL/prepared statements
 		return database_->execute_query(query_string);
@@ -138,7 +139,7 @@ namespace kcenon::database
 		if (!database_)
 		{
 			return kcenon::common::Result<core::database_result>(
-				kcenon::common::error_info{-1, "No database backend", "database_manager"});
+				kcenon::common::error_info{static_cast<int>(error_code::invalid_state), "No database backend", "database_manager"});
 		}
 		return database_->select_query(query_string);
 	}
@@ -148,7 +149,7 @@ namespace kcenon::database
 		if (!database_)
 		{
 			return kcenon::common::VoidResult(
-				kcenon::common::error_info{-1, "No database backend", "database_manager"});
+				kcenon::common::error_info{static_cast<int>(error_code::invalid_state), "No database backend", "database_manager"});
 		}
 		return database_->execute_query(query_string);
 	}
@@ -158,7 +159,7 @@ namespace kcenon::database
 		if (!database_)
 		{
 			return kcenon::common::VoidResult(
-				kcenon::common::error_info{-1, "No database backend", "database_manager"});
+				kcenon::common::error_info{static_cast<int>(error_code::invalid_state), "No database backend", "database_manager"});
 		}
 		return database_->begin_transaction();
 	}
@@ -168,7 +169,7 @@ namespace kcenon::database
 		if (!database_)
 		{
 			return kcenon::common::VoidResult(
-				kcenon::common::error_info{-1, "No database backend", "database_manager"});
+				kcenon::common::error_info{static_cast<int>(error_code::invalid_state), "No database backend", "database_manager"});
 		}
 		return database_->commit_transaction();
 	}
@@ -178,7 +179,7 @@ namespace kcenon::database
 		if (!database_)
 		{
 			return kcenon::common::VoidResult(
-				kcenon::common::error_info{-1, "No database backend", "database_manager"});
+				kcenon::common::error_info{static_cast<int>(error_code::invalid_state), "No database backend", "database_manager"});
 		}
 		return database_->rollback_transaction();
 	}

--- a/src/integrated/adapters/backends/common_logger_backend.cpp
+++ b/src/integrated/adapters/backends/common_logger_backend.cpp
@@ -4,6 +4,8 @@
 
 #include <kcenon/database/integrated/adapters/backends/common_logger_backend.h>
 
+#include <kcenon/database/core/result.h>
+
 #if KCENON_HAS_COMMON_SYSTEM
 #include <kcenon/common/interfaces/global_logger_registry.h>
 #include <kcenon/common/logging/log_macros.h>
@@ -14,7 +16,12 @@
 
 namespace
 {
-	inline common::VoidResult make_error(const std::string& msg, int code = -1)
+	// Default to an in-band database_system code (see core/result.h) so the
+	// shared common::error_info::code resolves to "DatabaseSystem", not the
+	// common (-1..-99) band.
+	inline common::VoidResult make_error(
+		const std::string& msg,
+		int code = static_cast<int>(kcenon::database::error_code::unknown_error))
 	{
 		return common::VoidResult(common::error_info{ code, msg, "" });
 	}

--- a/src/integrated/adapters/backends/fallback_logger_backend.cpp
+++ b/src/integrated/adapters/backends/fallback_logger_backend.cpp
@@ -4,6 +4,8 @@
 
 #include <kcenon/database/integrated/adapters/backends/fallback_logger_backend.h>
 
+#include <kcenon/database/core/result.h>
+
 #include <chrono>
 #include <ctime>
 #include <filesystem>
@@ -14,7 +16,12 @@
 
 namespace
 {
-	inline common::VoidResult make_error(const std::string& msg, int code = -1)
+	// Default to an in-band database_system code (see core/result.h) so the
+	// shared common::error_info::code resolves to "DatabaseSystem", not the
+	// common (-1..-99) band.
+	inline common::VoidResult make_error(
+		const std::string& msg,
+		int code = static_cast<int>(kcenon::database::error_code::unknown_error))
 	{
 		return common::VoidResult(common::error_info{ code, msg, "" });
 	}

--- a/src/integrated/adapters/backends/fallback_monitoring_backend.cpp
+++ b/src/integrated/adapters/backends/fallback_monitoring_backend.cpp
@@ -4,21 +4,29 @@
 
 #include <kcenon/database/integrated/adapters/backends/fallback_monitoring_backend.h>
 
+#include <kcenon/database/core/result.h>
+
 #include <algorithm>
 #include <numeric>
 #include <sstream>
 
 namespace
 {
+	// In-band database_system code (see core/result.h) so the shared
+	// common::error_info::code resolves to "DatabaseSystem", not the common
+	// (-1..-99) band.
+	constexpr int kDatabaseErrorCode =
+		static_cast<int>(kcenon::database::error_code::unknown_error);
+
 	inline common::VoidResult make_error(const std::string& msg)
 	{
-		return common::VoidResult(common::error_info{ -1, msg, "" });
+		return common::VoidResult(common::error_info{ kDatabaseErrorCode, msg, "" });
 	}
 
 	template<typename T>
 	common::Result<T> make_error_result(const std::string& msg)
 	{
-		return common::Result<T>(common::error_info{ -1, msg, "" });
+		return common::Result<T>(common::error_info{ kDatabaseErrorCode, msg, "" });
 	}
 }
 

--- a/src/integrated/adapters/backends/fallback_thread_backend.cpp
+++ b/src/integrated/adapters/backends/fallback_thread_backend.cpp
@@ -4,13 +4,19 @@
 
 #include <kcenon/database/integrated/adapters/backends/fallback_thread_backend.h>
 
+#include <kcenon/database/core/result.h>
+
 #include <algorithm>
 
 namespace
 {
+	// In-band database_system code (see core/result.h) so the shared
+	// common::error_info::code resolves to "DatabaseSystem", not the common
+	// (-1..-99) band.
 	inline common::VoidResult make_error(const std::string& msg)
 	{
-		return common::VoidResult(common::error_info{ -1, msg, "" });
+		return common::VoidResult(common::error_info{
+			static_cast<int>(kcenon::database::error_code::unknown_error), msg, "" });
 	}
 }
 

--- a/src/integrated/adapters/backends/system_monitoring_backend.cpp
+++ b/src/integrated/adapters/backends/system_monitoring_backend.cpp
@@ -4,6 +4,7 @@
 
 #include <kcenon/database/integrated/adapters/backends/system_monitoring_backend.h>
 
+#include <kcenon/database/core/result.h>
 #include <kcenon/monitoring/core/performance_monitor.h>
 #include <kcenon/monitoring/exporters/metric_exporters.h>
 
@@ -13,15 +14,21 @@
 
 namespace
 {
+	// In-band database_system code (see core/result.h) so the shared
+	// common::error_info::code resolves to "DatabaseSystem", not the common
+	// (-1..-99) band.
+	constexpr int kDatabaseErrorCode =
+		static_cast<int>(kcenon::database::error_code::unknown_error);
+
 	inline common::VoidResult make_error(const std::string& msg)
 	{
-		return common::VoidResult(common::error_info{ -1, msg, "" });
+		return common::VoidResult(common::error_info{ kDatabaseErrorCode, msg, "" });
 	}
 
 	template<typename T>
 	common::Result<T> make_error_result(const std::string& msg)
 	{
-		return common::Result<T>(common::error_info{ -1, msg, "" });
+		return common::Result<T>(common::error_info{ kDatabaseErrorCode, msg, "" });
 	}
 }
 

--- a/src/integrated/adapters/logger_adapter.cpp
+++ b/src/integrated/adapters/logger_adapter.cpp
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 #include <kcenon/database/integrated/adapters/logger_adapter.h>
+#include <kcenon/database/core/result.h>
 #include <kcenon/database/integrated/adapters/backends/logger_backend.h>
 #include <kcenon/database/integrated/adapters/backends/null_logger_backend.h>
 #include <kcenon/database/integrated/adapters/backends/fallback_logger_backend.h>
@@ -156,7 +157,7 @@ common::VoidResult logger_adapter::initialize()
 	if (!backend_)
 	{
 		return common::VoidResult(
-			common::error_info{ -1, "Backend not created", "" });
+			common::error_info{ static_cast<int>(error_code::invalid_state), "Backend not created", "" });
 	}
 
 	return backend_->initialize();

--- a/src/integrated/adapters/monitoring_adapter.cpp
+++ b/src/integrated/adapters/monitoring_adapter.cpp
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 #include <kcenon/database/integrated/adapters/monitoring_adapter.h>
+#include <kcenon/database/core/result.h>
 #include <kcenon/database/integrated/adapters/backends/monitoring_backend.h>
 #include <kcenon/database/integrated/adapters/backends/null_monitoring_backend.h>
 #include <kcenon/database/integrated/adapters/backends/fallback_monitoring_backend.h>
@@ -83,7 +84,7 @@ common::VoidResult monitoring_adapter::initialize()
 	if (!backend_)
 	{
 		return common::VoidResult(
-			common::error_info{ -1, "Backend not created", "" });
+			common::error_info{ static_cast<int>(error_code::invalid_state), "Backend not created", "" });
 	}
 
 	return backend_->initialize();
@@ -113,7 +114,7 @@ common::VoidResult monitoring_adapter::record_metric(const std::string& name, do
 	if (!backend_)
 	{
 		return common::VoidResult(
-			common::error_info{ -1, "Backend not initialized", "" });
+			common::error_info{ static_cast<int>(error_code::invalid_state), "Backend not initialized", "" });
 	}
 
 	return backend_->record_metric(name, value);
@@ -126,7 +127,7 @@ common::VoidResult monitoring_adapter::record_metric(
 	if (!backend_)
 	{
 		return common::VoidResult(
-			common::error_info{ -1, "Backend not initialized", "" });
+			common::error_info{ static_cast<int>(error_code::invalid_state), "Backend not initialized", "" });
 	}
 
 	return backend_->record_metric(name, value, tags);
@@ -137,7 +138,7 @@ common::Result<backends::metrics_snapshot> monitoring_adapter::get_metrics()
 	if (!backend_)
 	{
 		return common::Result<backends::metrics_snapshot>(
-			common::error_info{ -1, "Backend not initialized", "" });
+			common::error_info{ static_cast<int>(error_code::invalid_state), "Backend not initialized", "" });
 	}
 
 	return backend_->get_metrics();
@@ -148,7 +149,7 @@ common::Result<backends::health_check_result> monitoring_adapter::check_health()
 	if (!backend_)
 	{
 		return common::Result<backends::health_check_result>(
-			common::error_info{ -1, "Backend not initialized", "" });
+			common::error_info{ static_cast<int>(error_code::invalid_state), "Backend not initialized", "" });
 	}
 
 	return backend_->check_health();
@@ -159,7 +160,7 @@ common::VoidResult monitoring_adapter::reset()
 	if (!backend_)
 	{
 		return common::VoidResult(
-			common::error_info{ -1, "Backend not initialized", "" });
+			common::error_info{ static_cast<int>(error_code::invalid_state), "Backend not initialized", "" });
 	}
 
 	return backend_->reset();
@@ -230,7 +231,7 @@ common::Result<database_metrics> monitoring_adapter::get_database_metrics()
 	if (!backend_)
 	{
 		return common::Result<database_metrics>(
-			common::error_info{ -1, "Backend not initialized", "" });
+			common::error_info{ static_cast<int>(error_code::invalid_state), "Backend not initialized", "" });
 	}
 
 	return backend_->get_database_metrics();

--- a/src/integrated/adapters/thread_adapter.cpp
+++ b/src/integrated/adapters/thread_adapter.cpp
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 #include <kcenon/database/integrated/adapters/thread_adapter.h>
+#include <kcenon/database/core/result.h>
 #include <kcenon/database/integrated/adapters/backends/thread_backend.h>
 #include <kcenon/database/integrated/adapters/backends/null_thread_backend.h>
 #include <kcenon/database/integrated/adapters/backends/fallback_thread_backend.h>
@@ -63,7 +64,7 @@ common::VoidResult thread_adapter::initialize()
 	if (!backend_)
 	{
 		return common::VoidResult(
-			common::error_info{ -1, "Backend not created", "" });
+			common::error_info{ static_cast<int>(error_code::invalid_state), "Backend not created", "" });
 	}
 
 	return backend_->initialize();
@@ -93,7 +94,7 @@ common::VoidResult thread_adapter::execute(std::function<void()> task)
 	if (!backend_)
 	{
 		return common::VoidResult(
-			common::error_info{ -1, "Backend not initialized", "" });
+			common::error_info{ static_cast<int>(error_code::invalid_state), "Backend not initialized", "" });
 	}
 
 	return backend_->execute(std::move(task));

--- a/src/integrated/core/database_coordinator.cpp
+++ b/src/integrated/core/database_coordinator.cpp
@@ -4,6 +4,7 @@
 
 #include <kcenon/database/integrated/core/database_coordinator.h>
 
+#include <kcenon/database/core/result.h>
 #include <kcenon/database/integrated/adapters/logger_adapter.h>
 #include <kcenon/database/integrated/adapters/monitoring_adapter.h>
 #include <kcenon/database/integrated/adapters/thread_adapter.h>
@@ -19,7 +20,12 @@ namespace integrated
 // Helper to create error result
 namespace
 {
-	inline common::VoidResult make_error(const std::string& msg, int code = -1)
+	// Default to an in-band database_system code (see core/result.h) so the
+	// shared common::error_info::code resolves to the "DatabaseSystem" category
+	// instead of the common (-1..-99) band.
+	inline common::VoidResult make_error(
+		const std::string& msg,
+		int code = static_cast<int>(error_code::unknown_error))
 	{
 		return common::VoidResult(common::error_info{ code, msg, "" });
 	}
@@ -302,7 +308,7 @@ public:
 		if (!initialized_)
 		{
 			return common::Result<bool>(
-				common::error_info{ -1, "Coordinator not initialized", "" }
+				common::error_info{ static_cast<int>(error_code::invalid_state), "Coordinator not initialized", "" }
 			);
 		}
 

--- a/src/integrated/unified_database_system.cpp
+++ b/src/integrated/unified_database_system.cpp
@@ -31,15 +31,20 @@ namespace kcenon::database::integrated {
 
 namespace {
 
+// Default error code for these helpers: an in-band database_system value so the
+// shared common::error_info::code resolves to the "DatabaseSystem" category
+// rather than the common (-1..-99) band. See core/result.h for the band design.
+constexpr int kDefaultErrorCode = static_cast<int>(error_code::unknown_error);
+
 // Helper to create error VoidResult
-inline kcenon::common::VoidResult make_error(const std::string& msg, int code = -1, const std::string& context = "")
+inline kcenon::common::VoidResult make_error(const std::string& msg, int code = kDefaultErrorCode, const std::string& context = "")
 {
     return kcenon::common::VoidResult(kcenon::common::error_info{code, msg, context});
 }
 
 // Helper to create error Result<T>
 template <typename T>
-inline kcenon::common::Result<T> make_error_result(const std::string& msg, int code = -1, const std::string& context = "")
+inline kcenon::common::Result<T> make_error_result(const std::string& msg, int code = kDefaultErrorCode, const std::string& context = "")
 {
     return kcenon::common::Result<T>(kcenon::common::error_info{code, msg, context});
 }
@@ -197,7 +202,7 @@ public:
         const std::vector<query_param>& params) override {
 
         if (!active_) {
-            return make_error_result<query_result>("Transaction not active", -1, "transaction");
+            return make_error_result<query_result>("Transaction not active", static_cast<int>(error_code::invalid_state), "transaction");
         }
 
         auto start = std::chrono::steady_clock::now();
@@ -243,12 +248,12 @@ public:
 
     kcenon::common::VoidResult commit() override {
         if (!active_) {
-            return make_error("Transaction not active", -1, "transaction");
+            return make_error("Transaction not active", static_cast<int>(error_code::invalid_state), "transaction");
         }
 
         auto result = backend_->commit_transaction();
         if (result.is_err()) {
-            return make_error("Commit failed: " + result.error().message, -1, "transaction");
+            return make_error("Commit failed: " + result.error().message, static_cast<int>(error_code::invalid_state), "transaction");
         }
 
         active_ = false;
@@ -257,12 +262,12 @@ public:
 
     kcenon::common::VoidResult rollback() override {
         if (!active_) {
-            return make_error("Transaction not active", -1, "transaction");
+            return make_error("Transaction not active", static_cast<int>(error_code::invalid_state), "transaction");
         }
 
         auto result = backend_->rollback_transaction();
         if (result.is_err()) {
-            return make_error("Rollback failed: " + result.error().message, -1, "transaction");
+            return make_error("Rollback failed: " + result.error().message, static_cast<int>(error_code::invalid_state), "transaction");
         }
 
         active_ = false;
@@ -312,7 +317,7 @@ public:
         }
 
         if (connected_) {
-            return make_error("Already connected", -1, "unified_database_system");
+            return make_error("Already connected", static_cast<int>(error_code::invalid_state), "unified_database_system");
         }
 
         backend_type_ = backend;
@@ -321,14 +326,14 @@ public:
         // Create backend instance
         backend_ = create_backend(backend);
         if (!backend_) {
-            return make_error("Unsupported backend type", -2, "unified_database_system");
+            return make_error("Unsupported backend type", static_cast<int>(error_code::invalid_argument), "unified_database_system");
         }
 
         // Connect to database using connection_config
         auto config = core::connection_config::from_string(connection_string);
         auto result = backend_->initialize(config);
         if (result.is_err()) {
-            return make_error("Connection failed: " + result.error().message, -3, "unified_database_system");
+            return make_error("Connection failed: " + result.error().message, static_cast<int>(error_code::connection_failed), "unified_database_system");
         }
 
         connected_ = true;
@@ -384,7 +389,7 @@ public:
         std::lock_guard<std::mutex> lock(mutex_);
 
         if (!connected_) {
-            return make_error_result<query_result>("Not connected to database", -1, "unified_database_system");
+            return make_error_result<query_result>("Not connected to database", static_cast<int>(error_code::invalid_state), "unified_database_system");
         }
 
         // Record query start
@@ -458,7 +463,7 @@ public:
         auto* thread_pool = coordinator_->get_thread_pool();
         if (!thread_pool) {
             std::promise<kcenon::common::Result<query_result>> promise;
-            promise.set_value(make_error_result<query_result>("Thread pool not available", -1, "unified_database_system"));
+            promise.set_value(make_error_result<query_result>("Thread pool not available", static_cast<int>(error_code::invalid_state), "unified_database_system"));
             return promise.get_future();
         }
 
@@ -476,7 +481,7 @@ public:
         auto* thread_pool = coordinator_->get_thread_pool();
         if (!thread_pool) {
             std::promise<kcenon::common::Result<query_result>> promise;
-            promise.set_value(make_error_result<query_result>("Thread pool not available", -1, "unified_database_system"));
+            promise.set_value(make_error_result<query_result>("Thread pool not available", static_cast<int>(error_code::invalid_state), "unified_database_system"));
             return promise.get_future();
         }
 
@@ -495,7 +500,7 @@ public:
         std::lock_guard<std::mutex> lock(mutex_);
 
         if (!connected_) {
-            return make_error_result<std::unique_ptr<transaction>>("Not connected to database", -1, "unified_database_system");
+            return make_error_result<std::unique_ptr<transaction>>("Not connected to database", static_cast<int>(error_code::invalid_state), "unified_database_system");
         }
 
         ++metrics_.transactions_started;
@@ -614,7 +619,7 @@ private:
         auto init_result = coordinator_->initialize();
         if (!init_result.is_ok()) {
             return make_error("Failed to initialize database coordinator: " +
-                init_result.error().message, -10, "unified_database_system");
+                init_result.error().message, static_cast<int>(error_code::invalid_state), "unified_database_system");
         }
         initialized_ = true;
         return kcenon::common::ok();

--- a/tests/test_database.cpp
+++ b/tests/test_database.cpp
@@ -3,10 +3,13 @@
 // See the LICENSE file in the project root for full license information.
 
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <memory>
 #include <vector>
 
+#include <kcenon/common/error/error_codes.h>
 #include <kcenon/database/core/database_context.h>
+#include <kcenon/database/core/result.h>
 #include <kcenon/database/database_manager.h>
 #include <kcenon/database/database_types.h>
 
@@ -116,4 +119,67 @@ TEST_F(DatabaseTest, GeneralQueryExecution) {
   // Test various query types work without crashing
   EXPECT_NO_THROW(db_mgr_->create_query_result("SELECT 1"));
   EXPECT_NO_THROW(db_mgr_->select_query_result("SELECT 1"));
+}
+
+// ---------------------------------------------------------------------------
+// Error-code band tests (issue #600)
+//
+// The database error_code enumerators must live in common_system's reserved
+// database_system band [-599, -500] so that when a backend casts one into the
+// shared kcenon::common::error_info::code, common's error registry attributes
+// it to the "DatabaseSystem" category instead of the common (-1..-99) band.
+// ---------------------------------------------------------------------------
+TEST(DatabaseErrorCodeBandTest, RepresentativeCodeIsInDatabaseBand) {
+  const int code = static_cast<int>(error_code::connection_failed);
+
+  // Inside the reserved database_system band.
+  EXPECT_GE(code, -599);
+  EXPECT_LE(code, -500);
+
+  // common's registry resolves it to the DatabaseSystem category.
+  EXPECT_EQ(kcenon::common::error::get_category_name(code), "DatabaseSystem");
+}
+
+TEST(DatabaseErrorCodeBandTest, AlignedCodesMatchCommonDatabaseSystem) {
+  namespace cds = kcenon::common::error::codes::database_system;
+
+  // Codes with a common equivalent are aligned to the exact common value so the
+  // shared message table returns the correct text.
+  EXPECT_EQ(static_cast<int>(error_code::connection_failed), cds::connection_failed);
+  EXPECT_EQ(static_cast<int>(error_code::query_failed), cds::query_failed);
+  EXPECT_EQ(static_cast<int>(error_code::timeout), cds::query_timeout);
+
+  // connection_failed has a dedicated message in common's table.
+  EXPECT_EQ(
+      kcenon::common::error::get_error_message(
+          static_cast<int>(error_code::connection_failed)),
+      "Database connection failed");
+}
+
+TEST(DatabaseErrorCodeBandTest, AllNonZeroCodesInBandAndDistinct) {
+  const std::vector<int> codes = {
+      static_cast<int>(error_code::connection_failed),
+      static_cast<int>(error_code::query_failed),
+      static_cast<int>(error_code::timeout),
+      static_cast<int>(error_code::unknown_error),
+      static_cast<int>(error_code::invalid_argument),
+      static_cast<int>(error_code::not_implemented),
+      static_cast<int>(error_code::invalid_state),
+  };
+
+  for (int code : codes) {
+    EXPECT_GE(code, -599) << "code " << code << " below database band";
+    EXPECT_LE(code, -500) << "code " << code << " above database band";
+    EXPECT_EQ(kcenon::common::error::get_category_name(code), "DatabaseSystem")
+        << "code " << code << " not attributed to DatabaseSystem";
+  }
+
+  // All enumerators are distinct (no collisions within the band).
+  std::vector<int> sorted = codes;
+  std::sort(sorted.begin(), sorted.end());
+  EXPECT_EQ(std::adjacent_find(sorted.begin(), sorted.end()), sorted.end())
+      << "duplicate error_code value detected";
+
+  // success stays 0.
+  EXPECT_EQ(static_cast<int>(error_code::success), 0);
 }


### PR DESCRIPTION
## What

Move database's local `error_code` enum out of common's reserved generic band and into common's reserved `-500..-599` database band, and route hand-coded colliding/positive literals through the enum.

## Why

`include/kcenon/database/core/result.h` defined `enum class error_code { ..., connection_failed=-5, query_failed=-6, timeout=-7 }` — these collide with common's common_errors (`cancelled=-5`, `not_initialized=-6`, `already_exists=-7`). Backends cast the enum into common's shared `error_info.code` (~20 sites), so a consumer reading `common::get_error_message(-5)` got "Cancelled" and `get_category_name(-5)`="Common", never "DatabaseSystem".

## How

- Renumbered all non-zero `error_code` enumerators into `-500..-599`: `connection_failed=-500`, `query_failed=-540`, `timeout=-542` aligned exactly to common's `codes::database_system::` values (so error messages resolve correctly); database-only generics (`invalid_state=-596`, `not_implemented=-597`, `invalid_argument=-598`, `unknown_error=-599`) take distinct tail slots; `success=0`.
- **Completeness sweep (monitoring #697 lesson)**: routed ~30 hand-coded literals that bypassed the enum through it — `backend_registry.cpp` (positive `1,2,3,4` → "Invalid"), `postgres_manager.cpp` (~21), `database_manager.cpp` (8), `unified_database_system.cpp`, `database_coordinator.cpp`, and several integrated adapters. Adversarial review caught one missed `-10` literal in `unified_database_system.cpp` (a `make_error` helper the first grep didn't cover) — now fixed to `invalid_state`. Final 3-vector grep is clean.
- Added `DatabaseErrorCodeBandTest` (in-band + "DatabaseSystem" classification + common-alignment).

## Verification

database's develop-PR CI runs integration tests; local build is the deeper gate:
- Local build PASS (`cmake --preset debug`; PostgreSQL/SQLite auto-OFF without libpqxx → postgres_manager compiled in mock mode; the changed lines are identical literal→enum substitutions across all preprocessor branches).
- `database_unit_tests` 27 pass / 1 skip (pre-existing); `backend_registry_test` 25/25, `connection_pool_test` 12/12, adapter tests pass.
- Independent adversarial review: enum band/alignment/classification verified exact against common's header; "zero colliding codes" confirmed after the `-10` fix.
- Pre-existing (NOT this change): some integrated **sample/test executables fail to LINK** on undefined `kcenon::thread::thread_pool` / `kcenon::monitoring::system_monitor` (a CMake linkage gap; `async_executor_demo` sample), and a `forward.h` namespace inconsistency — none reference error codes; CI integration tests are the cross-check.

## Out of scope

DI-layer codes in `di/service_registration.h` (`-52`/`-1`) reach common error_info but are semantically common-layer DI errors (classify "Common" by design) — left untouched.

Closes #600
Part of (ecosystem error-code registry contract, kcenon/common_system#699/#701)
