### PR TITLE
fix(ci): grant actions:read so OSV reusable workflow can start

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -18,6 +18,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   security-events: write
 
@@ -33,6 +34,7 @@ jobs:
   osv-scan:
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.5
     permissions:
+      actions: read
       contents: read
       security-events: write
     with:


### PR DESCRIPTION
## What

Grant `actions: read` to the OSV Vulnerability Scan workflow so the reusable
workflow it calls can start.

Change type: **fix(ci)** — workflow permissions.

## Why

`OSV Vulnerability Scan` has failed with `startup_failure` (zero jobs created)
on every scheduled run since it was added (e.g. 2026-06-07/14/21). The
`osv-scan` job uses
`google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.5`,
whose reusable workflow declares `permissions: actions:read, contents:read,
security-events:write` (the `actions:read` is needed to upload SARIF to
CodeQL). The caller granted only `contents:read` and `security-events:write`,
so GitHub refuses to create any job and the run is `startup_failure` — a silent
failure that never reaches the scan itself.

## Where

`.github/workflows/osv-scanner.yml` — add `actions: read` to the `osv-scan`
job-level `permissions` (which gates the reusable workflow) and to the
top-level `permissions` for consistency.

## How (verification)

After merge to `develop` and `main`, dispatch / next schedule should create the
`osv-scan` job (jobs `total_count` > 0) instead of `startup_failure`, and run
the dependency scan to completion. (A real vulnerability finding would be a
legitimate, separate result — distinct from the startup failure this fixes.)

Relates to ecosystem CI hygiene (common_system#408 OSV adoption).
